### PR TITLE
ci: remove 'make lint' step from Test workflow (#1043)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,9 +58,6 @@ jobs:
             ~/Library/Caches/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
-      - name: Lint
-        if: runner.os == 'Linux'
-        run: make lint
       - name: test
         if: runner.os == 'Linux'
         run: make test


### PR DESCRIPTION
Backport https://github.com/pomerium/ingress-controller/commit/a38803829dfdd0a97d383e94ddf8aba9b0aafe29 from https://github.com/pomerium/ingress-controller/pull/1043