### PR TITLE
pomerium/ctrl: use a file manager for certificates to delete orphaned files

### DIFF
--- a/internal/filemgr/filemgr.go
+++ b/internal/filemgr/filemgr.go
@@ -1,0 +1,72 @@
+// Package filemgr contains a manager for files based on byte slices.
+package filemgr
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/martinlindhe/base36"
+
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+)
+
+// A Manager manages temporary files created from data.
+type Manager struct {
+	cacheDir string
+}
+
+// New creates a new Manager.
+func New(cacheDir string) *Manager {
+	return &Manager{
+		cacheDir: cacheDir,
+	}
+}
+
+// CreateFile creates a new file based on the passed in data.
+func (mgr *Manager) CreateFile(fileName string, data []byte) (filePath string, err error) {
+	h := base36.EncodeBytes(cryptutil.Hash("filemgr", data))
+	ext := filepath.Ext(fileName)
+	fileName = fmt.Sprintf("%s-%x%s", fileName[:len(fileName)-len(ext)], h, ext)
+	filePath = filepath.Join(mgr.cacheDir, fileName)
+
+	if err := os.MkdirAll(mgr.cacheDir, 0o700); err != nil {
+		return filePath, fmt.Errorf("filemgr: error creating cache directory: %w", err)
+	}
+
+	_, err = os.Stat(filePath)
+	if err == nil {
+		return filePath, nil
+	}
+
+	err = os.WriteFile(filePath, data, 0o600)
+	if err != nil {
+		_ = os.Remove(filePath)
+		return filePath, fmt.Errorf("filemgr: error writing file: %w", err)
+	}
+
+	err = os.Chmod(filePath, 0o400)
+	if err != nil {
+		_ = os.Remove(filePath)
+		return filePath, fmt.Errorf("filemgr: error chmoding file: %w", err)
+	}
+
+	return filePath, nil
+}
+
+// DeleteFiles deletes all the files managed by the file manager.
+func (mgr *Manager) DeleteFiles() error {
+	if _, err := os.Stat(mgr.cacheDir); os.IsNotExist(err) {
+		return nil
+	}
+
+	return filepath.Walk(mgr.cacheDir, func(p string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !fi.IsDir() {
+			return os.Remove(p)
+		}
+		return nil
+	})
+}

--- a/internal/filemgr/filemgr_test.go
+++ b/internal/filemgr/filemgr_test.go
@@ -1,0 +1,40 @@
+package filemgr
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManager(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), uuid.New().String())
+	defer os.RemoveAll(dir)
+
+	mgr := New(dir)
+	fp1, err := mgr.CreateFile("hello.txt", []byte("HELLO WORLD"))
+	assert.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "hello-32474a4f41355432494e594e58334e4b4b4453483555314e4842584544424139375148533858303543434f4e56524b43374a.txt"), fp1)
+
+	fp2, err := mgr.CreateFile("empty", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "empty-314a323947555a5055304f45304944514c4f5242384244493339453533505551393131494e484f545353425a443759435453"), fp2)
+
+	assert.Equal(t, 2, countFiles(dir))
+	assert.NoError(t, mgr.DeleteFiles())
+	assert.Equal(t, 0, countFiles(dir))
+}
+
+func countFiles(dir string) int {
+	fileCount := 0
+	filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
+		if !info.IsDir() {
+			fileCount++
+		}
+		return nil
+	})
+	return fileCount
+}

