### PR TITLE
docker: use distroless noroot user/group

### DIFF
--- a/config/pomerium/deployment/no-root.yaml
+++ b/config/pomerium/deployment/no-root.yaml
@@ -12,5 +12,5 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
-            runAsGroup: 1000
-            runAsUser: 1000
+            runAsGroup: 65532
+            runAsUser: 65532

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -622,9 +622,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsGroup: 1000
+          runAsGroup: 65532
           runAsNonRoot: true
-          runAsUser: 1000
+          runAsUser: 65532
         volumeMounts:
         - mountPath: /tmp
           name: tmp


### PR DESCRIPTION
## Summary

Uses `noroot` user and group from `distroless` base image. 

## Related issues

Fixes https://github.com/pomerium/internal/issues/1685

<!-- For example...
Fixes #159
-->


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
