### PR TITLE
fix custom secrets

### DIFF
--- a/model/ingress_config.go
+++ b/model/ingress_config.go
@@ -144,7 +144,7 @@ func (ic *IngressConfig) ParseTLSCerts() ([]*TLSCert, error) {
 
 	for _, secret := range ic.Secrets {
 		if secret.Type != corev1.SecretTypeTLS {
-			return nil, fmt.Errorf("secret=%s, expected type %s, got %s", secret.Name, corev1.SecretTypeTLS, secret.Type)
+			continue
 		}
 		certs = append(certs, &TLSCert{
 			Key:  secret.Data[corev1.TLSPrivateKeyKey],

--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -271,6 +271,9 @@ func applySecretAnnotations(
 		if secret == nil {
 			return fmt.Errorf("annotation %s references secret %s, but the secret wasn't fetched. this is a bug", k, name)
 		}
+		if secret.Type != corev1.SecretTypeOpaque {
+			return fmt.Errorf("annotation %s references secret %s, expected type %s, got %s", k, name, corev1.SecretTypeOpaque, secret.Type)
+		}
 		switch k {
 		case model.KubernetesServiceAccountTokenSecret:
 			token, ok := secret.Data[model.KubernetesServiceAccountTokenSecretKey]

--- a/pomerium/ingress_annotations_test.go
+++ b/pomerium/ingress_annotations_test.go
@@ -101,18 +101,21 @@ func TestAnnotations(t *testing.T) {
 				Data: map[string][]byte{
 					model.KubernetesServiceAccountTokenSecretKey: []byte("k8s-token-data"),
 				},
+				Type: corev1.SecretTypeOpaque,
 			},
 			{Name: "request_headers", Namespace: "test"}: {
 				Data: map[string][]byte{
 					"req_key_1": []byte("req_data1"),
 					"req_key_2": []byte("req_data2"),
 				},
+				Type: corev1.SecretTypeOpaque,
 			},
 			{Name: "response_headers", Namespace: "test"}: {
 				Data: map[string][]byte{
 					"res_key_1": []byte("res_data1"),
 					"res_key_2": []byte("res_data2"),
 				},
+				Type: corev1.SecretTypeOpaque,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Adds tests for custom secret handling and drops unnecessary TLS cert check. 

## Related issues

https://github.com/pomerium/ingress-controller/issues/205

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
