### PR TITLE
docs: update pass identity headers reference link

### DIFF
--- a/apis/ingress/v1/pomerium_types.go
+++ b/apis/ingress/v1/pomerium_types.go
@@ -282,7 +282,7 @@ type PomeriumSpec struct {
 	// AuthorizeLogFields sets the <a href="https://www.pomerium.com/docs/reference/authorize-log-fields">authorize fields</a> to log.
 	AuthorizeLogFields *[]string `json:"authorizeLogFields,omitempty"`
 
-	// PassIdentityHeaders sets the <a href="https://www.pomerium.com/docs/reference/routes/pass-identity-headers">pass identity headers</a> option.
+	// PassIdentityHeaders sets the <a href="https://www.pomerium.com/docs/reference/pass-identity-headers">pass identity headers</a> option.
 	PassIdentityHeaders *bool `json:"passIdentityHeaders,omitempty"`
 }
 

--- a/config/crd/bases/ingress.pomerium.io_pomerium.yaml
+++ b/config/crd/bases/ingress.pomerium.io_pomerium.yaml
@@ -215,7 +215,7 @@ spec:
                   Getting User Identity</a> guide.
                 type: object
               passIdentityHeaders:
-                description: PassIdentityHeaders sets the <a href="https://www.pomerium.com/docs/reference/routes/pass-identity-headers">pass
+                description: PassIdentityHeaders sets the <a href="https://www.pomerium.com/docs/reference/pass-identity-headers">pass
                   identity headers</a> option.
                 type: boolean
               programmaticRedirectDomains:

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -223,7 +223,7 @@ spec:
                   Getting User Identity</a> guide.
                 type: object
               passIdentityHeaders:
-                description: PassIdentityHeaders sets the <a href="https://www.pomerium.com/docs/reference/routes/pass-identity-headers">pass
+                description: PassIdentityHeaders sets the <a href="https://www.pomerium.com/docs/reference/pass-identity-headers">pass
                   identity headers</a> option.
                 type: boolean
               programmaticRedirectDomains:


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

- https://github.com/pomerium/pomerium/issues/4197

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
