### PR TITLE
support regex path

### DIFF
--- a/model/ingress_config.go
+++ b/model/ingress_config.go
@@ -19,6 +19,8 @@ const (
 	TLSDownstreamClientCASecret = "tls_downstream_client_ca_secret"
 	// SecureUpstream indicate that service communication should happen over HTTPS
 	SecureUpstream = "secure_upstream"
+	// PathRegex indicates that paths of ImplementationSpecific type should be treated as regular expression
+	PathRegex = "path_regex"
 )
 
 // IngressConfig represents ingress and all other required resources
@@ -29,8 +31,16 @@ type IngressConfig struct {
 	Services map[types.NamespacedName]*corev1.Service
 }
 
+func (ic *IngressConfig) IsAnnotationSet(name string) bool {
+	return strings.ToLower(ic.Ingress.Annotations[fmt.Sprintf("%s/%s", ic.AnnotationPrefix, name)]) == "true"
+}
+
 func (ic *IngressConfig) IsSecureUpstream() bool {
-	return strings.ToLower(ic.Ingress.Annotations[fmt.Sprintf("%s/secure_upstream", ic.AnnotationPrefix)]) == "true"
+	return ic.IsAnnotationSet(SecureUpstream)
+}
+
+func (ic *IngressConfig) IsPathRegex() bool {
+	return ic.IsAnnotationSet(PathRegex)
 }
 
 // GetServicePortByName returns service named port

--- a/pomerium/envoy/envoy_darwin_amd64.go
+++ b/pomerium/envoy/envoy_darwin_amd64.go
@@ -1,5 +1,5 @@
-//go:build darwin
-// +build darwin
+//go:build darwin && amd64
+// +build darwin,amd64
 
 package envoy
 

--- a/pomerium/envoy/envoy_darwin_arm64.go
+++ b/pomerium/envoy/envoy_darwin_arm64.go
@@ -1,0 +1,15 @@
+//go:build darwin && arm64
+// +build darwin,arm64
+
+package envoy
+
+import _ "embed" // embed
+
+//go:embed bin/envoy-darwin-arm64
+var rawBinary []byte
+
+//go:embed bin/envoy-darwin-arm64.sha256
+var rawChecksum string
+
+//go:embed bin/envoy-darwin-arm64.version
+var rawVersion string

--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -64,6 +64,7 @@ var (
 	})
 	handledElsewhere = boolMap([]string{
 		model.SecureUpstream,
+		model.PathRegex,
 	})
 )
 

--- a/pomerium/ingress_to_route.go
+++ b/pomerium/ingress_to_route.go
@@ -129,7 +129,11 @@ func pathToRoute(r *pb.Route, name types.NamespacedName, host string, p networki
 
 	switch *p.PathType {
 	case networkingv1.PathTypeImplementationSpecific:
-		r.Prefix = p.Path
+		if ic.IsPathRegex() {
+			r.Regex = p.Path
+		} else {
+			r.Prefix = p.Path
+		}
 	case networkingv1.PathTypeExact:
 		r.Path = p.Path
 	case networkingv1.PathTypePrefix:


### PR DESCRIPTION
## Summary

Supporting [regex paths](https://www.pomerium.com/reference/#regex) in `Ingress` resources is a non-standard extension, which may be enabled by 

1. Setting `pathType` to `ImplementationSpecific`
2. Setting annotation `ingress.pomerium.io/path_regex` to `"true"`

## Related issues

Fixes https://github.com/pomerium/ingress-controller/issues/96

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
