### PR TITLE
set ImplementationSpecific path behavior to Prefix

### DIFF
--- a/pomerium/ingress_to_route.go
+++ b/pomerium/ingress_to_route.go
@@ -129,7 +129,7 @@ func pathToRoute(r *pb.Route, name types.NamespacedName, host string, p networki
 
 	switch *p.PathType {
 	case networkingv1.PathTypeImplementationSpecific:
-		r.Path = p.Path
+		r.Prefix = p.Path
 	case networkingv1.PathTypeExact:
 		r.Path = p.Path
 	case networkingv1.PathTypePrefix:


### PR DESCRIPTION
## Summary

Change the behavior for `pathType: ImplementationSpecific` to be `Prefix`.  

I believe this more closely aligns to the rest of the ecosystem and is a reasonable default.  It also matches how we would treat this in the operator, where at lot of folks are coming from.

## Related issues

Partially addresses #94 


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
