### PR TITLE
setResponseHeaders: fix typo

### DIFF
--- a/apis/ingress/v1/pomerium_types.go
+++ b/apis/ingress/v1/pomerium_types.go
@@ -287,9 +287,9 @@ type PomeriumSpec struct {
 	// +optional
 	JWTClaimHeaders map[string]string `json:"jwtClaimHeaders,omitempty"`
 
-	// SetRequestHeaders sets HTTP headers on the request before sending it to the upstream service.
+	// SetResponseHeaders specifies a mapping of HTTP Header to be added globally to all managed routes and pomerium's authenticate service.
 	// +optional
-	// See <a href="https://www.pomerium.com/docs/reference/#set-request-headers">Set Request Headers</a>
+	// See <a href="https://www.pomerium.com/docs/reference/set-response-headers">Set Response Headers</a>
 	SetResponseHeaders map[string]string `json:"setResponseHeaders,omitempty"`
 }
 

--- a/config/crd/bases/ingress.pomerium.io_pomerium.yaml
+++ b/config/crd/bases/ingress.pomerium.io_pomerium.yaml
@@ -212,9 +212,10 @@ spec:
               setResponseHeaders:
                 additionalProperties:
                   type: string
-                description: SetRequestHeaders sets HTTP headers on the request before
-                  sending it to the upstream service. See <a href="https://www.pomerium.com/docs/reference/#set-request-headers">Set
-                  Request Headers</a>
+                description: SetResponseHeaders specifies a mapping of HTTP Header
+                  to be added globally to all managed routes and pomerium's authenticate
+                  service. See <a href="https://www.pomerium.com/docs/reference/set-response-headers">Set
+                  Response Headers</a>
                 type: object
               storage:
                 description: Storage defines persistent storage for sessions and other

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -220,9 +220,10 @@ spec:
               setResponseHeaders:
                 additionalProperties:
                   type: string
-                description: SetRequestHeaders sets HTTP headers on the request before
-                  sending it to the upstream service. See <a href="https://www.pomerium.com/docs/reference/#set-request-headers">Set
-                  Request Headers</a>
+                description: SetResponseHeaders specifies a mapping of HTTP Header
+                  to be added globally to all managed routes and pomerium's authenticate
+                  service. See <a href="https://www.pomerium.com/docs/reference/set-response-headers">Set
+                  Response Headers</a>
                 type: object
               storage:
                 description: Storage defines persistent storage for sessions and other


### PR DESCRIPTION
## Summary

Was incorrectly called _request_ headers. 

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
