### PR TITLE
fix posting events to crd

### DIFF
--- a/controllers/reporter/ingress.go
+++ b/controllers/reporter/ingress.go
@@ -138,7 +138,12 @@ type IngressSettingsEventReporter struct {
 }
 
 func (r *IngressSettingsEventReporter) postEvent(ctx context.Context, ingress types.NamespacedName, eventType, reason, msg string) error {
-	r.EventRecorder.AnnotatedEventf(&icsv1.Pomerium{ObjectMeta: metav1.ObjectMeta{Name: r.Name}},
+	var obj icsv1.Pomerium
+	if err := r.Client.Get(ctx, r.NamespacedName, &obj); err != nil {
+		return fmt.Errorf("get %s: %w", r.NamespacedName, err)
+	}
+
+	r.EventRecorder.AnnotatedEventf(&obj,
 		map[string]string{"ingress": ingress.String()},
 		eventType, reason, "%s: %s", ingress.String(), msg)
 	return nil


### PR DESCRIPTION
## Summary

For some reason, you need a full object that was previously returned by the API server, to post events to it. 
Otherwise, they are just silently skipped? 

## Related issues

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
