### PR TITLE
ci: add setup-go action to build-docker job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,6 +89,9 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+        with:
+          go-version: 1.21.x
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - name: build
         run: make docker-build


### PR DESCRIPTION
## Summary

Make sure to install the particular version of Go we want to use, rather than the system default for ubuntu-latest.

(Pomerium Core now requires Go 1.21.)

## Related issues

- https://github.com/pomerium/ingress-controller/pull/860#issuecomment-1881532428

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
