### PR TITLE
ci: avoid opening multiple "update core" PRs

### DIFF
--- a/.github/workflows/update-core.yaml
+++ b/.github/workflows/update-core.yaml
@@ -33,7 +33,6 @@ jobs:
         with:
           author: GitHub Actions <apparitor@users.noreply.github.com>
           body: "This PR updates the Pomerium Core to the latest commit in main"
-          branch-suffix: random
           branch: ci/update-core
           commit-message: "ci: update core to latest commit in main"
           delete-branch: true


### PR DESCRIPTION
## Summary

Avoid opening multiple "ci: update core to latest commit in main" PRs.

This is the configuration recommended at https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#action-behaviour.

## Related issues

- https://github.com/pomerium/internal/issues/1851

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
