### PR TITLE
add load balancing configs

### DIFF
--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -57,7 +57,10 @@ var (
 	envoyAnnotations = boolMap([]string{
 		"health_checks",
 		"outlier_detection",
-		"lb_config",
+		"lb_policy",
+		"least_request_lb_config",
+		"ring_hash_lb_config",
+		"maglev_lb_config",
 	})
 	tlsAnnotations = boolMap([]string{
 		model.TLSCustomCASecret,


### PR DESCRIPTION
## Summary

Now that Ingress Controller uses Endpoints by default, the health checks, load balancing policies and outlier detection take effect.

## Related issues

Implements https://github.com/pomerium/ingress-controller/issues/72

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
