### PR TITLE
ci: remove 'make lint' step from Test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,9 +58,6 @@ jobs:
             ~/Library/Caches/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
-      - name: Lint
-        if: runner.os == 'Linux'
-        run: make lint
       - name: test
         if: runner.os == 'Linux'
         run: make test


### PR DESCRIPTION
## Summary

There is a separate Lint workflow, so let's not run a duplicate lint step in the Test workflow.

## Related issues

- https://github.com/pomerium/ingress-controller/issues/1042


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
