### PR TITLE
crd /status update check

### DIFF
--- a/cmd/all_in_one.go
+++ b/cmd/all_in_one.go
@@ -302,7 +302,7 @@ func (s *allCmdParam) runBootstrapConfigController(ctx context.Context, reconcil
 	}
 	name := "bootstrap"
 	if host, err := os.Hostname(); err == nil {
-		name = fmt.Sprintf("%s-%s", name, host)
+		name = fmt.Sprintf("%s pod/%s", name, host)
 	}
 	if err := settings.NewSettingsController(mgr, reconciler, s.settings, name, false); err != nil {
 		return fmt.Errorf("settings controller: %w", err)

--- a/controllers/ingress/reconcile.go
+++ b/controllers/ingress/reconcile.go
@@ -112,15 +112,13 @@ func (r *ingressController) deleteIngress(ctx context.Context, name types.Namesp
 }
 
 func (r *ingressController) upsertIngress(ctx context.Context, ic *model.IngressConfig) (ctrl.Result, error) {
-	changed, err := r.IngressReconciler.Upsert(ctx, ic)
+	_, err := r.IngressReconciler.Upsert(ctx, ic)
 	if err != nil {
 		r.IngressNotReconciled(ctx, ic.Ingress, err)
 		return ctrl.Result{Requeue: true}, fmt.Errorf("upsert: %w", err)
 	}
 
-	if changed {
-		r.IngressReconciled(ctx, ic.Ingress)
-	}
+	r.IngressReconciled(ctx, ic.Ingress)
 
 	if err = r.updateIngressStatus(ctx, ic.Ingress); err != nil {
 		return ctrl.Result{Requeue: true}, fmt.Errorf("update ingress status: %w", err)

--- a/controllers/settings/controller.go
+++ b/controllers/settings/controller.go
@@ -147,9 +147,16 @@ func (c *settingsController) Reconcile(ctx context.Context, req ctrl.Request) (c
 		c.SettingsRejected(ctx, &cfg.Pomerium, err)
 		return ctrl.Result{Requeue: true}, fmt.Errorf("set config: %w", err)
 	}
-	if changed {
+	if changed || !statusUpToDate(&cfg.Pomerium) {
 		c.SettingsUpdated(ctx, &cfg.Pomerium)
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func statusUpToDate(pom *icsv1.Pomerium) bool {
+	if pom.Status.SettingsStatus == nil {
+		return false
+	}
+	return pom.Generation == pom.Status.SettingsStatus.ObservedGeneration
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v0.46.1
+	github.com/pomerium/csrf v1.7.0
 	github.com/pomerium/pomerium v0.20.0
 	github.com/sergi/go-diff v1.2.0
 	github.com/spf13/cobra v1.6.1
@@ -229,7 +230,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polyfloyd/go-errorlint v1.0.5 // indirect
-	github.com/pomerium/csrf v1.7.0 // indirect
 	github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 // indirect
 	github.com/pomerium/webauthn v0.0.0-20211014213840-422c7ce1077f // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect


### PR DESCRIPTION
## Summary

sometimes `/status` was not updated in a following scenario:
 
- valid configuration (`/status` updated to reflect a new configuration was applied)
- not valid configuration (`/status` updated the new configuration was not applied)
- valid configuration (`/status` was not updated, as Pomerium config was not changed)

This PR adds a check to see if generation or currently reported reconciliation state is different.

NB: we cannot just overwrite the `/status` every time, as it would trigger a reconciliation event, and the 
controller would be in the always-updating loop.

## Related issues


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
