### PR TITLE
deployment: fix multi-arch rolling image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 # Build the manager binary
-ARG ARCH=amd64
 
 FROM golang:1.17 as builder
 
@@ -20,7 +19,7 @@ RUN CGO_ENABLED=0 make build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:debug-nonroot-${ARCH}
+FROM gcr.io/distroless/base:debug-nonroot-${TARGETARCH:-amd64}
 WORKDIR /
 COPY --from=builder /workspace/bin/manager .
 USER 65532:65532

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,6 +1,6 @@
 ARG ARCH
 
-FROM gcr.io/distroless/base:nonroot-${ARCH}
+FROM gcr.io/distroless/base:nonroot-${TARGETARCH:-amd64}
 WORKDIR /pomerium
 COPY pomerium* /bin/
 ENTRYPOINT [ "/bin/pomerium-ingress" ]

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -60,7 +60,7 @@ dockers:
     dockerfile: Dockerfile.release
     build_flag_templates:
       - "--pull"
-      - "--build-arg=ARCH=amd64"
+      - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -74,7 +74,7 @@ dockers:
     dockerfile: Dockerfile.release
     build_flag_templates:
       - "--pull"
-      - "--build-arg=ARCH=arm64"
+      - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"


### PR DESCRIPTION
## Summary

Similar to https://github.com/pomerium/pomerium/pull/2925.  Fix the way we build multi-arch `main` image as we were using the wrong env var before.  Also update the release strategy to be consistent.

## Related issues

https://github.com/pomerium/pomerium/pull/2925


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
