### PR TITLE
fix updating /status/loadBalancer for non-owned Ingress objects

### DIFF
--- a/controllers/ingress/reconcile.go
+++ b/controllers/ingress/reconcile.go
@@ -51,8 +51,8 @@ func (r *ingressController) reconcileInitial(ctx context.Context) (err error) {
 	}
 
 	_, err = r.IngressReconciler.Set(ctx, ics)
-	for i := range ingressList.Items {
-		ingress := &ingressList.Items[i]
+	for i := range ics {
+		ingress := ics[i].Ingress
 		if err != nil {
 			r.IngressNotReconciled(ctx, ingress, err)
 		} else if err := r.updateIngressStatus(ctx, ingress); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/open-policy-agent/opa v0.43.0
+	github.com/pomerium/csrf v1.7.0
 	github.com/pomerium/pomerium v0.18.0
 	github.com/sergi/go-diff v1.2.0
 	github.com/spf13/cobra v1.5.0
@@ -224,7 +225,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polyfloyd/go-errorlint v1.0.0 // indirect
-	github.com/pomerium/csrf v1.7.0 // indirect
 	github.com/pomerium/webauthn v0.0.0-20211014213840-422c7ce1077f // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect


### PR DESCRIPTION
## Summary

During initial sync we iterated over non-filtered list of Ingress objects when updating the status field.

## Related issues

Fixes #347

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
