### PR TITLE
ingress-controller/config: support go durations in annotations

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -19,7 +19,7 @@ words:
   - sslkey
   - sslrootcert
   - uifs
-  - unmarshalled
+  - unmarshaled
   - upsert
 languageSettings:
   - languageId: go

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -7,18 +7,20 @@ words:
   - databroker
   - deepcopy
   - envtest
+  - filemgr
   - mockgen
+  - oidc
   - pomerium
   - protobuf
-  - oidc
+  - protojson
   - readyz
   - sharedkey
   - sslcert
   - sslkey
   - sslrootcert
-  - upsert
   - uifs
-  - filemgr
+  - unmarshalled
+  - upsert
 languageSettings:
   - languageId: go
     allowCompoundWords: false

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v0.69.0
+	github.com/pomerium/csrf v1.7.0
 	github.com/pomerium/pomerium v0.27.1-0.20241004190459-6f6186a67da2
 	github.com/rs/zerolog v1.33.0
 	github.com/sergi/go-diff v1.3.1
@@ -159,7 +160,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/pomerium/csrf v1.7.0 // indirect
 	github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 // indirect
 	github.com/pomerium/webauthn v0.0.0-20240603205124-0428df511172 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect

--- a/pomerium/proto.go
+++ b/pomerium/proto.go
@@ -3,6 +3,7 @@ package pomerium
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"google.golang.org/protobuf/encoding/protojson"
@@ -32,9 +33,7 @@ func unmarshalAnnotations(dst proto.Message, kvs map[string]string) error {
 		return err
 	}
 
-	return (&protojson.UnmarshalOptions{
-		DiscardUnknown: false,
-	}).Unmarshal(data, dst)
+	return protojson.Unmarshal(data, dst)
 }
 
 func preprocessAnnotationMessage(md protoreflect.MessageDescriptor, data any) any {
@@ -109,11 +108,6 @@ func goDurationStringToProtoJSONDurationString(in string) string {
 		return in
 	}
 
-	var str string
-	err = json.Unmarshal(bs, &str)
-	if err != nil {
-		return in
-	}
-
+	str := strings.Trim(string(bs), `"`)
 	return str
 }

--- a/pomerium/proto.go
+++ b/pomerium/proto.go
@@ -1,0 +1,119 @@
+package pomerium
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"gopkg.in/yaml.v3"
+)
+
+func unmarshalAnnotations(dst proto.Message, kvs map[string]string) error {
+	// first convert the map[string]string to a map[string]any via yaml
+	src := make(map[string]any, len(kvs))
+	for k, v := range kvs {
+		var out any
+		if err := yaml.Unmarshal([]byte(v), &out); err != nil {
+			return fmt.Errorf("%s: %w", k, err)
+		}
+		src[k] = out
+	}
+
+	// pre-process the json to handle custom formats
+	preprocessAnnotationMessage(dst.ProtoReflect().Descriptor(), src)
+
+	// marshal as json so it can be unmarshalled via protojson
+	data, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+
+	return (&protojson.UnmarshalOptions{
+		DiscardUnknown: false,
+	}).Unmarshal(data, dst)
+}
+
+func preprocessAnnotationMessage(md protoreflect.MessageDescriptor, data any) any {
+	switch md.FullName() {
+	case "google.protobuf.Duration":
+		// convert go duration strings into protojson duration strings
+		if v, ok := data.(string); ok {
+			return goDurationStringToProtoJSONDurationString(v)
+		}
+	default:
+		// preprocess all the fields
+		if v, ok := data.(map[string]any); ok {
+			fds := md.Fields()
+			for i := 0; i < fds.Len(); i++ {
+				fd := fds.Get(i)
+				name := string(fd.Name())
+				vv, ok := v[name]
+				if ok {
+					v[name] = preprocessAnnotationField(fd, vv)
+				}
+			}
+			return v
+		}
+	}
+	return data
+}
+
+func preprocessAnnotationField(fd protoreflect.FieldDescriptor, data any) any {
+	// if this is a repeated field, handle each of the field values separately
+	if fd.IsList() {
+		vs, ok := data.([]any)
+		if ok {
+			nvs := make([]any, len(vs))
+			for i, v := range vs {
+				nvs[i] = preprocessAnnotationFieldValue(fd, v)
+			}
+			return nvs
+		}
+	}
+
+	return preprocessAnnotationFieldValue(fd, data)
+}
+
+func preprocessAnnotationFieldValue(fd protoreflect.FieldDescriptor, data any) any {
+	// convert map[string]any -> map[string]string
+	if fd.IsMap() && fd.MapKey().Kind() == protoreflect.StringKind && fd.MapValue().Kind() == protoreflect.StringKind {
+		if v, ok := data.(map[string]any); ok {
+			m := make(map[string]string, len(v))
+			for k, vv := range v {
+				m[k] = fmt.Sprint(vv)
+			}
+			return m
+		}
+	}
+
+	switch fd.Kind() {
+	case protoreflect.MessageKind:
+		return preprocessAnnotationMessage(fd.Message(), data)
+	}
+
+	return data
+}
+
+func goDurationStringToProtoJSONDurationString(in string) string {
+	dur, err := time.ParseDuration(in)
+	if err != nil {
+		return in
+	}
+
+	bs, err := protojson.Marshal(durationpb.New(dur))
+	if err != nil {
+		return in
+	}
+
+	var str string
+	err = json.Unmarshal(bs, &str)
+	if err != nil {
+		return in
+	}
+
+	return str
+}

--- a/pomerium/proto.go
+++ b/pomerium/proto.go
@@ -27,7 +27,7 @@ func unmarshalAnnotations(dst proto.Message, kvs map[string]string) error {
 	// pre-process the json to handle custom formats
 	preprocessAnnotationMessage(dst.ProtoReflect().Descriptor(), src)
 
-	// marshal as json so it can be unmarshalled via protojson
+	// marshal as json so it can be unmarshaled via protojson
 	data, err := json.Marshal(src)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
Update the annotation parsing code to support Go duration strings.

Go duration strings are slightly different from `protojson` duration strings. There wasn't an easy way to customize `protojson`, so instead we preprocess the data and rewrite the Go duration strings so `protojson` can parse them.

I also refactored the way we handled `map[string]any` data so it can also be handled in the preprocessing.

## Related issues
- https://github.com/pomerium/ingress-controller/issues/981


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
