### PR TITLE
config: turn on leadership election

### DIFF
--- a/cmd/all_in_one.go
+++ b/cmd/all_in_one.go
@@ -270,7 +270,8 @@ func (s *allCmdParam) buildController(ctx context.Context, cfg *config.Config) (
 			Scheme:             scheme,
 			MetricsBindAddress: s.ingressMetricsAddr,
 			Port:               0,
-			LeaderElection:     false,
+			LeaderElection:     true,
+			LeaderElectionID:   "pomerium-controller",
 		},
 		IngressCtrlOpts: s.ingressOpts,
 		GlobalSettings:  &s.settings,
@@ -295,7 +296,8 @@ func (s *allCmdParam) runBootstrapConfigController(ctx context.Context, reconcil
 		Scheme:             scheme,
 		MetricsBindAddress: s.bootstrapMetricsAddr,
 		Port:               0,
-		LeaderElection:     false,
+		LeaderElection:     true,
+		LeaderElectionID:   "pomerium-controller-bootstrap",
 	})
 	if err != nil {
 		return fmt.Errorf("manager: %w", err)

--- a/config/pomerium/rbac/role.yaml
+++ b/config/pomerium/rbac/role.yaml
@@ -62,3 +62,12 @@ rules:
     verbs:
       - create
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - patch
+      - update

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -23,245 +23,272 @@ spec:
     singular: pomerium
   scope: Cluster
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: Pomerium define runtime-configurable Pomerium settings that do
-          not fall into the category of deployment parameters
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: PomeriumSpec defines the desired state of Settings
-            properties:
-              authenticate:
-                description: Authenticate sets authenticate service parameters
-                properties:
-                  callbackPath:
-                    description: CallbackPath see https://www.pomerium.com/reference/#authenticate-callback-path
-                    type: string
-                  url:
-                    description: AuthenticateURL should be publicly accessible URL
-                      the non-authenticated persons would be referred to see https://www.pomerium.com/reference/#authenticate-service-url
-                    format: uri
-                    pattern: ^https://
-                    type: string
-                required:
-                - url
-                type: object
-              certificates:
-                description: Certificates is a list of secrets of type TLS to use
-                items:
-                  type: string
-                type: array
-              identityProvider:
-                description: IdentityProvider see https://www.pomerium.com/docs/identity-providers/
-                properties:
-                  provider:
-                    description: Provider one of accepted providers https://www.pomerium.com/reference/#identity-provider-name
-                    enum:
-                    - auth0
-                    - azure
-                    - google
-                    - okta
-                    - onelogin
-                    - oidc
-                    - ping
-                    - github
-                    type: string
-                  refreshDirectory:
-                    description: Specifies refresh settings
-                    properties:
-                      interval:
-                        format: duration
-                        type: string
-                      timeout:
-                        format: duration
-                        type: string
-                    required:
-                    - interval
-                    - timeout
-                    type: object
-                  requestParams:
-                    additionalProperties:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description:
+            Pomerium define runtime-configurable Pomerium settings that do
+            not fall into the category of deployment parameters
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: PomeriumSpec defines the desired state of Settings
+              properties:
+                authenticate:
+                  description: Authenticate sets authenticate service parameters
+                  properties:
+                    callbackPath:
+                      description: CallbackPath see https://www.pomerium.com/reference/#authenticate-callback-path
                       type: string
-                    description: RequestParams see https://www.pomerium.com/reference/#identity-provider-request-params
-                    type: object
-                  requestParamsSecret:
-                    description: RequestParamsSecret is a reference to a secret for
-                      additional parameters you'd prefer not to provide in plaintext
-                    type: string
-                  scopes:
-                    description: Scopes see https://www.pomerium.com/reference/#identity-provider-scopes
-                    items:
+                    url:
+                      description:
+                        AuthenticateURL should be publicly accessible URL
+                        the non-authenticated persons would be referred to see https://www.pomerium.com/reference/#authenticate-service-url
+                      format: uri
+                      pattern: ^https://
                       type: string
-                    type: array
-                  secret:
-                    description: Secret refers to a k8s secret containing IdP provider
-                      specific parameters and must contain at least `client_id` and
-                      `client_secret` map values, an optional `service_account` field,
-                      mapped to https://www.pomerium.com/reference/#identity-provider-service-account
-                    minLength: 1
+                  required:
+                    - url
+                  type: object
+                certificates:
+                  description: Certificates is a list of secrets of type TLS to use
+                  items:
                     type: string
-                  serviceAccountFromSecret:
-                    description: ServiceAccountFromSecret is a convenience way to
-                      build a value for `idp_service_account` from secret map values,
-                      see https://www.pomerium.com/docs/identity-providers/
-                    type: string
-                  url:
-                    description: URL is identity provider url, see https://www.pomerium.com/reference/#identity-provider-url
-                    format: uri
-                    pattern: ^https://
-                    type: string
-                required:
-                - provider
-                - secret
-                type: object
-              secrets:
-                description: Secrets references a Secret that must have the following
-                  keys - shared_secret - cookie_secret - signing_key
-                minLength: 1
-                type: string
-              storage:
-                description: Storage defines persistent storage for sessions and other
-                  data it will use in-memory if none specified see https://www.pomerium.com/docs/topics/data-storage
-                properties:
-                  postgres:
-                    description: Postgres specifies PostgreSQL database connection
-                      parameters
-                    properties:
-                      caSecret:
-                        description: CASecret should refer to a k8s secret with key
-                          `ca.crt` containing CA certificate that, if specified, would
-                          be used to populate `sslrootcert` parameter of the connection
-                          string
-                        minLength: 1
+                  type: array
+                identityProvider:
+                  description: IdentityProvider see https://www.pomerium.com/docs/identity-providers/
+                  properties:
+                    provider:
+                      description: Provider one of accepted providers https://www.pomerium.com/reference/#identity-provider-name
+                      enum:
+                        - auth0
+                        - azure
+                        - google
+                        - okta
+                        - onelogin
+                        - oidc
+                        - ping
+                        - github
+                      type: string
+                    refreshDirectory:
+                      description: Specifies refresh settings
+                      properties:
+                        interval:
+                          format: duration
+                          type: string
+                        timeout:
+                          format: duration
+                          type: string
+                      required:
+                        - interval
+                        - timeout
+                      type: object
+                    requestParams:
+                      additionalProperties:
                         type: string
-                      secret:
-                        description: Secret specifies a name of a Secret that must
-                          contain `connection` key for the connection DSN format and
-                          parameters, see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-                          the following keywords are not allowed to be part of the
-                          parameters, as they must be populated via `tlsCecret` and
-                          `caSecret` fields
-                        minLength: 1
+                      description: RequestParams see https://www.pomerium.com/reference/#identity-provider-request-params
+                      type: object
+                    requestParamsSecret:
+                      description:
+                        RequestParamsSecret is a reference to a secret for
+                        additional parameters you'd prefer not to provide in plaintext
+                      type: string
+                    scopes:
+                      description: Scopes see https://www.pomerium.com/reference/#identity-provider-scopes
+                      items:
                         type: string
-                      tlsSecret:
-                        description: TLSSecret should refer to a k8s secret of type
-                          `kubernetes.io/tls` and allows to specify an optional client
-                          certificate and key, by constructing `sslcert` and `sslkey`
-                          connection string parameter values see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
-                        minLength: 1
-                        type: string
-                    required:
+                      type: array
+                    secret:
+                      description:
+                        Secret refers to a k8s secret containing IdP provider
+                        specific parameters and must contain at least `client_id` and
+                        `client_secret` map values, an optional `service_account` field,
+                        mapped to https://www.pomerium.com/reference/#identity-provider-service-account
+                      minLength: 1
+                      type: string
+                    serviceAccountFromSecret:
+                      description:
+                        ServiceAccountFromSecret is a convenience way to
+                        build a value for `idp_service_account` from secret map values,
+                        see https://www.pomerium.com/docs/identity-providers/
+                      type: string
+                    url:
+                      description: URL is identity provider url, see https://www.pomerium.com/reference/#identity-provider-url
+                      format: uri
+                      pattern: ^https://
+                      type: string
+                  required:
+                    - provider
                     - secret
-                    type: object
-                  redis:
-                    description: Redis defines REDIS connection parameters
+                  type: object
+                secrets:
+                  description:
+                    Secrets references a Secret that must have the following
+                    keys - shared_secret - cookie_secret - signing_key
+                  minLength: 1
+                  type: string
+                storage:
+                  description:
+                    Storage defines persistent storage for sessions and other
+                    data it will use in-memory if none specified see https://www.pomerium.com/docs/topics/data-storage
+                  properties:
+                    postgres:
+                      description:
+                        Postgres specifies PostgreSQL database connection
+                        parameters
+                      properties:
+                        caSecret:
+                          description:
+                            CASecret should refer to a k8s secret with key
+                            `ca.crt` containing CA certificate that, if specified, would
+                            be used to populate `sslrootcert` parameter of the connection
+                            string
+                          minLength: 1
+                          type: string
+                        secret:
+                          description:
+                            Secret specifies a name of a Secret that must
+                            contain `connection` key for the connection DSN format and
+                            parameters, see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+                            the following keywords are not allowed to be part of the
+                            parameters, as they must be populated via `tlsCecret` and
+                            `caSecret` fields
+                          minLength: 1
+                          type: string
+                        tlsSecret:
+                          description:
+                            TLSSecret should refer to a k8s secret of type
+                            `kubernetes.io/tls` and allows to specify an optional client
+                            certificate and key, by constructing `sslcert` and `sslkey`
+                            connection string parameter values see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
+                          minLength: 1
+                          type: string
+                      required:
+                        - secret
+                      type: object
+                    redis:
+                      description: Redis defines REDIS connection parameters
+                      properties:
+                        caSecret:
+                          description:
+                            CASecret should refer to a k8s secret with key
+                            `ca.crt` that must be a PEM-encoded certificate authority
+                            to use when connecting to the databroker storage engine
+                            see https://www.pomerium.com/docs/reference/data-broker-storage-certificate-authority
+                          type: string
+                        secret:
+                          description:
+                            Secret specifies a name of a Secret that must
+                            contain `connection` key. see https://www.pomerium.com/docs/reference/data-broker-storage-connection-string
+                          minLength: 1
+                          type: string
+                        tlsSecret:
+                          description:
+                            TLSSecret should refer to a k8s secret of type
+                            `kubernetes.io/tls` and allows to specify an optional databroker
+                            storage client certificate and key, see - https://www.pomerium.com/docs/reference/data-broker-storage-certificate-file
+                            - https://www.pomerium.com/docs/reference/data-broker-storage-certificate-key-file
+                          minLength: 1
+                          type: string
+                        tlsSkipVerify:
+                          description:
+                            TLSSkipVerify disables TLS certificate chain
+                            validation see https://www.pomerium.com/docs/reference/data-broker-storage-tls-skip-verify
+                          type: boolean
+                      required:
+                        - secret
+                      type: object
+                  type: object
+              required:
+                - authenticate
+                - identityProvider
+                - secrets
+              type: object
+            status:
+              description: PomeriumStatus defines the observed state of Settings
+              properties:
+                ingress:
+                  additionalProperties:
+                    description:
+                      ResourceStatus represents the outcome of the latest
+                      attempt to reconcile it with Pomerium.
                     properties:
-                      caSecret:
-                        description: CASecret should refer to a k8s secret with key
-                          `ca.crt` that must be a PEM-encoded certificate authority
-                          to use when connecting to the databroker storage engine
-                          see https://www.pomerium.com/docs/reference/data-broker-storage-certificate-authority
+                      error:
+                        description:
+                          Error that prevented latest observedGeneration
+                          to be synchronized with Pomerium.
                         type: string
-                      secret:
-                        description: Secret specifies a name of a Secret that must
-                          contain `connection` key. see https://www.pomerium.com/docs/reference/data-broker-storage-connection-string
-                        minLength: 1
+                      observedAt:
+                        description:
+                          ObservedAt is when last reconciliation attempt
+                          was made.
+                        format: date-time
                         type: string
-                      tlsSecret:
-                        description: TLSSecret should refer to a k8s secret of type
-                          `kubernetes.io/tls` and allows to specify an optional databroker
-                          storage client certificate and key, see - https://www.pomerium.com/docs/reference/data-broker-storage-certificate-file
-                          - https://www.pomerium.com/docs/reference/data-broker-storage-certificate-key-file
-                        minLength: 1
-                        type: string
-                      tlsSkipVerify:
-                        description: TLSSkipVerify disables TLS certificate chain
-                          validation see https://www.pomerium.com/docs/reference/data-broker-storage-tls-skip-verify
+                      observedGeneration:
+                        description:
+                          ObservedGeneration represents the .metadata.generation
+                          that was last presented to Pomerium.
+                        format: int64
+                        type: integer
+                      reconciled:
+                        description:
+                          Reconciled is whether this object generation was
+                          successfully synced with pomerium.
                         type: boolean
                     required:
-                    - secret
+                      - reconciled
                     type: object
-                type: object
-            required:
-            - authenticate
-            - identityProvider
-            - secrets
-            type: object
-          status:
-            description: PomeriumStatus defines the observed state of Settings
-            properties:
-              ingress:
-                additionalProperties:
-                  description: ResourceStatus represents the outcome of the latest
-                    attempt to reconcile it with Pomerium.
+                  description: Routes provide per-Ingress status.
+                  type: object
+                settingsStatus:
+                  description:
+                    settingsStatus represent most recent main configuration
+                    reconciliation status.
                   properties:
                     error:
-                      description: Error that prevented latest observedGeneration
-                        to be synchronized with Pomerium.
+                      description:
+                        Error that prevented latest observedGeneration to
+                        be synchronized with Pomerium.
                       type: string
                     observedAt:
-                      description: ObservedAt is when last reconciliation attempt
-                        was made.
+                      description:
+                        ObservedAt is when last reconciliation attempt was
+                        made.
                       format: date-time
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the .metadata.generation
+                      description:
+                        ObservedGeneration represents the .metadata.generation
                         that was last presented to Pomerium.
                       format: int64
                       type: integer
                     reconciled:
-                      description: Reconciled is whether this object generation was
+                      description:
+                        Reconciled is whether this object generation was
                         successfully synced with pomerium.
                       type: boolean
                   required:
-                  - reconciled
+                    - reconciled
                   type: object
-                description: Routes provide per-Ingress status.
-                type: object
-              settingsStatus:
-                description: settingsStatus represent most recent main configuration
-                  reconciliation status.
-                properties:
-                  error:
-                    description: Error that prevented latest observedGeneration to
-                      be synchronized with Pomerium.
-                    type: string
-                  observedAt:
-                    description: ObservedAt is when last reconciliation attempt was
-                      made.
-                    format: date-time
-                    type: string
-                  observedGeneration:
-                    description: ObservedGeneration represents the .metadata.generation
-                      that was last presented to Pomerium.
-                    format: int64
-                    type: integer
-                  reconciled:
-                    description: Reconciled is whether this object generation was
-                      successfully synced with pomerium.
-                    type: boolean
-                required:
-                - reconciled
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -286,64 +313,73 @@ metadata:
     app.kubernetes.io/name: pomerium
   name: pomerium-controller
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - endpoints
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - services/status
-  - secrets/status
-  - endpoints/status
-  verbs:
-  - get
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses
-  - ingressclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ingress.pomerium.io
-  resources:
-  - pomerium
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ingress.pomerium.io
-  resources:
-  - pomerium/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+      - secrets/status
+      - endpoints/status
+    verbs:
+      - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ingress.pomerium.io
+    resources:
+      - pomerium
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ingress.pomerium.io
+    resources:
+      - pomerium/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -352,12 +388,12 @@ metadata:
     app.kubernetes.io/name: pomerium
   name: pomerium-gen-secrets
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -370,9 +406,9 @@ roleRef:
   kind: ClusterRole
   name: pomerium-controller
 subjects:
-- kind: ServiceAccount
-  name: pomerium-controller
-  namespace: pomerium
+  - kind: ServiceAccount
+    name: pomerium-controller
+    namespace: pomerium
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -385,9 +421,9 @@ roleRef:
   kind: ClusterRole
   name: pomerium-gen-secrets
 subjects:
-- kind: ServiceAccount
-  name: pomerium-gen-secrets
-  namespace: pomerium
+  - kind: ServiceAccount
+    name: pomerium-gen-secrets
+    namespace: pomerium
 ---
 apiVersion: v1
 kind: Service
@@ -398,10 +434,10 @@ metadata:
   namespace: pomerium
 spec:
   ports:
-  - name: metrics
-    port: 9090
-    protocol: TCP
-    targetPort: metrics
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: metrics
   selector:
     app.kubernetes.io/name: pomerium
   type: ClusterIP
@@ -415,14 +451,14 @@ metadata:
   namespace: pomerium
 spec:
   ports:
-  - name: https
-    port: 443
-    protocol: TCP
-    targetPort: https
-  - name: http
-    port: 80
-    protocol: TCP
-    targetPort: http
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
   selector:
     app.kubernetes.io/name: pomerium
   type: LoadBalancer
@@ -445,54 +481,54 @@ spec:
         app.kubernetes.io/name: pomerium
     spec:
       containers:
-      - args:
-        - all-in-one
-        - --pomerium-config=global
-        - --update-status-from-service=$(POMERIUM_NAMESPACE)/pomerium-proxy
-        - --metrics-bind-address=$(POD_IP):9090
-        env:
-        - name: TMPDIR
-          value: /tmp
-        - name: XDG_CACHE_HOME
-          value: /tmp
-        - name: POMERIUM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: pomerium/ingress-controller:sha-c34791e
-        imagePullPolicy: IfNotPresent
-        name: pomerium
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        - containerPort: 8080
-          name: http
-          protocol: TCP
-        - containerPort: 9090
-          name: metrics
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 5000m
-            memory: 1Gi
-          requests:
-            cpu: 300m
-            memory: 200Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsGroup: 1000
-          runAsNonRoot: true
-          runAsUser: 1000
-        volumeMounts:
-        - mountPath: /tmp
-          name: tmp
+        - args:
+            - all-in-one
+            - --pomerium-config=global
+            - --update-status-from-service=$(POMERIUM_NAMESPACE)/pomerium-proxy
+            - --metrics-bind-address=$(POD_IP):9090
+          env:
+            - name: TMPDIR
+              value: /tmp
+            - name: XDG_CACHE_HOME
+              value: /tmp
+            - name: POMERIUM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          image: pomerium/ingress-controller:sha-c34791e
+          imagePullPolicy: IfNotPresent
+          name: pomerium
+          ports:
+            - containerPort: 8443
+              name: https
+              protocol: TCP
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+            - containerPort: 9090
+              name: metrics
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 5000m
+              memory: 1Gi
+            requests:
+              cpu: 300m
+              memory: 200Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:
@@ -500,8 +536,8 @@ spec:
       serviceAccountName: pomerium-controller
       terminationGracePeriodSeconds: 10
       volumes:
-      - emptyDir: {}
-        name: tmp
+        - emptyDir: {}
+          name: tmp
 ---
 apiVersion: batch/v1
 kind: Job
@@ -518,19 +554,19 @@ spec:
       name: pomerium-gen-secrets
     spec:
       containers:
-      - args:
-        - gen-secrets
-        - --secrets=$(POD_NAMESPACE)/bootstrap
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        image: pomerium/ingress-controller:main
-        imagePullPolicy: IfNotPresent
-        name: gen-secrets
-        securityContext:
-          allowPrivilegeEscalation: false
+        - args:
+            - gen-secrets
+            - --secrets=$(POD_NAMESPACE)/bootstrap
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          image: pomerium/ingress-controller:main
+          imagePullPolicy: IfNotPresent
+          name: gen-secrets
+          securityContext:
+            allowPrivilegeEscalation: false
       nodeSelector:
         kubernetes.io/os: linux
       restartPolicy: OnFailure

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -23,272 +23,245 @@ spec:
     singular: pomerium
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description:
-            Pomerium define runtime-configurable Pomerium settings that do
-            not fall into the category of deployment parameters
-          properties:
-            apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
-              type: string
-            kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: PomeriumSpec defines the desired state of Settings
-              properties:
-                authenticate:
-                  description: Authenticate sets authenticate service parameters
-                  properties:
-                    callbackPath:
-                      description: CallbackPath see https://www.pomerium.com/reference/#authenticate-callback-path
-                      type: string
-                    url:
-                      description:
-                        AuthenticateURL should be publicly accessible URL
-                        the non-authenticated persons would be referred to see https://www.pomerium.com/reference/#authenticate-service-url
-                      format: uri
-                      pattern: ^https://
-                      type: string
-                  required:
-                    - url
-                  type: object
-                certificates:
-                  description: Certificates is a list of secrets of type TLS to use
-                  items:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Pomerium define runtime-configurable Pomerium settings that do
+          not fall into the category of deployment parameters
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PomeriumSpec defines the desired state of Settings
+            properties:
+              authenticate:
+                description: Authenticate sets authenticate service parameters
+                properties:
+                  callbackPath:
+                    description: CallbackPath see https://www.pomerium.com/reference/#authenticate-callback-path
                     type: string
-                  type: array
-                identityProvider:
-                  description: IdentityProvider see https://www.pomerium.com/docs/identity-providers/
-                  properties:
-                    provider:
-                      description: Provider one of accepted providers https://www.pomerium.com/reference/#identity-provider-name
-                      enum:
-                        - auth0
-                        - azure
-                        - google
-                        - okta
-                        - onelogin
-                        - oidc
-                        - ping
-                        - github
-                      type: string
-                    refreshDirectory:
-                      description: Specifies refresh settings
-                      properties:
-                        interval:
-                          format: duration
-                          type: string
-                        timeout:
-                          format: duration
-                          type: string
-                      required:
-                        - interval
-                        - timeout
-                      type: object
-                    requestParams:
-                      additionalProperties:
-                        type: string
-                      description: RequestParams see https://www.pomerium.com/reference/#identity-provider-request-params
-                      type: object
-                    requestParamsSecret:
-                      description:
-                        RequestParamsSecret is a reference to a secret for
-                        additional parameters you'd prefer not to provide in plaintext
-                      type: string
-                    scopes:
-                      description: Scopes see https://www.pomerium.com/reference/#identity-provider-scopes
-                      items:
-                        type: string
-                      type: array
-                    secret:
-                      description:
-                        Secret refers to a k8s secret containing IdP provider
-                        specific parameters and must contain at least `client_id` and
-                        `client_secret` map values, an optional `service_account` field,
-                        mapped to https://www.pomerium.com/reference/#identity-provider-service-account
-                      minLength: 1
-                      type: string
-                    serviceAccountFromSecret:
-                      description:
-                        ServiceAccountFromSecret is a convenience way to
-                        build a value for `idp_service_account` from secret map values,
-                        see https://www.pomerium.com/docs/identity-providers/
-                      type: string
-                    url:
-                      description: URL is identity provider url, see https://www.pomerium.com/reference/#identity-provider-url
-                      format: uri
-                      pattern: ^https://
-                      type: string
-                  required:
-                    - provider
-                    - secret
-                  type: object
-                secrets:
-                  description:
-                    Secrets references a Secret that must have the following
-                    keys - shared_secret - cookie_secret - signing_key
-                  minLength: 1
+                  url:
+                    description: AuthenticateURL should be publicly accessible URL
+                      the non-authenticated persons would be referred to see https://www.pomerium.com/reference/#authenticate-service-url
+                    format: uri
+                    pattern: ^https://
+                    type: string
+                required:
+                - url
+                type: object
+              certificates:
+                description: Certificates is a list of secrets of type TLS to use
+                items:
                   type: string
-                storage:
-                  description:
-                    Storage defines persistent storage for sessions and other
-                    data it will use in-memory if none specified see https://www.pomerium.com/docs/topics/data-storage
-                  properties:
-                    postgres:
-                      description:
-                        Postgres specifies PostgreSQL database connection
-                        parameters
-                      properties:
-                        caSecret:
-                          description:
-                            CASecret should refer to a k8s secret with key
-                            `ca.crt` containing CA certificate that, if specified, would
-                            be used to populate `sslrootcert` parameter of the connection
-                            string
-                          minLength: 1
-                          type: string
-                        secret:
-                          description:
-                            Secret specifies a name of a Secret that must
-                            contain `connection` key for the connection DSN format and
-                            parameters, see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-                            the following keywords are not allowed to be part of the
-                            parameters, as they must be populated via `tlsCecret` and
-                            `caSecret` fields
-                          minLength: 1
-                          type: string
-                        tlsSecret:
-                          description:
-                            TLSSecret should refer to a k8s secret of type
-                            `kubernetes.io/tls` and allows to specify an optional client
-                            certificate and key, by constructing `sslcert` and `sslkey`
-                            connection string parameter values see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
-                          minLength: 1
-                          type: string
-                      required:
-                        - secret
-                      type: object
-                    redis:
-                      description: Redis defines REDIS connection parameters
-                      properties:
-                        caSecret:
-                          description:
-                            CASecret should refer to a k8s secret with key
-                            `ca.crt` that must be a PEM-encoded certificate authority
-                            to use when connecting to the databroker storage engine
-                            see https://www.pomerium.com/docs/reference/data-broker-storage-certificate-authority
-                          type: string
-                        secret:
-                          description:
-                            Secret specifies a name of a Secret that must
-                            contain `connection` key. see https://www.pomerium.com/docs/reference/data-broker-storage-connection-string
-                          minLength: 1
-                          type: string
-                        tlsSecret:
-                          description:
-                            TLSSecret should refer to a k8s secret of type
-                            `kubernetes.io/tls` and allows to specify an optional databroker
-                            storage client certificate and key, see - https://www.pomerium.com/docs/reference/data-broker-storage-certificate-file
-                            - https://www.pomerium.com/docs/reference/data-broker-storage-certificate-key-file
-                          minLength: 1
-                          type: string
-                        tlsSkipVerify:
-                          description:
-                            TLSSkipVerify disables TLS certificate chain
-                            validation see https://www.pomerium.com/docs/reference/data-broker-storage-tls-skip-verify
-                          type: boolean
-                      required:
-                        - secret
-                      type: object
-                  type: object
-              required:
-                - authenticate
-                - identityProvider
-                - secrets
-              type: object
-            status:
-              description: PomeriumStatus defines the observed state of Settings
-              properties:
-                ingress:
-                  additionalProperties:
-                    description:
-                      ResourceStatus represents the outcome of the latest
-                      attempt to reconcile it with Pomerium.
+                type: array
+              identityProvider:
+                description: IdentityProvider see https://www.pomerium.com/docs/identity-providers/
+                properties:
+                  provider:
+                    description: Provider one of accepted providers https://www.pomerium.com/reference/#identity-provider-name
+                    enum:
+                    - auth0
+                    - azure
+                    - google
+                    - okta
+                    - onelogin
+                    - oidc
+                    - ping
+                    - github
+                    type: string
+                  refreshDirectory:
+                    description: Specifies refresh settings
                     properties:
-                      error:
-                        description:
-                          Error that prevented latest observedGeneration
-                          to be synchronized with Pomerium.
+                      interval:
+                        format: duration
                         type: string
-                      observedAt:
-                        description:
-                          ObservedAt is when last reconciliation attempt
-                          was made.
-                        format: date-time
+                      timeout:
+                        format: duration
                         type: string
-                      observedGeneration:
-                        description:
-                          ObservedGeneration represents the .metadata.generation
-                          that was last presented to Pomerium.
-                        format: int64
-                        type: integer
-                      reconciled:
-                        description:
-                          Reconciled is whether this object generation was
-                          successfully synced with pomerium.
+                    required:
+                    - interval
+                    - timeout
+                    type: object
+                  requestParams:
+                    additionalProperties:
+                      type: string
+                    description: RequestParams see https://www.pomerium.com/reference/#identity-provider-request-params
+                    type: object
+                  requestParamsSecret:
+                    description: RequestParamsSecret is a reference to a secret for
+                      additional parameters you'd prefer not to provide in plaintext
+                    type: string
+                  scopes:
+                    description: Scopes see https://www.pomerium.com/reference/#identity-provider-scopes
+                    items:
+                      type: string
+                    type: array
+                  secret:
+                    description: Secret refers to a k8s secret containing IdP provider
+                      specific parameters and must contain at least `client_id` and
+                      `client_secret` map values, an optional `service_account` field,
+                      mapped to https://www.pomerium.com/reference/#identity-provider-service-account
+                    minLength: 1
+                    type: string
+                  serviceAccountFromSecret:
+                    description: ServiceAccountFromSecret is a convenience way to
+                      build a value for `idp_service_account` from secret map values,
+                      see https://www.pomerium.com/docs/identity-providers/
+                    type: string
+                  url:
+                    description: URL is identity provider url, see https://www.pomerium.com/reference/#identity-provider-url
+                    format: uri
+                    pattern: ^https://
+                    type: string
+                required:
+                - provider
+                - secret
+                type: object
+              secrets:
+                description: Secrets references a Secret that must have the following
+                  keys - shared_secret - cookie_secret - signing_key
+                minLength: 1
+                type: string
+              storage:
+                description: Storage defines persistent storage for sessions and other
+                  data it will use in-memory if none specified see https://www.pomerium.com/docs/topics/data-storage
+                properties:
+                  postgres:
+                    description: Postgres specifies PostgreSQL database connection
+                      parameters
+                    properties:
+                      caSecret:
+                        description: CASecret should refer to a k8s secret with key
+                          `ca.crt` containing CA certificate that, if specified, would
+                          be used to populate `sslrootcert` parameter of the connection
+                          string
+                        minLength: 1
+                        type: string
+                      secret:
+                        description: Secret specifies a name of a Secret that must
+                          contain `connection` key for the connection DSN format and
+                          parameters, see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+                          the following keywords are not allowed to be part of the
+                          parameters, as they must be populated via `tlsCecret` and
+                          `caSecret` fields
+                        minLength: 1
+                        type: string
+                      tlsSecret:
+                        description: TLSSecret should refer to a k8s secret of type
+                          `kubernetes.io/tls` and allows to specify an optional client
+                          certificate and key, by constructing `sslcert` and `sslkey`
+                          connection string parameter values see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
+                        minLength: 1
+                        type: string
+                    required:
+                    - secret
+                    type: object
+                  redis:
+                    description: Redis defines REDIS connection parameters
+                    properties:
+                      caSecret:
+                        description: CASecret should refer to a k8s secret with key
+                          `ca.crt` that must be a PEM-encoded certificate authority
+                          to use when connecting to the databroker storage engine
+                          see https://www.pomerium.com/docs/reference/data-broker-storage-certificate-authority
+                        type: string
+                      secret:
+                        description: Secret specifies a name of a Secret that must
+                          contain `connection` key. see https://www.pomerium.com/docs/reference/data-broker-storage-connection-string
+                        minLength: 1
+                        type: string
+                      tlsSecret:
+                        description: TLSSecret should refer to a k8s secret of type
+                          `kubernetes.io/tls` and allows to specify an optional databroker
+                          storage client certificate and key, see - https://www.pomerium.com/docs/reference/data-broker-storage-certificate-file
+                          - https://www.pomerium.com/docs/reference/data-broker-storage-certificate-key-file
+                        minLength: 1
+                        type: string
+                      tlsSkipVerify:
+                        description: TLSSkipVerify disables TLS certificate chain
+                          validation see https://www.pomerium.com/docs/reference/data-broker-storage-tls-skip-verify
                         type: boolean
                     required:
-                      - reconciled
+                    - secret
                     type: object
-                  description: Routes provide per-Ingress status.
-                  type: object
-                settingsStatus:
-                  description:
-                    settingsStatus represent most recent main configuration
-                    reconciliation status.
+                type: object
+            required:
+            - authenticate
+            - identityProvider
+            - secrets
+            type: object
+          status:
+            description: PomeriumStatus defines the observed state of Settings
+            properties:
+              ingress:
+                additionalProperties:
+                  description: ResourceStatus represents the outcome of the latest
+                    attempt to reconcile it with Pomerium.
                   properties:
                     error:
-                      description:
-                        Error that prevented latest observedGeneration to
-                        be synchronized with Pomerium.
+                      description: Error that prevented latest observedGeneration
+                        to be synchronized with Pomerium.
                       type: string
                     observedAt:
-                      description:
-                        ObservedAt is when last reconciliation attempt was
-                        made.
+                      description: ObservedAt is when last reconciliation attempt
+                        was made.
                       format: date-time
                       type: string
                     observedGeneration:
-                      description:
-                        ObservedGeneration represents the .metadata.generation
+                      description: ObservedGeneration represents the .metadata.generation
                         that was last presented to Pomerium.
                       format: int64
                       type: integer
                     reconciled:
-                      description:
-                        Reconciled is whether this object generation was
+                      description: Reconciled is whether this object generation was
                         successfully synced with pomerium.
                       type: boolean
                   required:
-                    - reconciled
+                  - reconciled
                   type: object
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                description: Routes provide per-Ingress status.
+                type: object
+              settingsStatus:
+                description: settingsStatus represent most recent main configuration
+                  reconciliation status.
+                properties:
+                  error:
+                    description: Error that prevented latest observedGeneration to
+                      be synchronized with Pomerium.
+                    type: string
+                  observedAt:
+                    description: ObservedAt is when last reconciliation attempt was
+                      made.
+                    format: date-time
+                    type: string
+                  observedGeneration:
+                    description: ObservedGeneration represents the .metadata.generation
+                      that was last presented to Pomerium.
+                    format: int64
+                    type: integer
+                  reconciled:
+                    description: Reconciled is whether this object generation was
+                      successfully synced with pomerium.
+                    type: boolean
+                required:
+                - reconciled
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -313,73 +286,73 @@ metadata:
     app.kubernetes.io/name: pomerium
   name: pomerium-controller
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - services
-      - endpoints
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - services/status
-      - secrets/status
-      - endpoints/status
-    verbs:
-      - get
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-      - ingressclasses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - ingress.pomerium.io
-    resources:
-      - pomerium
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ingress.pomerium.io
-    resources:
-      - pomerium/status
-    verbs:
-      - get
-      - update
-      - patch
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - create
-      - patch
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - create
-      - get
-      - patch
-      - update
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  - secrets/status
+  - endpoints/status
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ingress.pomerium.io
+  resources:
+  - pomerium
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ingress.pomerium.io
+  resources:
+  - pomerium/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -388,12 +361,12 @@ metadata:
     app.kubernetes.io/name: pomerium
   name: pomerium-gen-secrets
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -406,9 +379,9 @@ roleRef:
   kind: ClusterRole
   name: pomerium-controller
 subjects:
-  - kind: ServiceAccount
-    name: pomerium-controller
-    namespace: pomerium
+- kind: ServiceAccount
+  name: pomerium-controller
+  namespace: pomerium
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -421,9 +394,9 @@ roleRef:
   kind: ClusterRole
   name: pomerium-gen-secrets
 subjects:
-  - kind: ServiceAccount
-    name: pomerium-gen-secrets
-    namespace: pomerium
+- kind: ServiceAccount
+  name: pomerium-gen-secrets
+  namespace: pomerium
 ---
 apiVersion: v1
 kind: Service
@@ -434,10 +407,10 @@ metadata:
   namespace: pomerium
 spec:
   ports:
-    - name: metrics
-      port: 9090
-      protocol: TCP
-      targetPort: metrics
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: metrics
   selector:
     app.kubernetes.io/name: pomerium
   type: ClusterIP
@@ -451,14 +424,14 @@ metadata:
   namespace: pomerium
 spec:
   ports:
-    - name: https
-      port: 443
-      protocol: TCP
-      targetPort: https
-    - name: http
-      port: 80
-      protocol: TCP
-      targetPort: http
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
   selector:
     app.kubernetes.io/name: pomerium
   type: LoadBalancer
@@ -481,54 +454,54 @@ spec:
         app.kubernetes.io/name: pomerium
     spec:
       containers:
-        - args:
-            - all-in-one
-            - --pomerium-config=global
-            - --update-status-from-service=$(POMERIUM_NAMESPACE)/pomerium-proxy
-            - --metrics-bind-address=$(POD_IP):9090
-          env:
-            - name: TMPDIR
-              value: /tmp
-            - name: XDG_CACHE_HOME
-              value: /tmp
-            - name: POMERIUM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-          image: pomerium/ingress-controller:sha-c34791e
-          imagePullPolicy: IfNotPresent
-          name: pomerium
-          ports:
-            - containerPort: 8443
-              name: https
-              protocol: TCP
-            - containerPort: 8080
-              name: http
-              protocol: TCP
-            - containerPort: 9090
-              name: metrics
-              protocol: TCP
-          resources:
-            limits:
-              cpu: 5000m
-              memory: 1Gi
-            requests:
-              cpu: 300m
-              memory: 200Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsGroup: 1000
-            runAsNonRoot: true
-            runAsUser: 1000
-          volumeMounts:
-            - mountPath: /tmp
-              name: tmp
+      - args:
+        - all-in-one
+        - --pomerium-config=global
+        - --update-status-from-service=$(POMERIUM_NAMESPACE)/pomerium-proxy
+        - --metrics-bind-address=$(POD_IP):9090
+        env:
+        - name: TMPDIR
+          value: /tmp
+        - name: XDG_CACHE_HOME
+          value: /tmp
+        - name: POMERIUM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: pomerium/ingress-controller:sha-c34791e
+        imagePullPolicy: IfNotPresent
+        name: pomerium
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        - containerPort: 9090
+          name: metrics
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 5000m
+            memory: 1Gi
+          requests:
+            cpu: 300m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:
@@ -536,8 +509,8 @@ spec:
       serviceAccountName: pomerium-controller
       terminationGracePeriodSeconds: 10
       volumes:
-        - emptyDir: {}
-          name: tmp
+      - emptyDir: {}
+        name: tmp
 ---
 apiVersion: batch/v1
 kind: Job
@@ -554,19 +527,19 @@ spec:
       name: pomerium-gen-secrets
     spec:
       containers:
-        - args:
-            - gen-secrets
-            - --secrets=$(POD_NAMESPACE)/bootstrap
-          env:
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-          image: pomerium/ingress-controller:main
-          imagePullPolicy: IfNotPresent
-          name: gen-secrets
-          securityContext:
-            allowPrivilegeEscalation: false
+      - args:
+        - gen-secrets
+        - --secrets=$(POD_NAMESPACE)/bootstrap
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: pomerium/ingress-controller:main
+        imagePullPolicy: IfNotPresent
+        name: gen-secrets
+        securityContext:
+          allowPrivilegeEscalation: false
       nodeSelector:
         kubernetes.io/os: linux
       restartPolicy: OnFailure


### PR DESCRIPTION
## Summary
Enable Kubernetes leadership election in all-in-one mode so only a single ingress controller will run at a time.

## Related issues
Fixes https://github.com/pomerium/internal/issues/890


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
