### PR TITLE
remove ingress class default cert

### DIFF
--- a/cmd/ingress_opts.go
+++ b/cmd/ingress_opts.go
@@ -16,7 +16,6 @@ type ingressControllerOpts struct {
 	ClassName               string `validate:"required"`
 	AnnotationPrefix        string `validate:"required"`
 	Namespaces              []string
-	DisableCertCheck        bool
 	UpdateStatusFromService string `validate:"required"`
 	GlobalSettings          string `validate:"required"`
 }
@@ -28,7 +27,6 @@ const (
 	sharedSecret               = "shared-secret"
 	debug                      = "debug"
 	updateStatusFromService    = "update-status-from-service"
-	disableCertCheck           = "disable-cert-check"
 	globalSettings             = "pomerium-config"
 )
 
@@ -37,7 +35,6 @@ func (s *ingressControllerOpts) setupFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&s.AnnotationPrefix, annotationPrefix, ingress.DefaultAnnotationPrefix, "Ingress annotation prefix")
 	flags.StringSliceVar(&s.Namespaces, namespaces, nil, "namespaces to watch, or none to watch all namespaces")
 	flags.StringVar(&s.UpdateStatusFromService, updateStatusFromService, "", "update ingress status from given service status (pomerium-proxy)")
-	flags.BoolVar(&s.DisableCertCheck, disableCertCheck, false, "disables certificate check")
 	flags.StringVar(&s.GlobalSettings, globalSettings, "",
 		fmt.Sprintf("namespace/name to a resource of type %s/Settings", icsv1.GroupVersion.Group))
 }
