### PR TITLE
ci: increase yarn network timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ internal/ui:
 
 internal/ui/node_modules: internal/ui
 	@echo "@==> $@"
-	@cd internal/ui && yarn install --network-timeout 120000
+	@cd internal/ui && yarn install --network-timeout 1000000
 
 .PHONY: pomerium-ui
 pomerium-ui: internal/ui/dist/index.js


### PR DESCRIPTION
## Summary

Increases yarn install timeout to ~16 mins, as it frequently times out in GitHub actions. 

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
