### PR TITLE
fix expected k8s service account secret type

### DIFF
--- a/apis/ingress/v1/pomerium_types.go
+++ b/apis/ingress/v1/pomerium_types.go
@@ -56,7 +56,7 @@ type IdentityProvider struct {
 	// +optional
 	Scopes []string `json:"scopes,omitempty"`
 
-	// refreshDirectory specifis
+	// RefreshDirectory defines IdP directory refresh options
 	// +optional
 	RefreshDirectory *RefreshDirectorySettings `json:"refreshDirectory"`
 }

--- a/config/crd/bases/ingress.pomerium.io_pomerium.yaml
+++ b/config/crd/bases/ingress.pomerium.io_pomerium.yaml
@@ -60,7 +60,7 @@ spec:
                 description: IdentityProvider see https://www.pomerium.com/docs/identity-providers/
                 properties:
                   provider:
-                    description: Provider one of accepted providers https://www.pomerium.com/reference/#identity-provider-name
+                    description: Provider one of accepted providers - see https://www.pomerium.com/reference/#identity-provider-name.
                     enum:
                     - auth0
                     - azure
@@ -72,12 +72,15 @@ spec:
                     - github
                     type: string
                   refreshDirectory:
-                    description: Specifies refresh settings
+                    description: refreshDirectory specifis
                     properties:
                       interval:
+                        description: interval is the time that pomerium will sync
+                          your IDP directory.
                         format: duration
                         type: string
                       timeout:
+                        description: timeout is the maximum time allowed each run.
                         format: duration
                         type: string
                     required:
@@ -91,18 +94,17 @@ spec:
                     type: object
                   requestParamsSecret:
                     description: RequestParamsSecret is a reference to a secret for
-                      additional parameters you'd prefer not to provide in plaintext
+                      additional parameters you'd prefer not to provide in plaintext.
                     type: string
                   scopes:
-                    description: Scopes see https://www.pomerium.com/reference/#identity-provider-scopes
+                    description: Scopes see https://www.pomerium.com/reference/#identity-provider-scopes.
                     items:
                       type: string
                     type: array
                   secret:
-                    description: Secret refers to a k8s secret containing IdP provider
-                      specific parameters and must contain at least `client_id` and
-                      `client_secret` map values, an optional `service_account` field,
-                      mapped to https://www.pomerium.com/reference/#identity-provider-service-account
+                    description: Secret containing IdP provider specific parameters
+                      and must contain at least client_id and client_secret values,
+                      an optional `service_account` field, mapped to https://www.pomerium.com/reference/#identity-provider-service-account
                     minLength: 1
                     type: string
                   serviceAccountFromSecret:
@@ -111,7 +113,7 @@ spec:
                       see https://www.pomerium.com/docs/identity-providers/
                     type: string
                   url:
-                    description: URL is identity provider url, see https://www.pomerium.com/reference/#identity-provider-url
+                    description: URL is identity provider url, see https://www.pomerium.com/reference/#identity-provider-url.
                     format: uri
                     pattern: ^https://
                     type: string

--- a/config/crd/bases/ingress.pomerium.io_pomerium.yaml
+++ b/config/crd/bases/ingress.pomerium.io_pomerium.yaml
@@ -72,7 +72,7 @@ spec:
                     - github
                     type: string
                   refreshDirectory:
-                    description: refreshDirectory specifis
+                    description: RefreshDirectory defines IdP directory refresh options
                     properties:
                       interval:
                         description: interval is the time that pomerium will sync

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -80,7 +80,7 @@ spec:
                     - github
                     type: string
                   refreshDirectory:
-                    description: refreshDirectory specifis
+                    description: RefreshDirectory defines IdP directory refresh options
                     properties:
                       interval:
                         description: interval is the time that pomerium will sync

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -68,7 +68,7 @@ spec:
                 description: IdentityProvider see https://www.pomerium.com/docs/identity-providers/
                 properties:
                   provider:
-                    description: Provider one of accepted providers https://www.pomerium.com/reference/#identity-provider-name
+                    description: Provider one of accepted providers - see https://www.pomerium.com/reference/#identity-provider-name.
                     enum:
                     - auth0
                     - azure
@@ -80,12 +80,15 @@ spec:
                     - github
                     type: string
                   refreshDirectory:
-                    description: Specifies refresh settings
+                    description: refreshDirectory specifis
                     properties:
                       interval:
+                        description: interval is the time that pomerium will sync
+                          your IDP directory.
                         format: duration
                         type: string
                       timeout:
+                        description: timeout is the maximum time allowed each run.
                         format: duration
                         type: string
                     required:
@@ -99,18 +102,17 @@ spec:
                     type: object
                   requestParamsSecret:
                     description: RequestParamsSecret is a reference to a secret for
-                      additional parameters you'd prefer not to provide in plaintext
+                      additional parameters you'd prefer not to provide in plaintext.
                     type: string
                   scopes:
-                    description: Scopes see https://www.pomerium.com/reference/#identity-provider-scopes
+                    description: Scopes see https://www.pomerium.com/reference/#identity-provider-scopes.
                     items:
                       type: string
                     type: array
                   secret:
-                    description: Secret refers to a k8s secret containing IdP provider
-                      specific parameters and must contain at least `client_id` and
-                      `client_secret` map values, an optional `service_account` field,
-                      mapped to https://www.pomerium.com/reference/#identity-provider-service-account
+                    description: Secret containing IdP provider specific parameters
+                      and must contain at least client_id and client_secret values,
+                      an optional `service_account` field, mapped to https://www.pomerium.com/reference/#identity-provider-service-account
                     minLength: 1
                     type: string
                   serviceAccountFromSecret:
@@ -119,7 +121,7 @@ spec:
                       see https://www.pomerium.com/docs/identity-providers/
                     type: string
                   url:
-                    description: URL is identity provider url, see https://www.pomerium.com/reference/#identity-provider-url
+                    description: URL is identity provider url, see https://www.pomerium.com/reference/#identity-provider-url.
                     format: uri
                     pattern: ^https://
                     type: string

--- a/pomerium/ingress_annotations_test.go
+++ b/pomerium/ingress_annotations_test.go
@@ -101,7 +101,7 @@ func TestAnnotations(t *testing.T) {
 				Data: map[string][]byte{
 					model.KubernetesServiceAccountTokenSecretKey: []byte("k8s-token-data"),
 				},
-				Type: corev1.SecretTypeOpaque,
+				Type: corev1.SecretTypeServiceAccountToken,
 			},
 			{Name: "request_headers", Namespace: "test"}: {
 				Data: map[string][]byte{

--- a/pomerium/routes_test.go
+++ b/pomerium/routes_test.go
@@ -441,7 +441,7 @@ func TestKubernetesToken(t *testing.T) {
 				Data: map[string][]byte{
 					model.KubernetesServiceAccountTokenSecretKey: []byte("123456"),
 				},
-				Type: corev1.SecretTypeOpaque,
+				Type: corev1.SecretTypeServiceAccountToken,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

We expected an Opaque secret type for the kubernetes service account defined via Ingress annotation 
`kubernetes_service_account_token_secret`. As service accounts are normally created automatically via `ServiceAccount`, they have 
`kubernetes.io/service-account-token` type instead. 

## Related issues

Fixes #335

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
