### PR TITLE
fix nil reference in timeouts section

### DIFF
--- a/pomerium/config.go
+++ b/pomerium/config.go
@@ -81,9 +81,15 @@ func applyTimeouts(_ context.Context, p *pb.Config, c *model.Config) error {
 	if tm.Read != nil && tm.Write != nil && tm.Read.Duration >= tm.Write.Duration {
 		return fmt.Errorf("read timeout (%s) must be less than write timeout (%s)", tm.Read.Duration, tm.Write.Duration)
 	}
-	p.Settings.TimeoutIdle = durationpb.New(tm.Idle.Duration)
-	p.Settings.TimeoutRead = durationpb.New(tm.Read.Duration)
-	p.Settings.TimeoutWrite = durationpb.New(tm.Write.Duration)
+	if tm.Idle != nil {
+		p.Settings.TimeoutIdle = durationpb.New(tm.Idle.Duration)
+	}
+	if tm.Read != nil {
+		p.Settings.TimeoutRead = durationpb.New(tm.Read.Duration)
+	}
+	if tm.Write != nil {
+		p.Settings.TimeoutWrite = durationpb.New(tm.Write.Duration)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes potential nil reference in new `timeouts` CRD section.

## Related issues

Fixes https://github.com/pomerium/pomerium/issues/4587

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
