### PR TITLE
Prometheus Resources as Kustomize Component

### DIFF
--- a/config/components/prometheus/kustomization.yaml
+++ b/config/components/prometheus/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+- ../../prometheus


### PR DESCRIPTION
## Summary

Adds support for prometheus resources to be composed into a pomerium deployment using the kustomize `components` feature.  

## Background

The current resources can be composed as kustomize `resources`

```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
- https://github.com/pomerium/ingress-controller.git/config/default?ref=v0.23.0
- https://github.com/pomerium/ingress-controller.git/config/prometheus?ref=v0.23.0
```

However [flux kustomizations](https://fluxcd.io/flux/components/kustomize/kustomizations/) only support one path which requires users to deploy two such objects.

Also, some users prefer not to use remote kustomize bases.

## Use Cases

Kustomize local or remote bases:

```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
- https://github.com/pomerium/ingress-controller.git/config/default?ref=<newtag>
components:
- https://github.com/pomerium/ingress-controller.git/config/components/prometheus?ref=<newtag>
```

Flux [kustomization](https://fluxcd.io/flux/components/kustomize/kustomizations/#components):

```
apiVersion: source.toolkit.fluxcd.io/v1
kind: GitRepository
metadata:
  name: pomerium-ingress-controller
spec:
  ref:
    tag: <newtag>
  url: https://github.com/pomerium/ingress-controller.git
---
apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
kind: Kustomization
metadata:
  name: pomerium-ingress-controller
spec:
  sourceRef:
    kind: GitRepository
    name: pomerium-ingress-controller
  path: config/default
  components:
  - ../components/prometheus
```

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
