### PR TITLE
set main manifests to point to main docker image

### DIFF
--- a/config/pomerium/deployment/image.yaml
+++ b/config/pomerium/deployment/image.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
         - name: pomerium
-          image: pomerium/ingress-controller:sha-cdc389c
-          imagePullPolicy: IfNotPresent
+          image: pomerium/ingress-controller:main
+          imagePullPolicy: Always

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -566,8 +566,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: pomerium/ingress-controller:sha-cdc389c
-        imagePullPolicy: IfNotPresent
+        image: pomerium/ingress-controller:main
+        imagePullPolicy: Always
         name: pomerium
         ports:
         - containerPort: 8443


### PR DESCRIPTION
## Summary

Always pull `ingress-controller:main` image when performing a deploy like this:

```shell
kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=main
```

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
