### PR TITLE
more fine grained debug logging

### DIFF
--- a/cmd/all_in_one.go
+++ b/cmd/all_in_one.go
@@ -33,6 +33,7 @@ import (
 type allCmdOptions struct {
 	ingressControllerOpts
 	debug                           bool
+	debugDumpConfigDiff             bool
 	configControllerShutdownTimeout time.Duration
 	// metricsBindAddress must be externally accessible host:port
 	metricsBindAddress string `validate:"required,hostname_port"`
@@ -81,7 +82,8 @@ func AllInOneCommand() (*cobra.Command, error) {
 func (s *allCmd) setupFlags() error {
 	flags := s.PersistentFlags()
 	flags.BoolVar(&s.debug, debug, false, "enable debug logging")
-	if err := flags.MarkHidden("debug"); err != nil {
+	flags.BoolVar(&s.debugDumpConfigDiff, debugDumpConfigDiff, false, "development dump of config diff, don't use in production")
+	if err := flags.MarkHidden(debugDumpConfigDiff); err != nil {
 		return err
 	}
 	flags.StringVar(&s.metricsBindAddress, metricsBindAddress, "", "host:port for aggregate metrics. host is mandatory")
@@ -89,7 +91,7 @@ func (s *allCmd) setupFlags() error {
 	flags.StringVar(&s.httpRedirectAddr, "http-redirect-addr", ":8080", "the address HTTP redirect would bind to")
 	flags.DurationVar(&s.configControllerShutdownTimeout, "config-controller-shutdown", time.Second*30, "timeout waiting for graceful config controller shutdown")
 	if err := flags.MarkHidden("config-controller-shutdown"); err != nil {
-		return nil
+		return err
 	}
 	s.ingressControllerOpts.setupFlags(flags)
 	return viperWalk(flags)
@@ -134,7 +136,7 @@ func (s *allCmdOptions) getParam() (*allCmdParam, error) {
 		settings:                        *settings,
 		ingressOpts:                     opts,
 		updateStatusFromService:         s.UpdateStatusFromService,
-		dumpConfigDiff:                  s.debug,
+		dumpConfigDiff:                  s.debugDumpConfigDiff,
 		configControllerShutdownTimeout: s.configControllerShutdownTimeout,
 	}
 	if err := p.makeBootstrapConfig(*s); err != nil {

--- a/cmd/ingress_opts.go
+++ b/cmd/ingress_opts.go
@@ -26,6 +26,7 @@ const (
 	namespaces                 = "namespaces"
 	sharedSecret               = "shared-secret"
 	debug                      = "debug"
+	debugDumpConfigDiff        = "debug-dump-config-diff"
 	updateStatusFromService    = "update-status-from-service"
 	globalSettings             = "pomerium-config"
 )

--- a/controllers/reporter/pomerium.go
+++ b/controllers/reporter/pomerium.go
@@ -73,7 +73,7 @@ func (s *SettingsStatusReporter) SettingsRejected(ctx context.Context, obj *icsv
 func getConfigWarnings(ctx context.Context) []string {
 	var out []string
 	for _, msg := range util.Get[pom_cfg.FieldMsg](ctx) {
-		out = append(out, fmt.Sprintf("%s: no longer supported, please see %s", msg.Key, msg.DocsURL))
+		out = append(out, fmt.Sprintf("%s: %s, please see %s", msg.Key, msg.FieldCheckMsg, msg.DocsURL))
 	}
 	return out
 }

--- a/controllers/reporter/reporter.go
+++ b/controllers/reporter/reporter.go
@@ -21,7 +21,7 @@ func logErrorIfAny(ctx context.Context, err error, kvs ...any) {
 	if err == nil {
 		return
 	}
-	log.FromContext(ctx).Error(err, "updating ingress status", kvs...)
+	log.FromContext(ctx).Error(err, "posting status updates", kvs...)
 }
 
 // IngressReconciled an ingress was successfully reconciled with Pomerium

--- a/pomerium/sync.go
+++ b/pomerium/sync.go
@@ -194,17 +194,17 @@ func (r *DataBrokerReconciler) saveConfig(ctx context.Context, prev, next *pb.Co
 	}
 
 	if r.DebugDumpConfigDiff {
-		debugDumpConfigDiff(prev, next)
+		logger.Info("config diff", "diff", debugDumpConfigDiff(prev, next))
 	}
 	logger.Info("new pomerium config applied")
 
 	return true, nil
 }
 
-func debugDumpConfigDiff(prev, next *pb.Config) {
+func debugDumpConfigDiff(prev, next *pb.Config) []byte {
 	dmp := diffmatchpatch.New()
 	txt1 := protojson.Format(prev)
 	txt2 := protojson.Format(next)
 	diffs := dmp.DiffMain(txt1, txt2, true)
-	fmt.Println("CONFIG DIFF", dmp.DiffPrettyText(diffs))
+	return []byte(dmp.DiffPrettyText(diffs))
 }


### PR DESCRIPTION
## Summary

Previous config diff debug dump would break JSON structured logging stream. 
Also changes the output message for a config validation warning.

## Related issues

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
