### PR TITLE
add a job to generate bootstrap secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,11 @@ dev-install:
 	@$(KUSTOMIZE) build config/dev | kubectl apply --filename -
 	@stern -n pomerium --selector app.kubernetes.io/name=pomerium
 
+.PHONY: dev-gen-secrets
+dev-gen-secrets:
+	@echo "==> $@"
+	@$(KUSTOMIZE) build config/dev/gen_secrets | kubectl apply --filename -
+
 .PHONY: dev-build
 dev-build:
 	@echo "==> $@"

--- a/apis/ingress/v1/settings_types.go
+++ b/apis/ingress/v1/settings_types.go
@@ -100,7 +100,7 @@ type RedisStorage struct {
 // PostgresStorage defines Postgres connection parameters
 type PostgresStorage struct {
 	// Secret specifies a name of a Secret that must contain
-	// `postgresql_connection_string`
+	// `connection` key
 	// for the connection DSN format and parameters, see
 	// https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
 	// the following keywords are not allowed to be part of the parameters,
@@ -132,9 +132,11 @@ type PostgresStorage struct {
 // Omit setting storage to use in-memory storage implementation.
 type Storage struct {
 	// Redis defines REDIS connection parameters
+	// +kubebuilder:validation:Optional
 	Redis *RedisStorage `json:"redis"`
 
 	// Postgres specifies PostgreSQL database connection parameters
+	// +kubebuilder:validation:Optional
 	Postgres *PostgresStorage `json:"postgresql"`
 }
 

--- a/config/crd/bases/ingress.pomerium.io_settings.yaml
+++ b/config/crd/bases/ingress.pomerium.io_settings.yaml
@@ -193,9 +193,6 @@ spec:
                     required:
                     - secret
                     type: object
-                required:
-                - postgresql
-                - redis
                 type: object
             required:
             - authenticate

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -4,3 +4,4 @@ commonLabels:
 bases:
   - ../crd
   - ../pomerium
+  - ../gen_secrets

--- a/config/gen_secrets/job.yaml
+++ b/config/gen_secrets/job.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pomerium-gen-secrets
+spec:
+  template:
+    metadata:
+      name: pomerium-gen-secrets
+    spec:
+      containers:
+        - name: gen-secrets
+          args:
+            - gen-secrets
+            - --secrets=$(POD_NAMESPACE)/bootstrap
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          image: controller:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
+        runAsUser: 1000
+      serviceAccountName: pomerium-gen-secrets

--- a/config/gen_secrets/kustomization.yaml
+++ b/config/gen_secrets/kustomization.yaml
@@ -1,0 +1,6 @@
+namespace: pomerium
+resources:
+  - job.yaml
+  - role_binding.yaml
+  - role.yaml
+  - service_account.yaml

--- a/config/gen_secrets/role.yaml
+++ b/config/gen_secrets/role.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pomerium-gen-secrets
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create

--- a/config/gen_secrets/role_binding.yaml
+++ b/config/gen_secrets/role_binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pomerium-gen-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pomerium-gen-secrets
+subjects:
+  - kind: ServiceAccount
+    name: pomerium-gen-secrets

--- a/config/gen_secrets/service_account.yaml
+++ b/config/gen_secrets/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pomerium-gen-secrets

--- a/config/pomerium/deployment.yaml
+++ b/config/pomerium/deployment.yaml
@@ -7,8 +7,12 @@ spec:
   replicas: 1
   template:
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
+        fsGroup: 1000
+        runAsUser: 1000
       containers:
         - name: pomerium
           command:

--- a/go.sum
+++ b/go.sum
@@ -1595,8 +1595,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
-github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -2638,12 +2636,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyz
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
 sigs.k8s.io/controller-runtime v0.12.2 h1:nqV02cvhbAj7tbt21bpPpTByrXGn2INHRsi39lXy9sE=
 sigs.k8s.io/controller-runtime v0.12.2/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
-sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20220628190934-17893a8fae1e h1:ph+mdifTubTmcA82D+w6LQBw8oqGN0FrESsCm2bMb1Q=
-sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20220628190934-17893a8fae1e/go.mod h1:nLkMD2WB4Jcix1qfVuJeOF4j5y/VfyeOIlTxG5Wj9co=
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20220629132207-365ae09c4c6c h1:DDeXe8254mA+hjwgBZD5tvUdB/iRun+Gu1wSqM8XS4c=
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20220629132207-365ae09c4c6c/go.mod h1:nLkMD2WB4Jcix1qfVuJeOF4j5y/VfyeOIlTxG5Wj9co=
-sigs.k8s.io/controller-tools v0.9.1 h1:/mnVp0o+DTwn503e55sq0vUa58DkE4JUQmJNTV9iq1Y=
-sigs.k8s.io/controller-tools v0.9.1/go.mod h1:NUkn8FTV3Sad3wWpSK7dt/145qfuQ8CKJV6j4jHC5rM=
 sigs.k8s.io/controller-tools v0.9.2 h1:AkTE3QAdz9LS4iD3EJvHyYxBkg/g9fTbgiYsrcsFCcM=
 sigs.k8s.io/controller-tools v0.9.2/go.mod h1:NUkn8FTV3Sad3wWpSK7dt/145qfuQ8CKJV6j4jHC5rM=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=


### PR DESCRIPTION
## Summary

Adds a job to generate bootstrap secrets, containing `shared_secret`, `cookie_secret` 
and `signing_key` parameter. That should minimize the amount of operations the user 
should perform to get Pomerium up and running. 

## Related issues


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
