### PR TITLE
bump docker image to v0.19.0

### DIFF
--- a/config/pomerium/deployment/image.yaml
+++ b/config/pomerium/deployment/image.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
         - name: pomerium
-          image: pomerium/ingress-controller:sha-b0b87be
+          image: pomerium/ingress-controller:sha-668a172
           imagePullPolicy: IfNotPresent

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -466,7 +466,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: pomerium/ingress-controller:sha-b0b87be
+        image: pomerium/ingress-controller:sha-668a172
         imagePullPolicy: IfNotPresent
         name: pomerium
         ports:


### PR DESCRIPTION
## Summary

Bump Docker image to v0.19.0 in the deployment.yaml

## Related issues

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
