### PR TITLE
ci: add daily check for core update

### DIFF
--- a/.github/workflows/update-core.yaml
+++ b/.github/workflows/update-core.yaml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
-        with:
-          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
@@ -26,10 +24,10 @@ jobs:
           git config --global user.email "apparitor@users.noreply.github.com"
           git config --global user.name "GitHub Actions"
           git add go.mod go.sum
-          git diff --cached --exit-code || echo "::set-output name=changed::true"
+          git diff --cached --exit-code || echo echo "changed=true" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
-        if: steps.git-diff.outputs.changed == 'true'
+        if: ${{ steps.git-diff.outputs.changed }} == 'true'
         uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e
         with:
           author: GitHub Actions <apparitor@users.noreply.github.com>

--- a/.github/workflows/update-core.yaml
+++ b/.github/workflows/update-core.yaml
@@ -2,7 +2,8 @@ name: Update Core to Latest Commit
 
 on:
   schedule:
-    - cron: '0 0 * * *' # every day at midnight
+    - cron: '40 1 * * *'
+  workflow_dispatch:
 
 jobs:
   update-pomerium-core:
@@ -24,7 +25,7 @@ jobs:
           git config --global user.email "apparitor@users.noreply.github.com"
           git config --global user.name "GitHub Actions"
           git add go.mod go.sum
-          git diff --cached --exit-code || echo echo "changed=true" >> $GITHUB_OUTPUT
+          git diff --cached --exit-code || echo "changed=true" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         if: ${{ steps.git-diff.outputs.changed }} == 'true'

--- a/.github/workflows/update-core.yaml
+++ b/.github/workflows/update-core.yaml
@@ -1,0 +1,43 @@
+name: Update Core to Latest Commit
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # every day at midnight
+
+jobs:
+  update-pomerium-core:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+        with:
+          go-version: 1.22.x
+      - name: Update Core
+        run: |
+          go get -u github.com/pomerium/pomerium@main
+          go mod tidy
+      - name: Check for changes
+        id: git-diff
+        run: |
+          git config --global user.email "apparitor@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
+          git add go.mod go.sum
+          git diff --cached --exit-code || echo "::set-output name=changed::true"
+
+      - name: Create Pull Request
+        if: steps.git-diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e
+        with:
+          author: GitHub Actions <apparitor@users.noreply.github.com>
+          body: "This PR updates the Pomerium Core to the latest commit in main"
+          branch-suffix: random
+          branch: ci/update-core
+          commit-message: "ci: update core to latest commit in main"
+          delete-branch: true
+          labels: ci
+          title: "ci: update core to latest commit in main"
+          token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a daily job for Ingress Controller `main` to track `main` in Core.

That way, users who are testing latest IC `main` would also test all changes that are committed to `pomerium/pomerium`.

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
