### PR TITLE
ci: use standard runners

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -9,8 +9,7 @@ on:
 
 jobs:
   backport:
-    runs-on:
-      group: ubuntu-latest
+    runs-on: ubuntu-latest
     name: Backport
     steps:
       - name: Generate token

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -10,8 +10,7 @@ on:
 jobs:
   backport:
     runs-on:
-      group: large-runners
-      labels: linux
+      group: ubuntu-latest
     name: Backport
     steps:
       - name: Generate token

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -9,8 +9,7 @@ on:
 jobs:
   publish:
     runs-on:
-      group: large-runners
-      labels: linux
+      group: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -8,8 +8,7 @@ on:
 
 jobs:
   publish:
-    runs-on:
-      group: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608

--- a/.github/workflows/docker-version-branches.yaml
+++ b/.github/workflows/docker-version-branches.yaml
@@ -9,8 +9,7 @@ on:
 jobs:
   publish:
     runs-on:
-      group: large-runners
-      labels: linux
+      group: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608

--- a/.github/workflows/docker-version-branches.yaml
+++ b/.github/workflows/docker-version-branches.yaml
@@ -8,8 +8,7 @@ on:
 
 jobs:
   publish:
-    runs-on:
-      group: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,8 +7,7 @@ on:
 jobs:
   pull-request:
     runs-on:
-      group: large-runners
-      labels: linux
+      group: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,8 +6,7 @@ on:
 
 jobs:
   pull-request:
-    runs-on:
-      group: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on:
-      group: ubuntu-latest
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
@@ -33,8 +32,7 @@ jobs:
           SKIP: go-mod-tidy,lint
 
   test:
-    runs-on:
-      group: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
@@ -68,8 +66,7 @@ jobs:
         run: make test
 
   build:
-    runs-on:
-      group: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
@@ -90,8 +87,7 @@ jobs:
           make build
 
   build-docker:
-    runs-on:
-      group: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - name: build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,8 +10,7 @@ on:
 jobs:
   pre-commit:
     runs-on:
-      group: large-runners
-      labels: linux
+      group: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
@@ -35,8 +34,7 @@ jobs:
 
   test:
     runs-on:
-      group: large-runners
-      labels: linux
+      group: ubuntu-latest
     steps:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
@@ -71,8 +69,7 @@ jobs:
 
   build:
     runs-on:
-      group: large-runners
-      labels: linux
+      group: ubuntu-latest
     steps:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
@@ -94,8 +91,7 @@ jobs:
 
   build-docker:
     runs-on:
-      group: large-runners
-      labels: linux
+      group: ubuntu-latest
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - name: build


### PR DESCRIPTION
## Summary

As we now mostly build outside of docker, we should probably no longer need large runners. 
this PR switches actions back to standard runners. 

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
