### PR TITLE
deployment: enable goreleaser buildx

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -58,6 +58,7 @@ dockers:
   - image_templates:
       - "pomerium/ingress-controller:{{ .Tag }}-amd64"
     dockerfile: Dockerfile.release
+    use: buildx
     build_flag_templates:
       - "--pull"
       - "--platform=linux/amd64"
@@ -72,6 +73,7 @@ dockers:
     image_templates:
       - "pomerium/ingress-controller:{{ .Tag }}-arm64"
     dockerfile: Dockerfile.release
+    use: buildx
     build_flag_templates:
       - "--pull"
       - "--platform=linux/arm64"


### PR DESCRIPTION
## Summary

Explicitly enable buildx in goreleaser to prevent build failures.

## Related issues

https://github.com/pomerium/cli/pull/31
https://github.com/pomerium/ingress-controller/pull/120

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
