### PR TITLE
cmd: remove env prefix

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -32,8 +32,6 @@ import (
 const (
 	defaultGRPCTimeout = time.Minute
 	leaseDuration      = time.Second * 30
-
-	envPrefix = "POMERIUM"
 )
 
 var (
@@ -100,7 +98,7 @@ const (
 )
 
 func envName(name string) string {
-	return strcase.ToScreamingSnake(fmt.Sprintf("%s_%s", envPrefix, name))
+	return strcase.ToScreamingSnake(name)
 }
 
 func (s *serveCmd) setupFlags() {


### PR DESCRIPTION
## Summary

Minor nit that I missed in the initial review.  To be consistent with the rest of our components, exclude the `POMERIUM` prefix on env vars.  This makes sharing `SHARED_SECRET` in particular much easier to do. 

## Related issues

https://github.com/pomerium/ingress-controller/pull/51


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
