### PR TITLE
remove empty boilerplate file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ generated: config/crd/bases/ingress.pomerium.io_pomerium.yaml apis/ingress/v1/zz
 
 apis/ingress/v1/zz_generated.deepcopy.go: apis/ingress/v1/pomerium_types.go
 	@echo "==> $@"
-	@$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths=$(CRD_PACKAGE) output:dir=apis/ingress/v1
+	@$(CONTROLLER_GEN) object paths=$(CRD_PACKAGE) output:dir=apis/ingress/v1
 
 config/crd/bases/ingress.pomerium.io_pomerium.yaml: apis/ingress/v1/pomerium_types.go
 	@echo "==> $@"


### PR DESCRIPTION
## Summary

The command to generate the DeepCopy code for the ingress CRD objects references an empty `headerFile`. The `headerFile` parameter appears to be optional, so I think we can skip it instead of passing an empty file.

## Related issues

n/a (minor cleanup)

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
