### PR TITLE
Support path-related rewrite annotations

### DIFF
--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -46,7 +46,7 @@ var (
 		"pass_identity_headers",
 		"tls_skip_verify",
 		"tls_server_name",
-		"prefix_rewrite"
+		"prefix_rewrite",
 	})
 	policyAnnotations = boolMap([]string{
 		"allowed_users",

--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -46,6 +46,7 @@ var (
 		"pass_identity_headers",
 		"tls_skip_verify",
 		"tls_server_name",
+		"prefix_rewrite"
 	})
 	policyAnnotations = boolMap([]string{
 		"allowed_users",

--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -47,6 +47,8 @@ var (
 		"tls_skip_verify",
 		"tls_server_name",
 		"prefix_rewrite",
+		"regex_rewrite_pattern",
+		"regex_rewrite_substitution",
 	})
 	policyAnnotations = boolMap([]string{
 		"allowed_users",

--- a/pomerium/ingress_annotations_test.go
+++ b/pomerium/ingress_annotations_test.go
@@ -71,6 +71,8 @@ func TestAnnotations(t *testing.T) {
 					"a/lb_policy":                            "LEAST_REQUEST",
 					"a/least_request_lb_config":              `{"choice_count":3,"active_request_bias":{"default_value":4,"runtime_key":"key"},"slow_start_config":{"slow_start_window":"3s","aggression":{"runtime_key":"key"}}}`,
 					"a/prefix_rewrite":                       "/",
+					"a/regex_rewrite_pattern":                `^/service/([^/]+)(/.*)$`,
+					"a/regex_rewrite_substitution":           `\\2/instance/\\1`,
 				},
 			},
 		},
@@ -122,6 +124,8 @@ func TestAnnotations(t *testing.T) {
 		HostPathRegexRewriteSubstitution: strp("rewrite-sub"),
 		PassIdentityHeaders:              true,
 		PrefixRewrite:                    "/",
+		RegexRewritePattern:              `^/service/([^/]+)(/.*)$`,
+		RegexRewriteSubstitution:         `\\2/instance/\\1`,
 		EnvoyOpts: &envoy_config_cluster_v3.Cluster{
 			HealthChecks: []*envoy_config_core_v3.HealthCheck{{
 				Timeout:            durationpb.New(time.Second * 10),

--- a/pomerium/ingress_annotations_test.go
+++ b/pomerium/ingress_annotations_test.go
@@ -70,6 +70,7 @@ func TestAnnotations(t *testing.T) {
 					"a/secure_upstream":                      "true",
 					"a/lb_policy":                            "LEAST_REQUEST",
 					"a/least_request_lb_config":              `{"choice_count":3,"active_request_bias":{"default_value":4,"runtime_key":"key"},"slow_start_config":{"slow_start_window":"3s","aggression":{"runtime_key":"key"}}}`,
+					"a/prefix_rewrite":                       "/",
 				},
 			},
 		},
@@ -120,6 +121,7 @@ func TestAnnotations(t *testing.T) {
 		HostPathRegexRewritePattern:      strp("rewrite-pattern"),
 		HostPathRegexRewriteSubstitution: strp("rewrite-sub"),
 		PassIdentityHeaders:              true,
+		PrefixRewrite:                    "/",
 		EnvoyOpts: &envoy_config_cluster_v3.Cluster{
 			HealthChecks: []*envoy_config_core_v3.HealthCheck{{
 				Timeout:            durationpb.New(time.Second * 10),


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

Latest ingress controller release does not support regex_rewrite or prefix_rewrite via
ingress annotation. This prevents some users from migrating away from legacy policy definitions/other ingress
controllers to Pomerium for applications that require path rewriting during forwarding.

Adds the following as supported base annotations:
- `ingress.pomerium.io/prefix_rewrite` 
- `ingress.pomerium.io/regex_rewrite_pattern` 
- `ingress.pomerium.io/regex_rewrite_substitution` 

## Related issues

Related: pomerium/pomerium#2979
pomerium/pomerium#3310

## Checklist

- [x] reference any related issues
- [x] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
