### PR TITLE
deployment: use `base` distroless build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/base:debug-nonroot
 WORKDIR /
 COPY --from=builder /workspace/bin/manager .
 USER 65532:65532


### PR DESCRIPTION
## Summary

Switch the main `Dockerfile` to use the `base` flavor of the distroless container and include debug utilities.  

- This is the dockerfile used for development and HEAD builds.  The debug utilities are helpful.
- Embedded envoy requires `base` since it isn't fully static.

## Related issues

n/a

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
