### PR TITLE
add cspell pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,12 @@ repos:
     rev: v0.0.17
     hooks:
       - id: go-mod-tidy
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v6.17.1
+    hooks:
+      - id: cspell
+        files: "^.*.go$"
+        #exclude: "^.*_test\\.go$"
   - repo: local
     hooks:
       - id: lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,6 @@ repos:
     hooks:
       - id: cspell
         files: "^.*.go$"
-        #exclude: "^.*_test\\.go$"
   - repo: local
     hooks:
       - id: lint

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ dev-install:
 	@echo "deleting pods..."
 	#@kubectl delete --force --selector app.kubernetes.io/name=pomerium pods || true
 	@kubectl delete deployment/pomerium -n pomerium --wait || true
-	@$(KUSTOMIZE) build config/dev/local | kubectl apply --filename -
+	@$(KUSTOMIZE) build config/dev/local --load-restrictor LoadRestrictionsNone | kubectl apply --filename -
 
 .PHONY: dev-logs
 dev-logs:

--- a/apis/ingress/v1/pomerium_types.go
+++ b/apis/ingress/v1/pomerium_types.go
@@ -48,7 +48,7 @@ type IdentityProvider struct {
 	// see <a href="https://docs.pomerium.com/docs/overview/upgrading#idp-directory-sync">Upgrade Guide</a>.
 	// +optional
 	ServiceAccountFromSecret *string `json:"serviceAccountFromSecret,omitempty" deprecated:"idp_directory_sync"`
-	// RequestParams to be added as part of a signin request using OAuth2 code flow.
+	// RequestParams to be added as part of a sign-in request using OAuth2 code flow.
 	//
 	// +kubebuilder:validation:Format="namespace/name"
 	// +optional
@@ -114,7 +114,7 @@ type PostgresStorage struct {
 	// <code>connection</code> key. See
 	// <a href="https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING">DSN Format and Parameters</a>.
 	// Do not set <code>sslrootcert</code>, <code>sslcert</code> and <code>sslkey</code> via connection string,
-	// use <code>tlsCecret</code> and <code>caSecret</code> CRD options instead.
+	// use <code>tlsSecret</code> and <code>caSecret</code> CRD options instead.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:MinLength=1

--- a/controllers/ingress/controller.go
+++ b/controllers/ingress/controller.go
@@ -34,8 +34,7 @@ type ingressController struct {
 
 	// Scheme keeps track between objects and their group/version/kinds
 	*runtime.Scheme
-	// Client is k8s apiserver client proxied thru controller-runtime,
-	// that also embeds object cache
+	// Client is k8s apiserver client with object caching
 	client.Client
 
 	// PomeriumReconciler updates Pomerium service configuration

--- a/controllers/settings/controller.go
+++ b/controllers/settings/controller.go
@@ -27,7 +27,7 @@ import (
 type settingsController struct {
 	// key kind/name of a settings object to watch, all others would be ignored
 	key model.Key
-	// Client is k8s apiserver client
+	// Client is k8s api server client
 	client.Client
 	// PomeriumReconciler updates Pomerium service configuration
 	pomerium.ConfigReconciler

--- a/controllers/settings/fetch_test.go
+++ b/controllers/settings/fetch_test.go
@@ -64,6 +64,7 @@ func TestFetchConstraints(t *testing.T) {
 		"postgres": {
 			corev1.SecretTypeOpaque,
 			map[string][]byte{
+				//cspell:disable-next-line
 				model.StorageConnectionStringKey: []byte("postgresql:///mydb?host=localhost&port=5433"),
 			},
 		},

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,0 +1,30 @@
+version: "0.2"
+language: en-US
+words:
+  - apimachinery
+  - apiserver
+  - configmap
+  - databroker
+  - deepcopy
+  - envtest
+  - pomerium
+  - protobuf
+  - oidc
+  - readyz
+  - sslcert
+  - sslkey
+  - sslrootcert
+  - upsert
+  - uifs
+  - filemgr
+languageSettings:
+  - languageId: go
+    allowCompoundWords: false
+    ignoreRegExpList:
+      - Urls
+      - Base64
+      - "/kubebuilder:.*/"
+      - "/nolint:.*/"
+      - "/go:.*/"
+    includeRegExpList:
+      - CStyleComment

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v0.48.0
+	github.com/pomerium/csrf v1.7.0
 	github.com/pomerium/pomerium v0.20.1-0.20230105213558-488bcd6f72f8
 	github.com/sergi/go-diff v1.2.0
 	github.com/spf13/cobra v1.6.1
@@ -246,7 +247,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polyfloyd/go-errorlint v1.0.5 // indirect
-	github.com/pomerium/csrf v1.7.0 // indirect
 	github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 // indirect
 	github.com/pomerium/webauthn v0.0.0-20221118023040-00a9c430578b // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/internal/init.go
+++ b/internal/init.go
@@ -1,2 +1,2 @@
-// Package internal implements few hacks to allow pomerium embeddeding
+// Package internal implements few hacks to allow pomerium embedding
 package internal

--- a/model/registry.go
+++ b/model/registry.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
-// Key is dependenciy key
+// Key is dependency key
 type Key struct {
 	Kind string
 	types.NamespacedName

--- a/pomerium/ingress_to_route.go
+++ b/pomerium/ingress_to_route.go
@@ -160,7 +160,7 @@ func setRoutePath(r *pb.Route, p networkingv1.HTTPIngressPath, ic *model.Ingress
 	case networkingv1.PathTypePrefix:
 		r.Prefix = p.Path
 	default:
-		// shouldn't get there as apiserver should not allow this
+		// shouldn't get there as api server should not allow this
 		return fmt.Errorf("unknown pathType %s", *p.PathType)
 	}
 

--- a/util/namespaced_name_test.go
+++ b/util/namespaced_name_test.go
@@ -79,7 +79,7 @@ func TestParseNamespacedName(t *testing.T) {
 	}} {
 		t.Run(tc.in, func(t *testing.T) {
 			got, err := util.ParseNamespacedName(tc.in, tc.opts...)
-			tc.errCheck(t, err, "errcheck")
+			tc.errCheck(t, err, "error check")
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
## Summary

Add cSpell pre-commit hook.

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Fixes #475

<!-- For example...
Fixes #159
-->


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
