### PR TITLE
ci: set pomerium core version

### DIFF
--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -37,13 +37,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build
-        run: |
-          TARGET=linux-amd64 scripts/get-envoy.bash
-          TARGET=linux-arm64 scripts/get-envoy.bash
-          make pomerium-ui generate fmt vet
-          mkdir -p bin-amd64 bin-arm64
-          GOARCH=amd64 go build -tags embed_pomerium -o bin-amd64/manager main.go
-          GOARCH=arm64 go build -tags embed_pomerium -o bin-arm64/manager main.go
+        run: make build-ci
 
       - name: Docker Publish - Main
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56

--- a/.github/workflows/docker-version-branches.yaml
+++ b/.github/workflows/docker-version-branches.yaml
@@ -40,13 +40,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build
-        run: |
-          TARGET=linux-amd64 scripts/get-envoy.bash
-          TARGET=linux-arm64 scripts/get-envoy.bash
-          make pomerium-ui generate fmt vet
-          mkdir -p bin-amd64 bin-arm64
-          GOARCH=amd64 go build `make version-flags` -tags embed_pomerium -o bin-amd64/manager main.go
-          GOARCH=arm64 go build `make version-flags` -tags embed_pomerium -o bin-arm64/manager main.go
+        run: make build-ci
 
       - name: Docker Publish - Version Branches
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56

--- a/.github/workflows/docker-version-branches.yaml
+++ b/.github/workflows/docker-version-branches.yaml
@@ -45,8 +45,8 @@ jobs:
           TARGET=linux-arm64 scripts/get-envoy.bash
           make pomerium-ui generate fmt vet
           mkdir -p bin-amd64 bin-arm64
-          GOARCH=amd64 go build -tags embed_pomerium -o bin-amd64/manager main.go
-          GOARCH=arm64 go build -tags embed_pomerium -o bin-arm64/manager main.go
+          GOARCH=amd64 go build `make version-flags` -tags embed_pomerium -o bin-amd64/manager main.go
+          GOARCH=arm64 go build `make version-flags` -tags embed_pomerium -o bin-arm64/manager main.go
 
       - name: Docker Publish - Version Branches
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,7 +2,7 @@
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/base-debian12:debug-nonroot@sha256:8548e3041a2cc583998c6a6beabf13ae93e6b006a5f6a6194966b4327ea741f5
 ARG TARGETARCH
-COPY bin-$TARGETARCH/manager /manager
+COPY bin/manager-linux-$TARGETARCH /manager
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## Summary

Previously, we did not set corresponding Pomerium Core version, that caused it to be rendered as 
`v0.0.0` in other applications when built as Ingress Controller.

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Fixes #855 


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
