### PR TITLE
make github actions use go 1.21

### DIFF
--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -15,6 +15,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+        with:
+          go-version: 1.21.x
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@9dc751fe249ad99385a2583ee0d084c400eee04e

--- a/.github/workflows/docker-version-branches.yaml
+++ b/.github/workflows/docker-version-branches.yaml
@@ -15,6 +15,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+        with:
+          go-version: 1.21.x
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@9dc751fe249ad99385a2583ee0d084c400eee04e

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Setup Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+        with:
+          go-version: 1.21.x
+
       - name: Build
         run: make build-ci
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,13 +85,3 @@ jobs:
       - name: build
         run: |
           make build
-
-  build-docker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
-        with:
-          go-version: 1.21.x
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
-      - name: build
-        run: make docker-build


### PR DESCRIPTION
## Summary

Update GitHub actions to use Go 1.21

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Fixes https://github.com/pomerium/ingress-controller/issues/862

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
