### PR TITLE
fix manifests, fix publish docs action

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           source_folder: "reference.md"
           destination_repo: "pomerium/documentation"
-          destination_folder: "content/docs/deploying/k8s"
+          destination_folder: "content/docs/deploy/k8s"
           destination_base_branch: "main"
           destination_head_branch: update-k8s-reference-${{ github.sha }}
           user_email: "dmishin@pomerium.com"

--- a/config/crd/bases/ingress.pomerium.io_pomerium.yaml
+++ b/config/crd/bases/ingress.pomerium.io_pomerium.yaml
@@ -105,6 +105,10 @@ spec:
                   sameSite:
                     description: SameSite sets the SameSite option for cookies. Defaults
                       to <code></code>.
+                    enum:
+                    - strict
+                    - lax
+                    - none
                     type: string
                   secure:
                     description: Secure if set to false, would make a cookie accessible
@@ -299,6 +303,30 @@ spec:
                     required:
                     - secret
                     type: object
+                type: object
+              timeouts:
+                description: Timeout specifies the <a href="https://www.pomerium.com/docs/reference/global-timeouts">global
+                  timeouts</a> for all routes.
+                properties:
+                  idle:
+                    description: Idle specifies the time at which a downstream or
+                      upstream connection will be terminated if there are no active
+                      streams.
+                    format: duration
+                    type: string
+                  read:
+                    description: Read specifies the amount of time for the entire
+                      request stream to be received from the client.
+                    format: duration
+                    type: string
+                  write:
+                    description: Write specifies max stream duration is the maximum
+                      time that a stream’s lifetime will span. An HTTP request/response
+                      exchange fully consumes a single stream. Therefore, this value
+                      must be greater than read_timeout as it covers both request
+                      and response time.
+                    format: duration
+                    type: string
                 type: object
             required:
             - secrets

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -113,6 +113,10 @@ spec:
                   sameSite:
                     description: SameSite sets the SameSite option for cookies. Defaults
                       to <code></code>.
+                    enum:
+                    - strict
+                    - lax
+                    - none
                     type: string
                   secure:
                     description: Secure if set to false, would make a cookie accessible
@@ -307,6 +311,30 @@ spec:
                     required:
                     - secret
                     type: object
+                type: object
+              timeouts:
+                description: Timeout specifies the <a href="https://www.pomerium.com/docs/reference/global-timeouts">global
+                  timeouts</a> for all routes.
+                properties:
+                  idle:
+                    description: Idle specifies the time at which a downstream or
+                      upstream connection will be terminated if there are no active
+                      streams.
+                    format: duration
+                    type: string
+                  read:
+                    description: Read specifies the amount of time for the entire
+                      request stream to be received from the client.
+                    format: duration
+                    type: string
+                  write:
+                    description: Write specifies max stream duration is the maximum
+                      time that a stream’s lifetime will span. An HTTP request/response
+                      exchange fully consumes a single stream. Therefore, this value
+                      must be greater than read_timeout as it covers both request
+                      and response time.
+                    format: duration
+                    type: string
                 type: object
             required:
             - secrets


### PR DESCRIPTION
## Summary

Apparently some earlier PR did not re-generate manifests. 
Also, auto-update PRs to `pomerium/documentation` repo were failing due to path reorg there. 

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
