### PR TITLE
ci: run prettier before opening docs PR

### DIFF
--- a/scripts/open-docs-pull-request.sh
+++ b/scripts/open-docs-pull-request.sh
@@ -18,6 +18,7 @@ git clone --depth 1 \
 echo "Copying contents to git repo"
 cp -R "$source_path" "$clone_dir/$destination_path"
 cd "$clone_dir"
+yarn && yarn prettier --write "$destination_path/$source_path"
 git checkout -b "$destination_head_branch"
 
 if [ -z "$(git status -z)" ]; then


### PR DESCRIPTION
## Summary

There is a GitHub Actions workflow to generate the docs page https://www.pomerium.com/docs/k8s/reference. This workflow is currently opening spurious PRs due to formatting differences. If we run `prettier` first we should be able to match the existing formatting in the documentation repo, which will hopefully avoid this issue.

## Related issues

- https://github.com/pomerium/ingress-controller/issues/695


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
