### PR TITLE
fix logging for ingresses that are not managed by us

### DIFF
--- a/controllers/mock/pomerium_ingress_reconciler.go
+++ b/controllers/mock/pomerium_ingress_reconciler.go
@@ -37,11 +37,12 @@ func (m *MockIngressReconciler) EXPECT() *MockIngressReconcilerMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockIngressReconciler) Delete(arg0 context.Context, arg1 types.NamespacedName) error {
+func (m *MockIngressReconciler) Delete(arg0 context.Context, arg1 types.NamespacedName) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Delete indicates an expected call of Delete.

--- a/controllers/reporter/ingress.go
+++ b/controllers/reporter/ingress.go
@@ -91,7 +91,7 @@ func (r *IngressSettingsReporter) IngressDeleted(ctx context.Context, name types
 		return err
 	}
 
-	return r.Status().Patch(ctx, &icsv1.Pomerium{
+	err = r.Status().Patch(ctx, &icsv1.Pomerium{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: r.Name,
 		},
@@ -99,6 +99,10 @@ func (r *IngressSettingsReporter) IngressDeleted(ctx context.Context, name types
 			Routes: map[string]icsv1.ResourceStatus{},
 		},
 	}, client.RawPatch(types.JSONPatchType, patch))
+	if err != nil {
+		return fmt.Errorf("failed to patch /status for ingress %v: %w", name, err)
+	}
+	return nil
 }
 
 // IngressEventReporter reflects updates as events posted to the ingress

--- a/controllers/reporter/reporter.go
+++ b/controllers/reporter/reporter.go
@@ -55,7 +55,7 @@ func (r MultiIngressStatusReporter) IngressDeleted(ctx context.Context, name typ
 			errs = multierror.Append(errs, err)
 		}
 	}
-	logErrorIfAny(ctx, errs.ErrorOrNil(), "ingress", name)
+	logErrorIfAny(ctx, errs.ErrorOrNil(), "ingress", name, "original reason", reason)
 }
 
 // SettingsUpdated marks that configuration was reconciled

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v0.49.0
+	github.com/pomerium/csrf v1.7.0
 	github.com/pomerium/pomerium v0.21.0
 	github.com/sergi/go-diff v1.3.1
 	github.com/spf13/cobra v1.6.1
@@ -247,7 +248,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polyfloyd/go-errorlint v1.0.6 // indirect
-	github.com/pomerium/csrf v1.7.0 // indirect
 	github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 // indirect
 	github.com/pomerium/webauthn v0.0.0-20221118023040-00a9c430578b // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/pomerium/reconcile.go
+++ b/pomerium/reconcile.go
@@ -16,7 +16,7 @@ type IngressReconciler interface {
 	// Set configuration to match provided ingresses and shared config settings
 	Set(ctx context.Context, ics []*model.IngressConfig) (changes bool, err error)
 	// Delete should delete pomerium routes corresponding to this ingress name
-	Delete(ctx context.Context, namespacedName types.NamespacedName) error
+	Delete(ctx context.Context, namespacedName types.NamespacedName) (changes bool, err error)
 }
 
 // ConfigReconciler only updates global parameters and does not deal with individual routes


### PR DESCRIPTION
## Summary

We receive all Ingress objects for reconcilation, but we only manage those that are in the designated namespaces and have a matching ingressClass / 
annotation set. 

However since introduction of Reporters that update CRD/status and post events to relevant ingress objects, we emitted log messages that made an impression 
that Pomerium is managing those ingresses. 

This PR fixes the condition so that it would only log state change when it actually happened.

## Related issues

Fixes #494

<!-- For example...
Fixes #159
-->


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
