### PR TITLE
Fix TLS cert parsing

### DIFF
--- a/model/ingress_config.go
+++ b/model/ingress_config.go
@@ -146,7 +146,7 @@ func (ic *IngressConfig) ParseTLSCerts(ctx context.Context) ([]*TLSCert, error) 
 
 	for _, secret := range ic.Secrets {
 		if secret.Type != corev1.SecretTypeTLS {
-			log.FromContext(ctx).Info(fmt.Sprintf("secret=%s, of type=%s found while parsing TLS certs, expected type=%s, ignoring", secret.Name, secret.Type, corev1.SecretTypeTLS))
+			log.FromContext(ctx).Info(fmt.Sprintf("secret=%s, of type=%s found while parsing TLS certs for Ingress %s, expected type=%s, ignoring", secret.Name, secret.Type, ic.Name, corev1.SecretTypeTLS))
 			continue
 		}
 		certs = append(certs, &TLSCert{

--- a/model/ingress_config.go
+++ b/model/ingress_config.go
@@ -2,12 +2,14 @@
 package model
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -139,12 +141,13 @@ func (ic *IngressConfig) Clone() *IngressConfig {
 }
 
 // ParseTLSCerts decodes K8s TLS secret
-func (ic *IngressConfig) ParseTLSCerts() ([]*TLSCert, error) {
+func (ic *IngressConfig) ParseTLSCerts(ctx context.Context) ([]*TLSCert, error) {
 	certs := make([]*TLSCert, 0, len(ic.Secrets))
 
 	for _, secret := range ic.Secrets {
 		if secret.Type != corev1.SecretTypeTLS {
-			return nil, fmt.Errorf("secret=%s, expected type %s, got %s", secret.Name, corev1.SecretTypeTLS, secret.Type)
+			log.FromContext(ctx).Info(fmt.Sprintf("secret=%s, of type=%s found while parsing TLS certs, expected type=%s, ignoring", secret.Name, secret.Type, corev1.SecretTypeTLS))
+			continue
 		}
 		certs = append(certs, &TLSCert{
 			Key:  secret.Data[corev1.TLSPrivateKeyKey],

--- a/pomerium/certs.go
+++ b/pomerium/certs.go
@@ -1,6 +1,7 @@
 package pomerium
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
@@ -10,8 +11,8 @@ import (
 )
 
 // upsertCerts updates certificate bundle
-func upsertCerts(cfg *pb.Config, ic *model.IngressConfig) error {
-	certs, err := ic.ParseTLSCerts()
+func upsertCerts(ctx context.Context, cfg *pb.Config, ic *model.IngressConfig) error {
+	certs, err := ic.ParseTLSCerts(ctx)
 	if err != nil {
 		return err
 	}

--- a/pomerium/routes.go
+++ b/pomerium/routes.go
@@ -15,7 +15,7 @@ func upsert(ctx context.Context, cfg *pb.Config, ic *model.IngressConfig) error 
 		return fmt.Errorf("upsert routes: %w", err)
 	}
 
-	if err := upsertCerts(cfg, ic); err != nil {
+	if err := upsertCerts(ctx, cfg, ic); err != nil {
 		return fmt.Errorf("updating certs: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

Updates `*IngressConfig.ParseTLSCerts` to simply ignore any secrets in `ic.Secrets` that are not of type `corev1.SecretTypeTLS`.
Instead, an informational message is printed out, in case the user did happen to specify an incorrect secret when providing TLS certs for a given Ingress.

This allows the new annotations added in #198 to be used without breaking TLS cert parsing.
`ParseTLSCerts` now accepts a `context.Context` in order to grab the appropriate logger.

Of course open to ideas if there's better/more preferred way to fix this one!

## Related issues

<!-- For example...
Fixes #159
-->

Fixes #205

## Additional Info

Also seeing the following issue in the logs when testing this update on my homelab. Not familiar enough with the codebase to tell exactly where the issue is, but I don't think its introduced by this change.
```logs
{"level":"info","ts":1651965517.0284693,"logger":"initial-sync","msg":"complete"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x19ab776]

goroutine 312 [running]:
github.com/pomerium/pomerium/internal/httputil/reproxy.(*Handler).GetPolicyIDHeaders(0x0, 0xc0021bb620)
	/go/pkg/mod/github.com/pomerium/pomerium@v0.17.2/internal/httputil/reproxy/reproxy.go:65 +0x56
github.com/pomerium/pomerium/config/envoyconfig.(*Builder).buildPolicyRoutes(0xc003171920, 0xc000cd7c00, {0xc000b87d90, 0x10})
	/go/pkg/mod/github.com/pomerium/pomerium@v0.17.2/config/envoyconfig/routes.go:295 +0xb8d
github.com/pomerium/pomerium/config/envoyconfig.(*Builder).buildMainHTTPConnectionManagerFilter(0xc000cd7c00, 0xc000cd7c00, {0xc002065a00, 0x20, 0x1ffffffffffffff}, {0x0, 0x8})
	/go/pkg/mod/github.com/pomerium/pomerium@v0.17.2/config/envoyconfig/listeners.go:329 +0x18a5
github.com/pomerium/pomerium/config/envoyconfig.(*Builder).buildMainListener(0xc003171920, {0x21b90a0, 0xc0002b5260}, 0xc003171960)
	/go/pkg/mod/github.com/pomerium/pomerium@v0.17.2/config/envoyconfig/listeners.go:115 +0x218
github.com/pomerium/pomerium/config/envoyconfig.(*Builder).BuildListeners(0x1e9a840, {0x21b90a0, 0xc0002b5260}, 0xc003171960)
	/go/pkg/mod/github.com/pomerium/pomerium@v0.17.2/config/envoyconfig/listeners.go:65 +0xfb
github.com/pomerium/ingress-controller/pomerium.validate({0x21b90a0, 0xc0002b5260}, 0xc001a92000, {0xc000dc0cf0, 0x24})
	/workspace/pomerium/validate.go:68 +0x6e5
github.com/pomerium/ingress-controller/pomerium.(*ConfigReconciler).Set(0x21d88d8, {0x21b90a0, 0xc0002b5260}, {0xc000354700, 0x19, 0xc000801d40})
	/workspace/pomerium/sync.go:69 +0x1d2
github.com/pomerium/ingress-controller/controllers.(*ingressController).reconcileInitial(0xc000cca7e0, {0x21b90a0, 0xc0002b5260})
	/workspace/controllers/reconcile.go:64 +0x76b
github.com/pomerium/ingress-controller/controllers.newOnce.func1()
	/workspace/controllers/once.go:19 +0x4d
created by github.com/pomerium/ingress-controller/controllers.newOnce
	/workspace/controllers/once.go:17 +0xe8
```

Because of this issue, I'm not able to personally test and validate this change works 100%. Any thoughts?

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
