### PR TITLE
routes: bypass service dns name and use endpoints directly

### DIFF
--- a/model/ingress_config.go
+++ b/model/ingress_config.go
@@ -27,8 +27,9 @@ const (
 type IngressConfig struct {
 	AnnotationPrefix string
 	*networkingv1.Ingress
-	Secrets  map[types.NamespacedName]*corev1.Secret
-	Services map[types.NamespacedName]*corev1.Service
+	Endpoints map[types.NamespacedName]*corev1.Endpoints
+	Secrets   map[types.NamespacedName]*corev1.Secret
+	Services  map[types.NamespacedName]*corev1.Service
 }
 
 func (ic *IngressConfig) IsAnnotationSet(name string) bool {
@@ -69,6 +70,7 @@ func (ic *IngressConfig) Clone() *IngressConfig {
 	dst := &IngressConfig{
 		AnnotationPrefix: ic.AnnotationPrefix,
 		Ingress:          ic.Ingress.DeepCopy(),
+		Endpoints:        make(map[types.NamespacedName]*corev1.Endpoints, len(ic.Endpoints)),
 		Secrets:          make(map[types.NamespacedName]*corev1.Secret, len(ic.Secrets)),
 		Services:         make(map[types.NamespacedName]*corev1.Service, len(ic.Services)),
 	}

--- a/pomerium/routes_test.go
+++ b/pomerium/routes_test.go
@@ -215,6 +215,17 @@ func TestSecureUpstream(t *testing.T) {
 				}},
 			},
 		},
+		Endpoints: map[types.NamespacedName]*corev1.Endpoints{
+			{Name: "service", Namespace: "default"}: {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{{
+					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+					Ports:     []corev1.EndpointPort{{Port: 443}},
+				}},
+			}},
 		Services: map[types.NamespacedName]*corev1.Service{
 			{Name: "service", Namespace: "default"}: {
 				ObjectMeta: metav1.ObjectMeta{
@@ -244,9 +255,9 @@ func TestSecureUpstream(t *testing.T) {
 		Path:      "/a",
 		Host:      "service.localhost.pomerium.io",
 	}]
-	require.NotNil(t, route)
+	require.NotNil(t, route, "route not found in %v", routes)
 	require.Equal(t, []string{
-		"https://service.default.svc.cluster.local:443",
+		"https://1.2.3.4:443",
 	}, route.To)
 }
 


### PR DESCRIPTION
## Summary
By default Kubernetes sets up services which map to multiple endpoints using a single ClusterIP. But Envoy will work better if we hand it the endpoints directly and let it do the load balancing. This PR updates the service URLs and watch code so that endpoints are queried and used for the destination address of a route.

## Related issues
- #71 


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
