### PR TITLE
set docker image target to v0.25.0

### DIFF
--- a/config/pomerium/deployment/image.yaml
+++ b/config/pomerium/deployment/image.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
         - name: pomerium
-          image: pomerium/ingress-controller:main
-          imagePullPolicy: Always
+          image: pomerium/ingress-controller:v0.25.0
+          imagePullPolicy: IfNotPresent

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -603,8 +603,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: pomerium/ingress-controller:main
-        imagePullPolicy: Always
+        image: pomerium/ingress-controller:v0.25.0
+        imagePullPolicy: IfNotPresent
         name: pomerium
         ports:
         - containerPort: 8443


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
