### PR TITLE
faster docker build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,7 +1,8 @@
-name: Docker Main
+name: Docker
 permissions:
   contents: read
 on:
+  pull_request: {}
   push:
     branches:
       - main
@@ -42,9 +43,9 @@ jobs:
       - name: Docker Publish - Main
         uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
         with:
-          context: .
-          file: ./Dockerfile
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,7 +40,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Docker Publish - Main
+      - name: Docker
         uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
         with:
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,25 @@
+name: Lint
+permissions:
+  contents: read
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: 1.19.x
+          cache: true
+
+      - uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376
+        with:
+          version: v1.49

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,12 +95,3 @@ jobs:
       - name: build
         run: |
           make build
-
-  build-docker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-        with:
-          fetch-depth: 0
-      - name: build
-        run: docker build .

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,9 +62,6 @@ jobs:
             ~/Library/Caches/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
-      - name: Lint
-        if: runner.os == 'Linux'
-        run: make lint
       - name: test
         if: runner.os == 'Linux'
         run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,37 +2,33 @@
 # make sure to run `make clean` if building locally
 
 FROM golang:1.19.3@sha256:dc76ef03e54c34a00dcdca81e55c242d24b34d231637776c4bb5c1a8e8514253 as go-modules
-
 WORKDIR /workspace
 
 COPY go.mod go.mod
 COPY go.sum go.sum
-COPY scripts scripts
-COPY Makefile Makefile
-
-RUN mkdir -p pomerium/envoy/bin
-RUN make envoy
 RUN go mod download
 
-COPY Makefile ./Makefile
+COPY scripts scripts
+COPY Makefile Makefile
+RUN mkdir -p pomerium/envoy/bin \
+    && make envoy
 
 # download ui dependencies from core module
-RUN mkdir -p internal
-RUN make internal/ui
+RUN mkdir -p internal \
+    && make internal/ui
 
 FROM node:16@sha256:b9fe422fdf0d51f616d25aa6ccc0d900eb25ca08bd78d79e369c480b4584c3a8 as ui
 WORKDIR /workspace
 
 COPY --from=go-modules /workspace/internal/ui ./
-RUN yarn install
-RUN yarn build
+RUN yarn install --network-timeout 120000 \
+    && yarn build
 
 FROM go-modules as go-builder
 WORKDIR /workspace
 
 # Copy the go source
 COPY . .
-
 COPY --from=ui /workspace/dist ./internal/ui/dist
 
 # Build

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ build: pomerium-ui build-go ## Build manager binary.
 
 ##@ Build
 .PHONY: build-go
-build-go: envoy generate fmt vet
+build-go: envoy
 	@echo "==> $@"
 	@go build $(GOTAGS) -o bin/manager main.go
 


### PR DESCRIPTION
## Summary
Always run the docker job, but only push on main. Add caching to the github action. Improve the dockerfile to skip generate, fmt, and vet steps, which should be done as separate github actions. (and `generate` code should be committed so not run as part of build)




## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
