### PR TITLE
full initial reconciliation

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -149,16 +149,13 @@ func (c *leadController) RunLeased(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("get k8s api config: %w", err)
 	}
-	mgr, err := controllers.NewIngressController(cfg, c.Options, c.PomeriumReconciler,
+	mgr, err := controllers.NewIngressController(ctx, cfg, c.Options, c.PomeriumReconciler,
 		controllers.WithNamespaces(c.namespaces),
 		controllers.WithAnnotationPrefix(c.annotationPrefix),
 		controllers.WithControllerName(c.className),
 	)
 	if err != nil {
 		return fmt.Errorf("creating controller: %w", err)
-	}
-	if err = c.PomeriumReconciler.DeleteAll(ctx); err != nil {
-		return fmt.Errorf("clear pomerium config on start: %w", err)
 	}
 	if err = mgr.Start(ctx); err != nil {
 		return fmt.Errorf("running controller: %w", err)

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -2,6 +2,7 @@ package controllers_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -79,8 +80,11 @@ func (m *mockPomeriumReconciler) Delete(ctx context.Context, name types.Namespac
 	return nil
 }
 
-func (m *mockPomeriumReconciler) DeleteAll(ctx context.Context) error {
-	panic("not implemented")
+func (m *mockPomeriumReconciler) Set(ctx context.Context, ics []*model.IngressConfig) error {
+	if len(ics) != 0 {
+		return errors.New("unexpected ingresses")
+	}
+	return nil
 }
 
 func (s *ControllerTestSuite) EventuallyDeleted(name types.NamespacedName) {
@@ -202,7 +206,7 @@ func (s *ControllerTestSuite) TearDownSuite() {
 
 func (s *ControllerTestSuite) createTestController(ctx context.Context, namespaces []string) {
 	s.mockPomeriumReconciler = &mockPomeriumReconciler{}
-	mgr, err := controllers.NewIngressController(s.Environment.Config,
+	mgr, err := controllers.NewIngressController(ctx, s.Environment.Config,
 		ctrl.Options{
 			Scheme: s.Environment.Scheme,
 		},

--- a/controllers/once.go
+++ b/controllers/once.go
@@ -1,0 +1,47 @@
+package controllers
+
+import (
+	"context"
+)
+
+type once struct {
+	execCtx chan context.Context
+	result  chan error
+}
+
+func newOnce(runnable func(ctx context.Context) error, onError func()) *once {
+	o := &once{
+		execCtx: make(chan context.Context),
+		result:  make(chan error),
+	}
+	go func() {
+		ctx := <-o.execCtx
+		err := runnable(ctx)
+		if err != nil {
+			onError()
+		}
+		o.result <- err
+		close(o.result)
+	}()
+	return o
+}
+
+func (o *once) yield(ctx context.Context) error {
+	select {
+	case err := <-o.result:
+		return err
+	case o.execCtx <- ctx:
+		return o.wait(ctx)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (o *once) wait(ctx context.Context) error {
+	select {
+	case err := <-o.result:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/controllers/once_test.go
+++ b/controllers/once_test.go
@@ -1,0 +1,46 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOnce(t *testing.T) {
+	var callCount int32
+	var errSeen int32
+	var onError int32
+
+	o := newOnce(func(ctx context.Context) error {
+		_ = atomic.AddInt32(&callCount, 1)
+		time.Sleep(time.Second)
+		return fmt.Errorf("ERROR")
+	}, func() {
+		_ = atomic.AddInt32(&onError, 1)
+	})
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+
+	iters := 100
+	wg.Add(iters)
+	for i := 0; i < iters; i++ {
+		go func(x int) {
+			time.Sleep(time.Millisecond * time.Duration(rand.Intn(10)+10))
+			if err := o.yield(ctx); err != nil {
+				_ = atomic.AddInt32(&errSeen, 1)
+			}
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	assert.Equal(t, callCount, int32(1))
+	assert.Equal(t, errSeen, int32(1))
+	assert.Equal(t, onError, int32(1))
+}

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,11 @@ go 1.17
 
 require (
 	github.com/client9/misspell v0.3.4
+	github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0
 	github.com/go-logr/zapr v0.4.0
+	github.com/golangci/golangci-lint v1.42.0
 	github.com/google/go-cmp v0.5.6
+	github.com/google/uuid v1.3.0
 	github.com/gosimple/slug v1.10.0
 	github.com/pomerium/pomerium v0.15.1-0.20210810012516-e38682d02460
 	github.com/spf13/cobra v1.2.1
@@ -18,9 +21,6 @@ require (
 	k8s.io/apimachinery v0.22.1
 	k8s.io/client-go v0.22.1
 	sigs.k8s.io/controller-runtime v0.9.2
-	github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0
-	github.com/golangci/golangci-lint v1.42.0
-	github.com/google/uuid v1.3.0
 )
 
 require (
@@ -183,7 +183,6 @@ require (
 	github.com/ryanrolds/sqlclosecheck v0.3.0 // indirect
 	github.com/sanposhiho/wastedassign/v2 v2.0.6 // indirect
 	github.com/securego/gosec/v2 v2.8.1 // indirect
-	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/sonatard/noctx v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,6 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alexkohler/prealloc v1.0.0 h1:Hbq0/3fJPQhNkN0dR95AVrr6R7tou91y0uHG5pOcUuw=
 github.com/alexkohler/prealloc v1.0.0/go.mod h1:VetnK3dIgFBBKmg0YnD9F9x6Icjd+9cvfHR56wJVlKE=
-github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
-github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -966,7 +964,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/securego/gosec/v2 v2.8.0/go.mod h1:hJZ6NT5TqoY+jmOsaxAV4cXoEdrMRLVaNPnSpUCvCZs=
 github.com/securego/gosec/v2 v2.8.1 h1:Tyy/nsH39TYCOkqf5HAgRE+7B5D8sHDwPdXRgFWokh8=
 github.com/securego/gosec/v2 v2.8.1/go.mod h1:pUmsq6+VyFEElJMUX+QB3p3LWNHXg1R3xh2ssVJPs8Q=
-github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c h1:W65qqJCIOVP4jpqPQ0YvHYKwcMEMVWIzWC5iNQQfBTU=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAxekIXwN8qQyfc5gl2NlkB3CQlkizAbOkeBs=

--- a/pomerium/certs.go
+++ b/pomerium/certs.go
@@ -16,6 +16,11 @@ func upsertCerts(cfg *pb.Config, ic *model.IngressConfig) error {
 		return err
 	}
 
+	addCerts(cfg, certs)
+	return nil
+}
+
+func addCerts(cfg *pb.Config, certs []*model.TLSCert) {
 	if cfg.Settings == nil {
 		cfg.Settings = new(pb.Settings)
 	}
@@ -26,8 +31,6 @@ func upsertCerts(cfg *pb.Config, ic *model.IngressConfig) error {
 			KeyBytes:  cert.Key,
 		})
 	}
-
-	return removeUnusedCerts(cfg)
 }
 
 func removeUnusedCerts(cfg *pb.Config) error {

--- a/pomerium/validate.go
+++ b/pomerium/validate.go
@@ -15,8 +15,8 @@ import (
 	"github.com/pomerium/ingress-controller/pomerium/envoy"
 )
 
-// Validate validates pomerium config.
-func Validate(ctx context.Context, cfg *pb.Config, id string) error {
+// validate validates pomerium config.
+func validate(ctx context.Context, cfg *pb.Config, id string) error {
 	options := config.NewDefaultOptions()
 	options.ApplySettings(ctx, cfg.GetSettings())
 	options.InsecureServer = true


### PR DESCRIPTION
## Summary

Add full initial reconciliation that is necessary in case many Ingresses exist. Otherwise, each ingress would be reconciled individually which puts an undue stress on envoy proxy reconfiguration, that may lead to excessive Envoy resource usage. 

Such operation is outside of the standard `controller-runtime` design pattern, and thus need be triggered inside either the reconciliation loop or when first ingress class is fetched, in order to utilize `controller-runtime` cache. 

There is still one corner case that cannot be covered under this model, if current databroker configuration exists and there are neither Ingresses nor IngressClasses registered. 

## Related issues

Provides workaround for https://github.com/pomerium/internal/issues/536

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
