### PR TITLE
bump to v19.0 docker image

### DIFF
--- a/config/pomerium/deployment/image.yaml
+++ b/config/pomerium/deployment/image.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
         - name: pomerium
-          image: pomerium/ingress-controller:sha-5294279
+          image: pomerium/ingress-controller:sha-b0b87be
           imagePullPolicy: IfNotPresent

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -466,7 +466,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: pomerium/ingress-controller:sha-5294279
+        image: pomerium/ingress-controller:sha-b0b87be
         imagePullPolicy: IfNotPresent
         name: pomerium
         ports:


### PR DESCRIPTION
## Summary

Upgrades docker image to use Pomerium v19.

## Related issues

Fix https://github.com/pomerium/internal/issues/978

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
