### PR TITLE
config: sort routes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters-settings:
     lines: 100
     statements: 50
   gci:
-    local-prefixes: github.com/pomerium/pomerium
+    local-prefixes: github.com/pomerium
   goconst:
     min-len: 2
     min-occurrences: 2
@@ -28,7 +28,7 @@ linters-settings:
   gocyclo:
     min-complexity: 15
   goimports:
-    local-prefixes: github.com/pomerium/pomerium
+    local-prefixes: github.com/pomerium
   govet:
     check-shadowing: false
   lll:

--- a/controllers/builder.go
+++ b/controllers/builder.go
@@ -4,9 +4,10 @@ package controllers
 import (
 	"fmt"
 
-	"github.com/pomerium/ingress-controller/model"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/pomerium/ingress-controller/model"
 )
 
 const (

--- a/pomerium/routes.go
+++ b/pomerium/routes.go
@@ -3,10 +3,11 @@ package pomerium
 import (
 	"context"
 	"fmt"
-	pb "github.com/pomerium/pomerium/pkg/grpc/config"
+
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/pomerium/ingress-controller/model"
+	pb "github.com/pomerium/pomerium/pkg/grpc/config"
 )
 
 func upsert(ctx context.Context, cfg *pb.Config, ic *model.IngressConfig) error {

--- a/pomerium/routes.go
+++ b/pomerium/routes.go
@@ -3,10 +3,8 @@ package pomerium
 import (
 	"context"
 	"fmt"
-
-	"k8s.io/apimachinery/pkg/types"
-
 	pb "github.com/pomerium/pomerium/pkg/grpc/config"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/pomerium/ingress-controller/model"
 )
@@ -36,6 +34,7 @@ func mergeRoutes(dst *pb.Config, src routeList, name types.NamespacedName) error
 	dstMap.removeName(name)
 	dstMap.merge(srcMap)
 	dst.Routes = dstMap.toList()
+
 	return nil
 }
 

--- a/pomerium/routes_test.go
+++ b/pomerium/routes_test.go
@@ -3,20 +3,21 @@ package pomerium
 import (
 	"context"
 	"fmt"
-	"sort"
-	"testing"
-
+	"github.com/google/go-cmp/cmp"
 	"github.com/pomerium/ingress-controller/model"
+	pb "github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
-	pb "github.com/pomerium/pomerium/pkg/grpc/config"
+	"math/rand"
+	"sort"
+	"testing"
 )
 
 func TestHttp01Solver(t *testing.T) {
@@ -587,5 +588,58 @@ func TestUseServiceProxy(t *testing.T) {
 	require.Equal(t, []string{
 		"http://service.default.svc.cluster.local:80",
 	}, route.To)
+}
 
+func TestSortRoutes(t *testing.T) {
+	r1 := &pb.Route{
+		Name: "route1",
+		From: "http://a.example.com",
+	}
+	r2 := &pb.Route{
+		Name: "route2",
+		From: "http://b.example.com",
+		Path: "/path/a",
+	}
+	r3 := &pb.Route{
+		Name: "route3",
+		From: "http://b.example.com",
+		Path: "/path",
+	}
+	r4 := &pb.Route{
+		Name:  "route4",
+		From:  "http://b.example.com",
+		Regex: "REGEX/A",
+	}
+	r5 := &pb.Route{
+		Name:  "route5",
+		From:  "http://b.example.com",
+		Regex: "REGEX",
+	}
+	r6 := &pb.Route{
+		Name:   "route6",
+		From:   "http://b.example.com",
+		Prefix: "/prefix/a/",
+	}
+	r7 := &pb.Route{
+		Name:   "route7",
+		From:   "http://b.example.com",
+		Prefix: "/prefix/",
+	}
+
+	random := rand.New(rand.NewSource(0))
+
+	for i := 0; i < 10; i++ {
+		routes := routeList{r1, r2, r3, r4, r5, r6, r7}
+		shuffleRoutes(random, routes)
+
+		sort.Sort(routes)
+		assert.Empty(t, cmp.Diff(routeList{r1, r2, r3, r4, r5, r6, r7}, routes, protocmp.Transform()))
+	}
+}
+
+func shuffleRoutes(random *rand.Rand, routes []*pb.Route) {
+	for i := range routes {
+		j := random.Intn(i + 1)
+		routes[i], routes[j] = routes[j], routes[i]
+	}
 }

--- a/pomerium/routes_test.go
+++ b/pomerium/routes_test.go
@@ -3,9 +3,11 @@ package pomerium
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
-	"github.com/pomerium/ingress-controller/model"
-	pb "github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -15,9 +17,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"math/rand"
-	"sort"
-	"testing"
+
+	"github.com/pomerium/ingress-controller/model"
+	pb "github.com/pomerium/pomerium/pkg/grpc/config"
 )
 
 func TestHttp01Solver(t *testing.T) {

--- a/pomerium/routes_test.go
+++ b/pomerium/routes_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/pomerium/ingress-controller/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -16,8 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	pb "github.com/pomerium/pomerium/pkg/grpc/config"
-
-	"github.com/pomerium/ingress-controller/model"
 )
 
 func TestHttp01Solver(t *testing.T) {
@@ -431,30 +430,6 @@ func TestDefaultBackendService(t *testing.T) {
 		require.Len(t, cfg.Routes, 3)
 		assert.Equal(t, "/", cfg.Routes[2].Prefix, protojson.Format(cfg))
 	})
-}
-
-// TestRouteSortOrder ensures we're following
-// https://kubernetes.io/docs/concepts/services-networking/ingress/#multiple-matches
-// 1. precedence will be given first to the longest matching path.
-// 2. If two paths are still equally matched, precedence will be given to paths with an exact path type over prefix path type.
-func TestRouteSortOrder(t *testing.T) {
-	routes := routeList{{
-		From:   "https://site",
-		Prefix: "/",
-		Id:     "c",
-	}, {
-		From: "https://site",
-		Path: "/.well-known/something",
-		Id:   "a",
-	}, {
-		From: "https://site",
-		Path: "/.well-known/else",
-		Id:   "b",
-	}}
-	assert.True(t, routes.Less(1, 0))
-	sort.Sort(routes)
-	assert.Equal(t, "a", routes[0].Id)
-	assert.Equal(t, "b", routes[1].Id)
 }
 
 func TestRegexPath(t *testing.T) {


### PR DESCRIPTION
## Summary
Change the way routes are sorted to handle `prefix` and `regex`. The order is: `from` ascending, `path` descending, `regex` descending, `prefix` descending and finally `id` ascending.

We may also need to add a regex priority order field.

## Related issues
- #135 


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
