### PR TITLE
make: update docker-build target

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,8 +78,6 @@ jobs:
         with:
           go-version: 1.21.x
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
-        with:
-          fetch-depth: 0
       - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
         with:
           path: |
@@ -100,7 +98,5 @@ jobs:
       labels: linux
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
-        with:
-          fetch-depth: 0
       - name: build
-        run: docker build .
+        run: make docker-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,7 @@
-# Build the manager binary
-# make sure to run `make clean` if building locally
-
-FROM golang:1.21.3-bookworm@sha256:d0214956a9c50c300e430c1f6c0a820007ace238e5242c53762e61b344659e05 as go-modules
-
-WORKDIR /workspace
-
-COPY go.mod go.mod
-COPY go.sum go.sum
-COPY scripts scripts
-COPY Makefile Makefile
-
-RUN mkdir -p pomerium/envoy/bin
-RUN make envoy
-RUN go mod download
-
-COPY Makefile ./Makefile
-
-# download ui dependencies from core module
-RUN mkdir -p internal
-RUN make internal/ui
-
-FROM node:lts-bookworm@sha256:42a4d97d4abf2f278c323370cf9c8dbccc2a238acceebceb53711926ecfb4110 as ui
-WORKDIR /workspace
-
-COPY --from=go-modules /workspace/internal/ui ./
-RUN yarn install --network-timeout 1000000
-RUN yarn build
-
-FROM go-modules as go-builder
-WORKDIR /workspace
-
-# Copy the go source
-COPY . .
-
-COPY --from=ui /workspace/dist ./internal/ui/dist
-
-# Build
-RUN CGO_ENABLED=0 make build-go
-
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/base-debian12:debug-nonroot@sha256:d53efe9604cae04e8c02df63e3b22040c64e2db505e0074325a6bc1b710a0ada
-WORKDIR /
-COPY --from=go-builder /workspace/bin/manager .
+COPY bin/manager /manager
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,6 +1,6 @@
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:debug-nonroot@sha256:6691be59b27dde70a2cec7b9794096b8bbf63eec7685062c06e327d1f06a773e
+FROM gcr.io/distroless/base-debian12:debug-nonroot@sha256:d53efe9604cae04e8c02df63e3b22040c64e2db505e0074325a6bc1b710a0ada
 ARG TARGETARCH
 COPY bin-$TARGETARCH/manager /manager
 USER 65532:65532

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	@go run $(GOTAGS) ./main.go
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+docker-build: build test ## Build docker image with the manager.
 	@echo "==> $@"
 	@docker build -t ${IMG} .
 


### PR DESCRIPTION
## Summary

Update the Makefile 'docker-build' target to build the same way as the GitHub Actions release workflows (i.e. build the Go binary first, apart from Docker). Update the GitHub Actions 'test' workflow to use the docker-build target for its build-docker job.

Update the Dockerfile.ci base image to match the main Dockerfile.

## Related issues

- #804 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