--- a/pomerium/ctrl/bootstrap.go
+++ b/pomerium/ctrl/bootstrap.go
@@ -74,7 +74,6 @@ func applyStorageRedis(dst *config.Options, src *model.Config) error {
 	dst.DataBrokerStorageConnectionString = string(conn)
 	dst.DataBrokerStorageCertSkipVerify = src.Spec.Storage.Redis.TLSSkipVerify
 
-	const prefix = "databroker-redis"
 	if src.StorageSecrets.CA != nil {
 		ca, err := storageFiles.CreateFile("ca.pem", src.StorageSecrets.Secret.Data[model.CAKey])
 		if err != nil {
@@ -103,7 +102,6 @@ func applyStoragePostgres(dst *config.Options, src *model.Config) error {
 		sslRootCert = "sslrootcert"
 		sslCert     = "sslcert"
 		sslKey      = "sslkey"
-		prefix      = "databroker-psql"
 	)
 	conn, ok := src.StorageSecrets.Secret.Data[model.StorageConnectionStringKey]
 	if !ok {

--- a/pomerium/ctrl/bootstrap_test.go
+++ b/pomerium/ctrl/bootstrap_test.go
@@ -1,6 +1,7 @@
 package ctrl
 
 import (
+	"context"
 	"encoding/base64"
 	"testing"
 
@@ -27,7 +28,7 @@ func TestSecretsDecode(t *testing.T) {
 	require.NoError(t, err)
 
 	var opts config.Options
-	require.NoError(t, applySecrets(&opts, &model.Config{Secrets: secrets}))
+	require.NoError(t, applySecrets(context.Background(), &opts, &model.Config{Secrets: secrets}))
 
 	assert.Equal(t, base64.StdEncoding.EncodeToString(secrets.Data["cookie_secret"]), opts.CookieSecret)
 	assert.Equal(t, base64.StdEncoding.EncodeToString(secrets.Data["shared_secret"]), opts.SharedKey)
@@ -37,7 +38,7 @@ func TestSecretsDecode(t *testing.T) {
 func TestSecretsDecodeRules(t *testing.T) {
 	var opts config.Options
 
-	assert.NoError(t, applySecrets(&opts, &model.Config{
+	assert.NoError(t, applySecrets(context.Background(), &opts, &model.Config{
 		Secrets: &v1.Secret{
 			Data: map[string][]byte{
 				"shared_secret": mustB64Decode(t, "9OkZR6hwfmVD3a7Sfmgq58lUbFJGGz4hl/R9xbHFCAg="),
@@ -47,8 +48,8 @@ func TestSecretsDecodeRules(t *testing.T) {
 		},
 	}), "ok secret")
 
-	assert.Error(t, applySecrets(&opts, &model.Config{}))
-	assert.Error(t, applySecrets(&opts, &model.Config{
+	assert.Error(t, applySecrets(context.Background(), &opts, &model.Config{}))
+	assert.Error(t, applySecrets(context.Background(), &opts, &model.Config{
 		Secrets: &v1.Secret{
 			Data: map[string][]byte{
 				"cookie_secret": mustB64Decode(t, "WwMtDXWaRDMBQCylle8OJ+w4kLIDIGd8W3cB4/zFFtg="),
@@ -56,7 +57,7 @@ func TestSecretsDecodeRules(t *testing.T) {
 			},
 		},
 	}))
-	assert.Error(t, applySecrets(&opts, &model.Config{
+	assert.Error(t, applySecrets(context.Background(), &opts, &model.Config{
 		Secrets: &v1.Secret{
 			Data: map[string][]byte{
 				"shared_secret": {1, 2, 3},

--- a/pomerium/ctrl/run.go
+++ b/pomerium/ctrl/run.go
@@ -49,7 +49,7 @@ func (r *Runner) GetConfig() *config.Config {
 func (r *Runner) SetConfig(ctx context.Context, src *model.Config) (changes bool, err error) {
 	dst := r.base.Clone()
 
-	if err := Apply(dst.Options, src); err != nil {
+	if err := Apply(ctx, dst.Options, src); err != nil {
 		return false, fmt.Errorf("transform config: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
Replace the `createFileFromSecret` function with a file manager that can delete files it creates. Files will be deleted before every evaluation, which should be fine on *nix because files can be deleted while they're still being used. 

## Related issues
Fixes https://github.com/pomerium/internal/issues/889


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
