### PR TITLE
deps: exclude core from auto update

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -29,6 +29,7 @@ updates:
           - "*"
         exclude-patterns:
           - "*k8s.io*"
+          - "github.com/pomerium/pomerium"
       k8s:
         patterns:
           - "*k8s.io*"


### PR DESCRIPTION
## Summary

We want IC `main` to generally track `main` in core, and often updates are synchronized to reflect any changes in core. 
This PR excludes pomerium/pomerium from dependabot Go group updates.

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
