### PR TITLE
ci: update docs script destination path

### DIFF
--- a/scripts/open-docs-pull-request.sh
+++ b/scripts/open-docs-pull-request.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 source_path="reference.md"
 destination_repo="pomerium/documentation"
-destination_path="content/docs/deploy/k8s"
+destination_path="content/docs/k8s"
 destination_base_branch="main"
 destination_head_branch="update-k8s-reference-$GITHUB_SHA"
 


### PR DESCRIPTION
## Summary

The k8s reference.md file was moved in https://github.com/pomerium/documentation/pull/1439. Update the open-docs-pull-request.sh script accordingly.

## Related issues

n/a

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
