### PR TITLE
deployment: set proxy service externalTrafficPolicy: Local

### DIFF
--- a/config/pomerium/service/proxy.yaml
+++ b/config/pomerium/service/proxy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: pomerium-proxy
 spec:
   type: LoadBalancer
+  externalTrafficPolicy: Local
   ports:
     - port: 443
       targetPort: https

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -568,6 +568,7 @@ metadata:
   name: pomerium-proxy
   namespace: pomerium
 spec:
+  externalTrafficPolicy: Local
   ports:
   - name: https
     port: 443


### PR DESCRIPTION
## Summary

Sets `externalTrafficPolicy: Local` to the `pomerium-proxy` `Service` so that Pomerium is able to capture the client IP address. 

## Related issues

Related: https://github.com/pomerium/pomerium/issues/5265

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
