### PR TITLE
docker: pin dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
 # make sure to run `make clean` if building locally
 
-FROM golang:1.18 as go-modules
+FROM golang:1.18@sha256:6e10f44d212b24a3611280c8035edaf9d519f20e3f4d8f6f5e26796b738433da as go-modules
 
 WORKDIR /workspace
 
@@ -20,7 +20,7 @@ COPY Makefile ./Makefile
 RUN mkdir -p internal
 RUN make internal/ui
 
-FROM node:16 as ui
+FROM node:16@sha256:da6394f75d6b6f88c0e1ef6fde5805d7385a50159237830a69e9ff154631775e as ui
 WORKDIR /workspace
 
 COPY --from=go-modules /workspace/internal/ui ./
@@ -40,7 +40,7 @@ RUN CGO_ENABLED=0 make build-go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:debug-nonroot-${TARGETARCH:-amd64}
+FROM gcr.io/distroless/base:debug-nonroot@sha256:dbce382b7e6bc34dd49db2c07b759797039ca144089a134617ac1de5a3bc5f27
 WORKDIR /
 COPY --from=go-builder /workspace/bin/manager .
 USER 65532:65532


### PR DESCRIPTION
## Summary
Upgrade docker dependencies and use a sha256 version pin.