@@ -63,9 +60,6 @@ func (s *ingressControllerOpts) getIngressControllerOptions() ([]ingress.Option,
 		ingress.WithNamespaces(s.Namespaces),
 		ingress.WithAnnotationPrefix(s.AnnotationPrefix),
 		ingress.WithControllerName(s.ClassName),
-	}
-	if s.DisableCertCheck {
-		opts = append(opts, ingress.WithDisableCertCheck())
 	}
 	if name, err := s.getGlobalSettings(); err != nil {
 		return nil, err

--- a/controllers/ingress/controller.go
+++ b/controllers/ingress/controller.go
@@ -63,10 +63,6 @@ type ingressController struct {
 	serviceKind      string
 	settingsKind     string
 
-	// disableCertCheck indicates that pomerium is deployed with insecure_server option
-	// no checks should be applied for the cert check
-	disableCertCheck bool
-
 	initComplete *once
 }
 
@@ -120,15 +116,6 @@ func WithUpdateIngressStatusFromService(name types.NamespacedName) Option {
 func WithWatchSettings(name types.NamespacedName) Option {
 	return func(ic *ingressController) {
 		ic.globalSettings = &name
-	}
-}
-
-// WithDisableCertCheck indicates that Pomerium this ingress controller is communicating with
-// is currently configured with insecure_server option
-// that would disable certificate checks
-func WithDisableCertCheck() Option {
-	return func(ic *ingressController) {
-		ic.disableCertCheck = true
 	}
 }
 

--- a/controllers/ingress/controller_integration_test.go
+++ b/controllers/ingress/controller_integration_test.go
@@ -387,48 +387,6 @@ func (s *ControllerTestSuite) TestIngressClass() {
 
 }
 
-func (s *ControllerTestSuite) TestDefaultCert() {
-	ctx := context.Background()
-	s.createTestController(ctx)
-
-	to := s.initialTestObjects("default")
-	to.Ingress.Spec.TLS[0].SecretName = ""
-	// ingress should not be picked up unless there's a certificate
-	s.NoError(s.Client.Create(ctx, to.Secret))
-	s.NoError(s.Client.Create(ctx, to.Ingress))
-	s.NoError(s.Client.Create(ctx, to.Endpoints))
-	s.NoError(s.Client.Create(ctx, to.Service))
-	s.NoError(s.Client.Create(ctx, to.IngressClass))
-	s.NeverEqual(func(ic *model.IngressConfig) string {
-		return cmp.Diff(to.Ingress, ic.Ingress, cmpOpts...)
-	})
-
-	to.IngressClass.Annotations = map[string]string{
-		fmt.Sprintf("%s/%s", ingress_controller.DefaultAnnotationPrefix, ingress_controller.DefaultCertSecretKey): fmt.Sprintf("%s/%s", to.Secret.Namespace, to.Secret.Name),
-	}
-	s.NoError(s.Client.Update(ctx, to.IngressClass))
-	s.EventuallyUpsert(func(ic *model.IngressConfig) string {
-		return cmp.Diff(to.Ingress, ic.Ingress, cmpOpts...)
-	}, "set default cert")
-}
-
-func (s *ControllerTestSuite) TestSkipCertCheck() {
-	ctx := context.Background()
-	s.createTestController(ctx, ingress_controller.WithDisableCertCheck())
-
-	to := s.initialTestObjects("default")
-	to.Ingress.Spec.TLS[0].SecretName = ""
-	s.NoError(s.Client.Create(ctx, to.Secret))
-	s.NoError(s.Client.Create(ctx, to.Ingress))
-	s.NoError(s.Client.Create(ctx, to.Endpoints))
-	s.NoError(s.Client.Create(ctx, to.Service))
-	s.NoError(s.Client.Create(ctx, to.IngressClass))
-
-	s.EventuallyUpsert(func(ic *model.IngressConfig) string {
-		return cmp.Diff(to.Ingress, ic.Ingress, cmpOpts...)
-	}, "set ingress with no certificate")
-}
-
 // TestDependencies verifies that when objects the Ingress depends on change,
 // a configuration reconciliation would happen
 func (s *ControllerTestSuite) TestDependencies() {

--- a/controllers/ingress/ingress_class.go
+++ b/controllers/ingress/ingress_class.go
@@ -5,11 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -17,12 +15,8 @@ const (
 	// IngressClassAnnotationKey although deprecated, still may be used by the HTTP solvers even for v1 Ingress resources
 	// see https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#deprecating-the-ingress-class-annotation
 	IngressClassAnnotationKey = "kubernetes.io/ingress.class"
-
 	// IngressClassDefaultAnnotationKey see https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
 	IngressClassDefaultAnnotationKey = "ingressclass.kubernetes.io/is-default-class"
-	// DefaultCertSecretKey is an annotation that may be added to ingressClass
-	// nolint:gosec
-	DefaultCertSecretKey = "default-cert-secret"
 )
 
 type ingressManageResult struct {
@@ -105,14 +99,6 @@ func getAnnotation(dict map[string]string, key string) (string, error) {
 	return txt, nil
 }
 
-func namespacedName(name string) (*types.NamespacedName, error) {
-	parts := strings.Split(name, "/")
-	if len(parts) != 2 {
-		return nil, errors.New("should be in namespace/name format")
-	}
-	return &types.NamespacedName{Namespace: parts[0], Name: parts[1]}, nil
-}
-
 func isDefaultIngressClass(ic *networkingv1.IngressClass) (bool, error) {
 	txt, err := getAnnotation(ic.Annotations, IngressClassDefaultAnnotationKey)
 	if err != nil {
@@ -123,12 +109,4 @@ func isDefaultIngressClass(ic *networkingv1.IngressClass) (bool, error) {
 		return false, fmt.Errorf("invalid value for annotation %s: %w", IngressClassDefaultAnnotationKey, err)
 	}
 	return val, nil
-}
-
-func getDefaultCertSecretName(ic *networkingv1.IngressClass, prefix string) (*types.NamespacedName, error) {
-	txt, err := getAnnotation(ic.Annotations, fmt.Sprintf("%s/%s", prefix, DefaultCertSecretKey))
-	if err != nil {
-		return nil, err
-	}
-	return namespacedName(txt)
 }

--- a/go.sum
+++ b/go.sum
@@ -2634,8 +2634,6 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyz
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
-sigs.k8s.io/controller-runtime v0.12.2 h1:nqV02cvhbAj7tbt21bpPpTByrXGn2INHRsi39lXy9sE=
-sigs.k8s.io/controller-runtime v0.12.2/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/controller-runtime v0.12.3 h1:FCM8xeY/FI8hoAfh/V4XbbYMY20gElh9yh+A98usMio=
 sigs.k8s.io/controller-runtime v0.12.3/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20220706151251-15154aaa6767 h1:vtJnIIQUlw5vjbCFB1wLLkHKTb07+aswYve6bmQzBdg=


### PR DESCRIPTION
## Summary

https://github.com/pomerium/ingress-controller/pull/151 Introduced default cert secret, set as an annotation for the `IngressClass`. 
This functionality is now superceded by ability to provide certificate list in the CRD, and has to be removed. 
We also remove `disable-cert-check` runtime option, as it is no longer necessary. 

## Related issues

https://github.com/pomerium/ingress-controller/pull/151

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
