### PR TITLE
crd: add certificate authority

### DIFF
--- a/apis/ingress/v1/pomerium_types.go
+++ b/apis/ingress/v1/pomerium_types.go
@@ -232,6 +232,14 @@ type PomeriumSpec struct {
 	// +optional
 	Certificates []string `json:"certificates"`
 
+	// CASecret should refer to a k8s secret with key <code>ca.crt</code> containing a CA certificate.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Format="namespace/name"
+	CASecret *string `json:"caSecret"`
+
 	// Secrets references a Secret with Pomerium bootstrap parameters.
 	//
 	// <p>

--- a/apis/ingress/v1/zz_generated.deepcopy.go
+++ b/apis/ingress/v1/zz_generated.deepcopy.go
@@ -186,6 +186,11 @@ func (in *PomeriumSpec) DeepCopyInto(out *PomeriumSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.CASecret != nil {
+		in, out := &in.CASecret, &out.CASecret
+		*out = new(string)
+		**out = **in
+	}
 	if in.Storage != nil {
 		in, out := &in.Storage, &out.Storage
 		*out = new(Storage)

--- a/config/crd/bases/ingress.pomerium.io_pomerium.yaml
+++ b/config/crd/bases/ingress.pomerium.io_pomerium.yaml
@@ -63,6 +63,12 @@ spec:
                 required:
                 - url
                 type: object
+              caSecret:
+                description: CASecret should refer to a k8s secret with key <code>ca.crt</code>
+                  containing a CA certificate.
+                format: namespace/name
+                minLength: 1
+                type: string
               certificates:
                 description: Certificates is a list of secrets of type TLS to use
                 format: namespace/name

--- a/controllers/settings/fetch.go
+++ b/controllers/settings/fetch.go
@@ -101,6 +101,7 @@ func fetchConfigSecrets(ctx context.Context, client client.Client, cfg *model.Co
 	s := cfg.Spec
 	return applyAll(
 		apply("bootstrap secret", required(&s.Secrets), &cfg.Secrets),
+		apply("ca", optional(s.CASecret), &cfg.CASecret),
 		apply("secret", required(&s.IdentityProvider.Secret), &cfg.IdpSecret),
 		apply("request params", optional(s.IdentityProvider.RequestParamsSecret), &cfg.RequestParams),
 		apply("service account", optional(s.IdentityProvider.ServiceAccountFromSecret), &cfg.IdpServiceAccount),

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -71,6 +71,12 @@ spec:
                 required:
                 - url
                 type: object
+              caSecret:
+                description: CASecret should refer to a k8s secret with key <code>ca.crt</code>
+                  containing a CA certificate.
+                format: namespace/name
+                minLength: 1
+                type: string
               certificates:
                 description: Certificates is a list of secrets of type TLS to use
                 format: namespace/name

--- a/model/ingress_config.go
+++ b/model/ingress_config.go
@@ -80,6 +80,8 @@ type Config struct {
 	icsv1.Pomerium
 	// Secrets are key secrets
 	Secrets *corev1.Secret
+	// CASecret is the certificate authority secret.
+	CASecret *corev1.Secret
 	// Certs are fetched certs from settings.Certificates
 	Certs map[types.NamespacedName]*corev1.Secret
 	// RequestParams is a secret from Settings.IdentityProvider.RequestParams

--- a/pomerium/ctrl/bootstrap.go
+++ b/pomerium/ctrl/bootstrap.go
@@ -26,6 +26,7 @@ func Apply(ctx context.Context, dst *config.Options, src *model.Config) error {
 		fn   func(context.Context, *config.Options, *model.Config) error
 	}{
 		{"secrets", applySecrets},
+		{"ca", applyCertificateAuthority},
 		{"storage", applyStorage},
 	} {
 		if err := apply.fn(ctx, dst, src); err != nil {
@@ -154,6 +155,15 @@ func applyStoragePostgres(dst *config.Options, src *model.Config) error {
 
 	u.RawQuery = param.Encode()
 	dst.DataBrokerStorageConnectionString = u.String()
+	return nil
+}
+
+func applyCertificateAuthority(ctx context.Context, dst *config.Options, src *model.Config) error {
+	if src.CASecret == nil {
+		return nil
+	}
+
+	dst.CA = base64.StdEncoding.EncodeToString(src.CASecret.Data[model.CAKey])
 	return nil
 }
 


### PR DESCRIPTION
## Summary
Add `caSecret` to the CRD.

## Related issues
Fixes https://github.com/pomerium/ingress-controller/issues/476


## Checklist
- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
