### PR TITLE
endpoints with https should have tls server name set automatically

### DIFF
--- a/model/ingress_config.go
+++ b/model/ingress_config.go
@@ -19,6 +19,8 @@ const (
 	TLSClientSecret = "tls_client_secret"
 	// TLSDownstreamClientCASecret replaces https://pomerium.io/reference/#tls-downstream-client-certificate-authority
 	TLSDownstreamClientCASecret = "tls_downstream_client_ca_secret"
+	// TLSServerName is annotation to override TLS server name
+	TLSServerName = "tls_server_name"
 	// SecureUpstream indicate that service communication should happen over HTTPS
 	SecureUpstream = "secure_upstream"
 	// PathRegex indicates that paths of ImplementationSpecific type should be treated as regular expression

--- a/pomerium/routes_test.go
+++ b/pomerium/routes_test.go
@@ -803,6 +803,157 @@ func TestServicePortsAndEndpoints(t *testing.T) {
 			}]
 			require.NotNil(t, route, "route not found in %v", routes)
 			require.ElementsMatch(t, tc.expectTO, route.To)
+			require.Empty(t, route.TlsServerName)
+		})
+	}
+}
+
+// TestEndpointsHTTPS verifies that endpoints would correctly set
+// https://github.com/pomerium/ingress-controller/issues/164
+func TestEndpointsHTTPS(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		ingressAnnotations  map[string]string
+		ingressPort         networkingv1.ServiceBackendPort
+		svcPorts            []corev1.ServicePort
+		endpointSubsets     []corev1.EndpointSubset
+		expectTO            []string
+		expectTLSServerName string
+	}{
+		{
+			"HTTPS multiple IPs - no annotations",
+			map[string]string{
+				fmt.Sprintf("p/%s", model.SecureUpstream): "true",
+			},
+			networkingv1.ServiceBackendPort{Name: "https"},
+			[]corev1.ServicePort{{
+				Name:       "https",
+				Port:       443,
+				TargetPort: intstr.IntOrString{IntVal: 443},
+			}},
+			[]corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}, {IP: "1.2.3.5"}},
+				Ports:     []corev1.EndpointPort{{Name: "https", Port: 443}},
+			}},
+			[]string{
+				"https://1.2.3.4:443",
+				"https://1.2.3.5:443",
+			},
+			"service.default.svc.cluster.local",
+		},
+		{
+			"HTTPS multiple IPs - override",
+			map[string]string{
+				fmt.Sprintf("p/%s", model.SecureUpstream): "true",
+				fmt.Sprintf("p/%s", model.TLSServerName):  "custom-service.default.svc.cluster.local",
+			},
+			networkingv1.ServiceBackendPort{Name: "https"},
+			[]corev1.ServicePort{{
+				Name:       "https",
+				Port:       443,
+				TargetPort: intstr.IntOrString{IntVal: 443},
+			}},
+			[]corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}, {IP: "1.2.3.5"}},
+				Ports:     []corev1.EndpointPort{{Name: "https", Port: 443}},
+			}},
+			[]string{
+				"https://1.2.3.4:443",
+				"https://1.2.3.5:443",
+			},
+			"custom-service.default.svc.cluster.local",
+		},
+		{
+			"HTTPS use service proxy",
+			map[string]string{
+				fmt.Sprintf("p/%s", model.SecureUpstream):  "true",
+				fmt.Sprintf("p/%s", model.UseServiceProxy): "true",
+			},
+			networkingv1.ServiceBackendPort{Name: "https"},
+			[]corev1.ServicePort{{
+				Name:       "https",
+				Port:       443,
+				TargetPort: intstr.IntOrString{IntVal: 443},
+			}},
+			[]corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}, {IP: "1.2.3.5"}},
+				Ports:     []corev1.EndpointPort{{Name: "https", Port: 443}},
+			}},
+			[]string{
+				"https://service.default.svc.cluster.local:443",
+			},
+			"",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pathTypePrefix := networkingv1.PathTypePrefix
+			ic := &model.IngressConfig{
+				AnnotationPrefix: "p",
+				Ingress: &networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "ingress",
+						Namespace:   "default",
+						Annotations: tc.ingressAnnotations,
+					},
+					Spec: networkingv1.IngressSpec{
+						TLS: []networkingv1.IngressTLS{{
+							Hosts:      []string{"service.localhost.pomerium.io"},
+							SecretName: "secret",
+						}},
+						Rules: []networkingv1.IngressRule{{
+							Host: "service.localhost.pomerium.io",
+							IngressRuleValue: networkingv1.IngressRuleValue{
+								HTTP: &networkingv1.HTTPIngressRuleValue{
+									Paths: []networkingv1.HTTPIngressPath{{
+										Path:     "/a",
+										PathType: &pathTypePrefix,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "service",
+												Port: tc.ingressPort,
+											},
+										},
+									}},
+								},
+							},
+						}},
+					},
+				},
+				Endpoints: map[types.NamespacedName]*corev1.Endpoints{
+					{Name: "service", Namespace: "default"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "service",
+							Namespace: "default",
+						},
+						Subsets: tc.endpointSubsets,
+					}},
+				Services: map[types.NamespacedName]*corev1.Service{
+					{Name: "service", Namespace: "default"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "service",
+							Namespace: "default",
+						},
+						Spec: corev1.ServiceSpec{
+							Ports: tc.svcPorts,
+						},
+						Status: corev1.ServiceStatus{},
+					},
+				},
+			}
+
+			cfg := new(pb.Config)
+			require.NoError(t, upsertRoutes(context.Background(), cfg, ic))
+			routes, err := routeList(cfg.Routes).toMap()
+			require.NoError(t, err)
+			route := routes[routeID{
+				Name:      "ingress",
+				Namespace: "default",
+				Path:      "/a",
+				Host:      "service.localhost.pomerium.io",
+			}]
+			require.NotNil(t, route, "route not found in %v", routes)
+			require.ElementsMatch(t, tc.expectTO, route.To)
+			require.Equal(t, tc.expectTLSServerName, route.TlsServerName)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

When endpoints are used (which is default mode right now), the upstream destination contains IP addresses, which will result in TLS cert verification failure.
This change would automatically set TLS server name to `service.namespace.svc.cluster.local` where `service` and `namespace` are `Service` resource name and namespace respectively. 

## Related issues

Implements https://github.com/pomerium/ingress-controller/issues/164

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
