### PR TITLE
ci: upgrade Go to 1.22

### DIFF
--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/docker-version-branches.yaml
+++ b/.github/workflows/docker-version-branches.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: generate docs
         run: make docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
           cache: false
 
       - run: make envoy

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Build
         run: make build-ci

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
         with:
           python-version: "3.x"
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: set env vars
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.21.3
+golang 1.22.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pomerium/ingress-controller
 
-go 1.21
+go 1.22
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1


### PR DESCRIPTION
## Summary

Upgrades Go to 1.22

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Related: https://github.com/pomerium/internal/issues/1731

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
