### PR TITLE
fix endpoint matching in case of multiple service ports

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1356,7 +1356,6 @@ github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tL
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
-github.com/spf13/cobra v1.3.0 h1:R7cSvGu+Vv+qX0gW5R/85dx2kmmJT5z5NM8ifdYjdn0=
 github.com/spf13/cobra v1.3.0/go.mod h1:BrRVncBjOJa/eUcVVm9CE+oC6as8k+VYr4NY7WCi9V4=
 github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
@@ -2180,7 +2179,6 @@ google.golang.org/grpc v1.40.1/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9K
 google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
 google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
-google.golang.org/grpc v1.44.0 h1:weqSxi/TMs1SqFRMHCtBgXRs8k3X39QIDEZ0pRcttUg=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.45.0 h1:NEpgUqV3Z+ZjkqMsxMg11IaDrXY4RY6CQukSGK0uI1M=
 google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=

--- a/pomerium/routes_test.go
+++ b/pomerium/routes_test.go
@@ -225,7 +225,7 @@ func TestSecureUpstream(t *testing.T) {
 				},
 				Subsets: []corev1.EndpointSubset{{
 					Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
-					Ports:     []corev1.EndpointPort{{Port: 443}},
+					Ports:     []corev1.EndpointPort{{Name: "https", Port: 443}},
 				}},
 			}},
 		Services: map[types.NamespacedName]*corev1.Service{

--- a/pomerium/routes_test.go
+++ b/pomerium/routes_test.go
@@ -645,3 +645,164 @@ func shuffleRoutes(random *rand.Rand, routes []*pb.Route) {
 		routes[i], routes[j] = routes[j], routes[i]
 	}
 }
+
+// TestServicePortsAndEndpoints checks that only correct Endpoints would be selected for a Service
+// https://github.com/pomerium/ingress-controller/issues/157
+// - if there's just one port defined for the service, it may be defined in numerical form
+// - if there are multiple, then name is required, that would be repeated in the endpoints
+func TestServicePortsAndEndpoints(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		ingressPort     networkingv1.ServiceBackendPort
+		svcPorts        []corev1.ServicePort
+		endpointSubsets []corev1.EndpointSubset
+		expectTO        []string
+		expectError     bool
+	}{
+		{
+			"unnamed port",
+			networkingv1.ServiceBackendPort{Number: 8080},
+			[]corev1.ServicePort{{
+				Port:       8080,
+				TargetPort: intstr.IntOrString{IntVal: 80},
+			}},
+			[]corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+				Ports:     []corev1.EndpointPort{{Port: 80}},
+			}},
+			[]string{
+				"http://1.2.3.4:80",
+			},
+			false,
+		},
+		{
+			"named port",
+			networkingv1.ServiceBackendPort{Name: "http"},
+			[]corev1.ServicePort{{
+				Name:       "http",
+				Port:       8000,
+				TargetPort: intstr.IntOrString{IntVal: 80},
+			}},
+			[]corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+				Ports:     []corev1.EndpointPort{{Name: "http", Port: 80}},
+			}},
+			[]string{
+				"http://1.2.3.4:80",
+			},
+			false,
+		},
+		{
+			"multiple IPs",
+			networkingv1.ServiceBackendPort{Name: "http"},
+			[]corev1.ServicePort{{
+				Name:       "http",
+				Port:       8000,
+				TargetPort: intstr.IntOrString{IntVal: 80},
+			}},
+			[]corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}, {IP: "1.2.3.5"}},
+				Ports:     []corev1.EndpointPort{{Name: "http", Port: 80}},
+			}},
+			[]string{
+				"http://1.2.3.4:80",
+				"http://1.2.3.5:80",
+			},
+			false,
+		},
+		{
+			"multiple services",
+			networkingv1.ServiceBackendPort{Name: "http"},
+			[]corev1.ServicePort{{
+				Name:       "http",
+				Port:       8000,
+				TargetPort: intstr.IntOrString{IntVal: 80},
+			}, {
+				Name:       "metrics",
+				Port:       9090,
+				TargetPort: intstr.IntOrString{IntVal: 8090},
+			}},
+			[]corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}, {IP: "1.2.3.5"}},
+				Ports: []corev1.EndpointPort{
+					{Name: "metrics", Port: 8090},
+					{Name: "http", Port: 80},
+				},
+			}},
+			[]string{
+				"http://1.2.3.4:80",
+				"http://1.2.3.5:80",
+			},
+			false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pathTypePrefix := networkingv1.PathTypePrefix
+			ic := &model.IngressConfig{
+				AnnotationPrefix: "p",
+				Ingress: &networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress",
+						Namespace: "default",
+					},
+					Spec: networkingv1.IngressSpec{
+						TLS: []networkingv1.IngressTLS{{
+							Hosts:      []string{"service.localhost.pomerium.io"},
+							SecretName: "secret",
+						}},
+						Rules: []networkingv1.IngressRule{{
+							Host: "service.localhost.pomerium.io",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{{
+										Path:     "/a",
+										PathType: &pathTypePrefix,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "service",
+												Port: tc.ingressPort,
+											},
+										},
+									}},
+								},
+							},
+						}},
+					},
+				},
+				Endpoints: map[types.NamespacedName]*corev1.Endpoints{
+					{Name: "service", Namespace: "default"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "service",
+							Namespace: "default",
+						},
+						Subsets: tc.endpointSubsets,
+					}},
+				Services: map[types.NamespacedName]*corev1.Service{
+					{Name: "service", Namespace: "default"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "service",
+							Namespace: "default",
+						},
+						Spec: corev1.ServiceSpec{
+							Ports: tc.svcPorts,
+						},
+						Status: corev1.ServiceStatus{},
+					},
+				},
+			}
+
+			cfg := new(pb.Config)
+			require.NoError(t, upsertRoutes(context.Background(), cfg, ic))
+			routes, err := routeList(cfg.Routes).toMap()
+			require.NoError(t, err)
+			route := routes[routeID{
+				Name:      "ingress",
+				Namespace: "default",
+				Path:      "/a",
+				Host:      "service.localhost.pomerium.io",
+			}]
+			require.NotNil(t, route, "route not found in %v", routes)
+			require.ElementsMatch(t, tc.expectTO, route.To)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Only select `Endpoints` ports that are explicitly referenced by the `Ingress`,
as if there were multiple ports defined for `Service` (i.e. authenticate had `metrics`), that could result in routing traffic to all ports. 

## Related issues

Fixes https://github.com/pomerium/ingress-controller/issues/157

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
