### PR TITLE
ci: fetch envoy before generate step

### DIFF
--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -40,12 +40,12 @@ jobs:
 
       - name: Build
         run: |
-          make pomerium-ui envoy generate fmt vet
-          for arch in amd64 arm64; do
-            mkdir -p bin-$arch
-            TARGET=linux-$arch scripts/get-envoy.bash
-            GOARCH=$arch go build -tags embed_pomerium -o bin-$arch/manager main.go
-          done
+          TARGET=linux-amd64 scripts/get-envoy.bash
+          TARGET=linux-arm64 scripts/get-envoy.bash
+          make pomerium-ui generate fmt vet
+          mkdir -p bin-amd64 bin-arm64
+          GOARCH=amd64 go build -tags embed_pomerium -o bin-amd64/manager main.go
+          GOARCH=arm64 go build -tags embed_pomerium -o bin-arm64/manager main.go
 
       - name: Docker Publish - Main
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build
         run: |
-          make pomerium-ui generate fmt vet
+          make pomerium-ui envoy generate fmt vet
           for arch in amd64 arm64; do
             mkdir -p bin-$arch
             TARGET=linux-$arch scripts/get-envoy.bash

--- a/.github/workflows/docker-version-branches.yaml
+++ b/.github/workflows/docker-version-branches.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build
         run: |
-          make pomerium-ui generate fmt vet
+          make pomerium-ui envoy generate fmt vet
           for arch in amd64 arm64; do
             mkdir -p bin-$arch
             TARGET=linux-$arch scripts/get-envoy.bash

--- a/.github/workflows/docker-version-branches.yaml
+++ b/.github/workflows/docker-version-branches.yaml
@@ -43,12 +43,12 @@ jobs:
 
       - name: Build
         run: |
-          make pomerium-ui envoy generate fmt vet
-          for arch in amd64 arm64; do
-            mkdir -p bin-$arch
-            TARGET=linux-$arch scripts/get-envoy.bash
-            GOARCH=$arch go build -tags embed_pomerium -o bin-$arch/manager main.go
-          done
+          TARGET=linux-amd64 scripts/get-envoy.bash
+          TARGET=linux-arm64 scripts/get-envoy.bash
+          make pomerium-ui generate fmt vet
+          mkdir -p bin-amd64 bin-arm64
+          GOARCH=amd64 go build -tags embed_pomerium -o bin-amd64/manager main.go
+          GOARCH=arm64 go build -tags embed_pomerium -o bin-arm64/manager main.go
 
       - name: Docker Publish - Version Branches
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09


### PR DESCRIPTION
## Summary

https://github.com/pomerium/ingress-controller/pull/778 was not correct.

The `make generate` step depends on the pomerium/envoy package, which in turn needs a set of Envoy binary/checksum/version files.

## Related issues

- https://github.com/pomerium/ingress-controller/issues/776

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
