### PR TITLE
Add support for kubernetes_service_account_token_file as Ingress annotation

### DIFF
--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -46,6 +46,7 @@ var (
 		"pass_identity_headers",
 		"tls_skip_verify",
 		"tls_server_name",
+		"kubernetes_service_account_token_file",
 	})
 	policyAnnotations = boolMap([]string{
 		"allowed_users",

--- a/pomerium/ingress_annotations_test.go
+++ b/pomerium/ingress_annotations_test.go
@@ -70,6 +70,7 @@ func TestAnnotations(t *testing.T) {
 					"a/secure_upstream":                      "true",
 					"a/lb_policy":                            "LEAST_REQUEST",
 					"a/least_request_lb_config":              `{"choice_count":3,"active_request_bias":{"default_value":4,"runtime_key":"key"},"slow_start_config":{"slow_start_window":"3s","aggression":{"runtime_key":"key"}}}`,
+					"a/kubernetes_service_account_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token",
 				},
 			},
 		},
@@ -163,6 +164,7 @@ func TestAnnotations(t *testing.T) {
 		}},
 		TlsSkipVerify: true,
 		TlsServerName: "my.server.name",
+		KubernetesServiceAccountTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 	}, cmpopts.IgnoreUnexported(
 		pb.Route{},
 		pb.RouteRewriteHeader{},


### PR DESCRIPTION
Signed-off-by: TJ Wesolowski <wojoinc@pm.me>

## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

Adds `ingress.pomerium.io/kubernetes_service_account_token_file` as a supported base annotation.

Note: Tests will not pass until related PR is merged, as updates to the protobuf definition for Route were required to support this annotation. I assume that updates to the go.mod will be needed after the related PR is merged.

## Related issues

<!-- For example...
Fixes #159
-->
#188 
Depends on: pomerium/pomerium#3309

## Checklist

- [x] reference any related issues
- [x] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
