### PR TITLE
Support for empty host in ingress rules (#941)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v0.64.1
+	github.com/pomerium/csrf v1.7.0
 	github.com/pomerium/pomerium v0.25.1-0.20240501190122-e30d90206df9
 	github.com/rs/zerolog v1.32.0
 	github.com/sergi/go-diff v1.3.1
@@ -154,7 +155,6 @@ require (
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/pomerium/csrf v1.7.0 // indirect
 	github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 // indirect
 	github.com/pomerium/webauthn v0.0.0-20221118023040-00a9c430578b // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/model/ingress_config.go
+++ b/model/ingress_config.go
@@ -32,6 +32,9 @@ const (
 	UseServiceProxy = "service_proxy_upstream"
 	// TCPUpstream indicates this route is a TCP service https://www.pomerium.com/docs/tcp/
 	TCPUpstream = "tcp_upstream"
+	// SubtleAllowEmptyHost is a required annotation when creating an ingress containing
+	// rules with an empty (catch-all) host, as it can cause unexpected behavior
+	SubtleAllowEmptyHost = "subtle_allow_empty_host"
 	// KubernetesServiceAccountTokenSecret allows k8s service authentication via pomerium
 	//nolint: gosec
 	KubernetesServiceAccountTokenSecret = "kubernetes_service_account_token_secret"

--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -75,6 +75,7 @@ var (
 		model.SecureUpstream,
 		model.TCPUpstream,
 		model.UseServiceProxy,
+		model.SubtleAllowEmptyHost,
 	})
 	unsupported = map[string]string{
 		"allowed_groups": "https://docs.pomerium.com/docs/overview/upgrading#idp-directory-sync",

--- a/pomerium/ingress_to_route.go
+++ b/pomerium/ingress_to_route.go
@@ -95,7 +95,8 @@ func ruleToRoute(rule networkingv1.IngressRule, tmpl *pb.Route, ic *model.Ingres
 		if ic.IsAnnotationSet(model.SubtleAllowEmptyHost) {
 			rule.Host = "*"
 		} else {
-			return nil, fmt.Errorf("ingress rule has empty host; if this is intentional, set the annotation '%s/%s=true'", ic.AnnotationPrefix, model.SubtleAllowEmptyHost)
+			return nil, fmt.Errorf("ingress rule has empty host; if this is intentional, set the annotation '%s/%s=true'",
+				ic.AnnotationPrefix, model.SubtleAllowEmptyHost)
 		}
 	}
 

--- a/pomerium/ingress_to_route.go
+++ b/pomerium/ingress_to_route.go
@@ -92,7 +92,11 @@ func defaultBackend(tmpl *pb.Route, ic *model.IngressConfig) (*pb.Route, error) 
 
 func ruleToRoute(rule networkingv1.IngressRule, tmpl *pb.Route, ic *model.IngressConfig) ([]*pb.Route, error) {
 	if rule.Host == "" {
-		return nil, errors.New("host is required")
+		if ic.IsAnnotationSet(model.SubtleAllowEmptyHost) {
+			rule.Host = "*"
+		} else {
+			return nil, fmt.Errorf("ingress rule has empty host; if this is intentional, set the annotation '%s/%s=true'", ic.AnnotationPrefix, model.SubtleAllowEmptyHost)
+		}
 	}
 
 	if rule.HTTP == nil {

--- a/pomerium/routes_test.go
+++ b/pomerium/routes_test.go
@@ -1377,5 +1377,6 @@ func TestEmptyHostRoute(t *testing.T) {
 
 	clear(ic.Annotations)
 
-	require.Error(t, upsertRoutes(context.Background(), &config, ic))
+	require.ErrorContains(t, upsertRoutes(context.Background(), &config, ic),
+		"ingress rule has empty host")
 }

--- a/pomerium/routes_test.go
+++ b/pomerium/routes_test.go
@@ -1289,3 +1289,93 @@ func TestEndpointsHTTPS(t *testing.T) {
 		})
 	}
 }
+
+func TestEmptyHostRoute(t *testing.T) {
+	pathTypePrefix := networkingv1.PathTypePrefix
+	ic := &model.IngressConfig{
+		AnnotationPrefix: "p",
+		Ingress: &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ingress",
+				Namespace: "default",
+				Annotations: map[string]string{
+					fmt.Sprintf("p/%s", model.SubtleAllowEmptyHost): "true",
+				},
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{
+					{
+						Host: "",
+						IngressRuleValue: networkingv1.IngressRuleValue{
+							HTTP: &networkingv1.HTTPIngressRuleValue{
+								Paths: []networkingv1.HTTPIngressPath{
+									{
+										Path:     "/foo",
+										PathType: &pathTypePrefix,
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: "service",
+												Port: networkingv1.ServiceBackendPort{
+													Name: "http",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Endpoints: map[types.NamespacedName]*corev1.Endpoints{
+			{Name: "service", Namespace: "default"}: {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service",
+					Namespace: "default",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
+						Ports:     []corev1.EndpointPort{{Name: "http", Port: 80}},
+					},
+				},
+			},
+		},
+		Services: map[types.NamespacedName]*corev1.Service{
+			{Name: "service", Namespace: "default"}: {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Protocol:   corev1.ProtocolTCP,
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var config pb.Config
+	require.NoError(t, upsertRoutes(context.Background(), &config, ic))
+	routes, err := routeList(config.Routes).toMap()
+	require.NoError(t, err)
+	route := routes[routeID{
+		Name:      "ingress",
+		Namespace: "default",
+		Host:      "*",
+		Path:      "/foo",
+	}]
+	require.NotNil(t, route, "route not found in %v", routes)
+	require.Equal(t, "https://*", route.From)
+
+	clear(ic.Annotations)
+
+	require.Error(t, upsertRoutes(context.Background(), &config, ic))
+}


### PR DESCRIPTION
## Summary

This adds support for empty host values in ingress rules, which act as wildcards and will match any hostname (or IP address).

There are many cases where an ingress configured this way can cause destructive or unintended behavior. Because it is very easy to (perhaps mistakenly) omit the host field in an ingress rule, the special annotation `ingress.pomerium.io/subtle_allow_empty_host: "true"` must be added to any ingress object containing rules with empty host fields.

## Related issues

Closes #941 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
