### PR TITLE
gateway: controller implementation

### DIFF
--- a/controllers/gateway/conditions.go
+++ b/controllers/gateway/conditions.go
@@ -1,0 +1,43 @@
+package gateway
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+func upsertConditions(
+	conditions *[]metav1.Condition,
+	observedGeneration int64,
+	condition ...metav1.Condition,
+) (modified bool) {
+	for _, c := range condition {
+		if upsertCondition(conditions, observedGeneration, c) {
+			modified = true
+		}
+	}
+	return modified
+}
+
+func upsertCondition(
+	conditions *[]metav1.Condition,
+	observedGeneration int64,
+	condition metav1.Condition,
+) (modified bool) {
+	condition.ObservedGeneration = observedGeneration
+	condition.LastTransitionTime = metav1.Now()
+
+	conds := *conditions
+	for i := range conds {
+		if conds[i].Type == condition.Type {
+			// Existing condition found.
+			if conds[i].ObservedGeneration == condition.ObservedGeneration &&
+				conds[i].Status == condition.Status &&
+				conds[i].Reason == condition.Reason &&
+				conds[i].Message == condition.Message {
+				return false
+			}
+			conds[i] = condition
+			return true
+		}
+	}
+	// No existing condition found, so add it.
+	*conditions = append(*conditions, condition)
+	return true
+}

--- a/controllers/gateway/controller.go
+++ b/controllers/gateway/controller.go
@@ -95,7 +95,10 @@ func (c *gatewayController) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
-	config := c.processGateways(ctx, o)
+	config, err := c.processGateways(ctx, o)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	_, err = c.SetGatewayConfig(ctx, config)
 	if err != nil {

--- a/controllers/gateway/controller.go
+++ b/controllers/gateway/controller.go
@@ -1,0 +1,98 @@
+package gateway
+
+import (
+	context "context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gateway_v1 "sigs.k8s.io/gateway-api/apis/v1"
+	gateway_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/pomerium/ingress-controller/pomerium"
+)
+
+const DefaultClassControllerName = "pomerium.io/gateway-controller"
+
+// ControllerConfig contains configuration options for the Gateway controller.
+type ControllerConfig struct {
+	// ControllerName associates this controller with a GatewayClass.
+	ControllerName string
+	// Gateway addresses are determined from this service.
+	ServiceName types.NamespacedName
+}
+
+type gatewayController struct {
+	client.Client
+	pomerium.GatewayReconciler
+	ControllerConfig
+}
+
+// NewGatewayController creates and registers a new controller for Gateway objects.
+func NewGatewayController(
+	ctx context.Context,
+	mgr ctrl.Manager,
+	pgr pomerium.GatewayReconciler,
+	config ControllerConfig,
+) error {
+	gtc := &gatewayController{
+		Client:            mgr.GetClient(),
+		GatewayReconciler: pgr,
+		ControllerConfig:  config,
+	}
+
+	mgr.GetFieldIndexer().IndexField(ctx, &corev1.Secret{}, "type",
+		func(o client.Object) []string { return []string{string(o.(*corev1.Secret).Type)} })
+
+	// All updates will trigger the same reconcile request.
+	enqueueRequest := handler.EnqueueRequestsFromMapFunc(
+		func(_ context.Context, _ client.Object) []reconcile.Request {
+			return []reconcile.Request{{
+				NamespacedName: types.NamespacedName{
+					Name: config.ControllerName,
+				},
+			}}
+		})
+
+	err := ctrl.NewControllerManagedBy(mgr).
+		Named("gateway").
+		Watches(
+			&gateway_v1.Gateway{},
+			enqueueRequest,
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
+		Watches(
+			&gateway_v1.HTTPRoute{},
+			enqueueRequest,
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
+		Watches(&corev1.Secret{}, enqueueRequest).
+		Watches(&corev1.Namespace{}, enqueueRequest).
+		Watches(&corev1.Service{}, enqueueRequest).
+		Watches(&gateway_v1beta1.ReferenceGrant{}, enqueueRequest).
+		Complete(gtc)
+	if err != nil {
+		return fmt.Errorf("build controller: %w", err)
+	}
+
+	return nil
+}
+
+func (c *gatewayController) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	o, err := c.fetchObjects(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	config := c.processGateways(ctx, o)
+
+	c.SetGatewayConfig(ctx, config)
+
+	return ctrl.Result{}, nil
+}

--- a/controllers/gateway/fetch.go
+++ b/controllers/gateway/fetch.go
@@ -1,0 +1,129 @@
+package gateway
+
+import (
+	context "context"
+
+	"github.com/hashicorp/go-set/v3"
+	"github.com/pomerium/ingress-controller/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gateway_v1 "sigs.k8s.io/gateway-api/apis/v1"
+	gateway_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// objects holds all relevant Gateway objects and their dependencies.
+type objects struct {
+	Gateways                map[refKey]*gateway_v1.Gateway
+	HTTPRoutesByGateway     map[refKey][]httpRouteInfo
+	OriginalHTTPRouteStatus []httpRouteAndOriginalStatus
+	Namespaces              map[string]*corev1.Namespace
+	ReferenceGrants         referenceGrantMap
+	TLSSecrets              map[refKey]*corev1.Secret
+	Services                map[types.NamespacedName]*corev1.Service
+}
+
+type httpRouteAndOriginalStatus struct {
+	route          *gateway_v1.HTTPRoute
+	originalStatus *gateway_v1.HTTPRouteStatus
+}
+
+// fetchObjects fetches all relevant Gateway objects.
+func (c *gatewayController) fetchObjects(ctx context.Context) (*objects, error) {
+	var o objects
+
+	// Fetch all GatewayClasses and filter by controller name.
+	var gcl gateway_v1.GatewayClassList
+	if err := c.List(ctx, &gcl); err != nil {
+		return nil, err
+	}
+	gcNames := set.New[string](0)
+	for i := range gcl.Items {
+		gc := &gcl.Items[i]
+		if gc.Spec.ControllerName == gateway_v1.GatewayController(c.ControllerName) {
+			gcNames.Insert(gc.Name)
+		}
+	}
+
+	// Fetch all Gateways and filter by GatewayClass name.
+	var gl gateway_v1.GatewayList
+	if err := c.List(ctx, &gl); err != nil {
+		return nil, err
+	}
+	o.Gateways = make(map[refKey]*gateway_v1.Gateway)
+	for i := range gl.Items {
+		g := &gl.Items[i]
+		if gcNames.Contains(string(g.Spec.GatewayClassName)) {
+			o.Gateways[refKeyForObject(g)] = g
+		}
+	}
+
+	// Fetch all HTTPRoutes and filter by Gateway parentRef.
+	var hrl gateway_v1.HTTPRouteList
+	if err := c.List(ctx, &hrl); err != nil {
+		return nil, err
+	}
+	o.HTTPRoutesByGateway = make(map[refKey][]httpRouteInfo)
+	for i := range hrl.Items {
+		hr := &hrl.Items[i]
+		o.OriginalHTTPRouteStatus = append(o.OriginalHTTPRouteStatus,
+			httpRouteAndOriginalStatus{route: hr, originalStatus: hr.Status.DeepCopy()})
+		ensureRouteParentStatusExists(hr, c.ControllerName)
+		for j := range hr.Spec.ParentRefs {
+			pr := &hr.Spec.ParentRefs[j]
+			key := refKeyForParentRef(hr, pr)
+			if _, ok := o.Gateways[key]; ok {
+				o.HTTPRoutesByGateway[key] = append(o.HTTPRoutesByGateway[key],
+					httpRouteInfo{hr, pr, &hr.Status.Parents[j]})
+			}
+		}
+	}
+
+	// Fetch all Namespaces (the labels may be needed for the allowedRoutes restrictions).
+	var nl corev1.NamespaceList
+	if err := c.List(ctx, &nl); err != nil {
+		return nil, err
+	}
+	o.Namespaces = make(map[string]*corev1.Namespace)
+	for i := range nl.Items {
+		n := &nl.Items[i]
+		o.Namespaces[n.Name] = n
+	}
+
+	// Fetch all ReferenceGrants.
+	var rgl gateway_v1beta1.ReferenceGrantList
+	if err := c.List(ctx, &rgl); err != nil {
+		return nil, err
+	}
+	o.ReferenceGrants = buildReferenceGrantMap(rgl.Items)
+
+	// Fetch all TLS secrets.
+	var sl corev1.SecretList
+	if err := c.List(ctx, &sl, client.MatchingFields{"type": string(corev1.SecretTypeTLS)}); err != nil {
+		return nil, err
+	}
+	o.TLSSecrets = make(map[refKey]*corev1.Secret)
+	for i := range sl.Items {
+		s := &sl.Items[i]
+		o.TLSSecrets[refKeyForObject(s)] = s
+	}
+
+	// Fetch all Services.
+	var servicesList corev1.ServiceList
+	if err := c.List(ctx, &servicesList); err != nil {
+		return nil, err
+	}
+	o.Services = make(map[types.NamespacedName]*corev1.Service)
+	for i := range servicesList.Items {
+		s := &servicesList.Items[i]
+		o.Services[util.GetNamespacedName(s)] = s
+	}
+
+	return &o, nil
+}
+
+type httpRouteInfo struct {
+	route  *gateway_v1.HTTPRoute
+	parent *gateway_v1.ParentReference
+	status *gateway_v1.RouteParentStatus
+}

--- a/controllers/gateway/fetch.go
+++ b/controllers/gateway/fetch.go
@@ -4,12 +4,13 @@ import (
 	context "context"
 
 	"github.com/hashicorp/go-set/v3"
-	"github.com/pomerium/ingress-controller/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gateway_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gateway_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/pomerium/ingress-controller/util"
 )
 
 // objects holds all relevant Gateway objects and their dependencies.

--- a/controllers/gateway/gateway.go
+++ b/controllers/gateway/gateway.go
@@ -1,0 +1,176 @@
+package gateway
+
+import (
+	context "context"
+	golog "log"
+
+	"github.com/pomerium/ingress-controller/model"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	gateway_v1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// processGateways updates the status of all Gateways and associated routes, and returns a
+// GatewayConfig object with all valid configuration.
+func (c *gatewayController) processGateways(
+	ctx context.Context,
+	o *objects,
+) *model.GatewayConfig {
+	var config model.GatewayConfig
+
+	for key := range o.Gateways {
+		c.processGateway(ctx, &config, o, key)
+	}
+
+	c.updateModifiedHTTPRouteStatus(ctx, o.OriginalHTTPRouteStatus)
+
+	return &config
+}
+
+// processGateway updates the status of this gateway and appends any valid configuration to the
+// GatewayConfig object.
+func (c *gatewayController) processGateway(
+	ctx context.Context,
+	config *model.GatewayConfig,
+	o *objects,
+	gatewayKey refKey,
+) {
+	logger := log.FromContext(ctx)
+
+	gateway := o.Gateways[gatewayKey]
+
+	// Snapshot the existing status, then compare after updates to determine if it has changed.
+	previousStatus := gateway.Status.DeepCopy()
+
+	// We need to preserve any existing ListenerStatus conditions, to avoid modifying the
+	// LastTransitionTime incorrectly.
+	ensureListenerStatusExists(gateway)
+
+	listenersByName := make(map[string]listenerAndStatus)
+
+	for i := range gateway.Spec.Listeners {
+		listener := &gateway.Spec.Listeners[i]
+		status := &gateway.Status.Listeners[i]
+		l := listenerAndStatus{listener, status, gateway.Generation}
+
+		processListener(config, o, gatewayKey, l)
+
+		// Filter out any listeners that do not support HTTPRoutes.
+		if len(status.SupportedKinds) > 0 {
+			listenersByName[string(listener.Name)] = l
+		}
+
+		// Reset AttachedRoutes because processHTTPRoute() will increment these counts.
+		status.AttachedRoutes = 0
+	}
+
+	for _, r := range o.HTTPRoutesByGateway[gatewayKey] {
+		result := processHTTPRoute(o, gateway, listenersByName, r)
+		if len(result.Hostnames) > 0 {
+			config.Routes = append(config.Routes, model.GatewayHTTPRouteConfig{
+				HTTPRoute:        r.route,
+				Hostnames:        result.Hostnames,
+				ValidBackendRefs: result.ValidBackendRefs,
+				Services:         o.Services,
+			})
+		}
+	}
+
+	updateGatewayAddresses(o, gateway, c.ServiceName)
+
+	upsertGatewayConditions(gateway,
+		metav1.Condition{
+			Type:   string(gateway_v1.GatewayConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gateway_v1.GatewayReasonAccepted),
+		},
+		metav1.Condition{
+			Type:   string(gateway_v1.GatewayConditionProgrammed),
+			Status: metav1.ConditionTrue,
+			Reason: string(gateway_v1.GatewayReasonProgrammed),
+		},
+	)
+
+	if !equality.Semantic.DeepEqual(gateway.Status, previousStatus) {
+		if err := c.Status().Update(ctx, gateway); err != nil {
+			logger.Error(err, "couldn't update Gateway status", "name", gateway.Name)
+		}
+	}
+}
+
+// ensureListenerStatusExists ensures that the elements of g.Status.Listeners correspond to the
+// elements of g.Spec.Listeners.
+func ensureListenerStatusExists(g *gateway_v1.Gateway) {
+	// Check to see if the listeners status already matches.
+	if len(g.Status.Listeners) == len(g.Spec.Listeners) {
+		ok := true
+		for i := range len(g.Spec.Listeners) {
+			if g.Status.Listeners[i].Name != g.Spec.Listeners[i].Name {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return
+		}
+	}
+
+	// Allocate new listeners status and copy over any existing status.
+	listenerStatusMap := make(map[string]gateway_v1.ListenerStatus)
+	for _, ls := range g.Status.Listeners {
+		listenerStatusMap[string(ls.Name)] = ls
+	}
+	g.Status.Listeners = make([]gateway_v1.ListenerStatus, len(g.Spec.Listeners))
+	for i := range len(g.Spec.Listeners) {
+		g.Status.Listeners[i] = listenerStatusMap[string(g.Spec.Listeners[i].Name)]
+	}
+}
+
+var (
+	gatewayAddressTypeIPAddress = gateway_v1.AddressType("IPAddress")
+	gatewayAddressTypeHostname  = gateway_v1.AddressType("Hostname")
+)
+
+func updateGatewayAddresses(
+	o *objects,
+	gateway *gateway_v1.Gateway,
+	serviceName types.NamespacedName,
+) {
+	// Copy the external addresses from the "pomerium-proxy" service, if it exists.
+	proxy := o.Services[serviceName]
+	if proxy == nil {
+		return
+	}
+	gateway.Status.Addresses = make([]gateway_v1.GatewayStatusAddress, 0, len(proxy.Status.LoadBalancer.Ingress))
+	for _, ingress := range proxy.Status.LoadBalancer.Ingress {
+		if ingress.IP != "" {
+			gateway.Status.Addresses = append(gateway.Status.Addresses, gateway_v1.GatewayStatusAddress{
+				Type:  &gatewayAddressTypeIPAddress,
+				Value: ingress.IP,
+			})
+		} else if ingress.Hostname != "" {
+			gateway.Status.Addresses = append(gateway.Status.Addresses, gateway_v1.GatewayStatusAddress{
+				Type:  &gatewayAddressTypeHostname,
+				Value: ingress.Hostname,
+			})
+		}
+	}
+}
+
+func upsertGatewayConditions(g *gateway_v1.Gateway, conditions ...metav1.Condition) (modified bool) {
+	return upsertConditions(&g.Status.Conditions, g.Generation, conditions...)
+}
+
+func (c *gatewayController) updateModifiedHTTPRouteStatus(
+	ctx context.Context, s []httpRouteAndOriginalStatus,
+) {
+	for _, r := range s {
+		if !equality.Semantic.DeepEqual(r.route.Status, r.originalStatus) {
+			if err := c.Status().Update(ctx, r.route); err != nil {
+				golog.Printf("couldn't update status for %q: %v", r.route.Name, err)
+			}
+		}
+	}
+}

--- a/controllers/gateway/gateway.go
+++ b/controllers/gateway/gateway.go
@@ -4,12 +4,13 @@ import (
 	context "context"
 	golog "log"
 
-	"github.com/pomerium/ingress-controller/model"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gateway_v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/pomerium/ingress-controller/model"
 )
 
 // processGateways updates the status of all Gateways and associated routes, and returns a

--- a/controllers/gateway/gatewayclass.go
+++ b/controllers/gateway/gatewayclass.go
@@ -1,0 +1,60 @@
+package gateway
+
+import (
+	context "context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gateway_v1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+type gatewayClassController struct {
+	client.Client
+	controllerName string
+}
+
+// NewGatewayClassController creates and registers a new controller for GatewayClass objects.
+// This controller does just one thing: it sets the "Accepted" status condition.
+func NewGatewayClassController(
+	mgr ctrl.Manager,
+	controllerName string,
+) error {
+	gtcc := &gatewayClassController{
+		Client:         mgr.GetClient(),
+		controllerName: controllerName,
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("gateway-class").
+		For(&gateway_v1.GatewayClass{}).
+		Complete(gtcc)
+}
+
+func (c *gatewayClassController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var gc gateway_v1.GatewayClass
+	if err := c.Get(ctx, req.NamespacedName, &gc); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if gc.Spec.ControllerName != gateway_v1.GatewayController(c.controllerName) {
+		return ctrl.Result{}, nil
+	}
+
+	if setGatewayClassAccepted(&gc) {
+		// Condition changed, need to update status.
+		if err := c.Status().Update(ctx, &gc); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func setGatewayClassAccepted(gc *gateway_v1.GatewayClass) (modified bool) {
+	return upsertCondition(&gc.Status.Conditions, gc.Generation, metav1.Condition{
+		Type:   string(gateway_v1.GatewayClassConditionStatusAccepted),
+		Status: metav1.ConditionTrue,
+		Reason: string(gateway_v1.GatewayClassReasonAccepted),
+	})
+}

--- a/controllers/gateway/httproute.go
+++ b/controllers/gateway/httproute.go
@@ -55,7 +55,7 @@ func processHTTPRoute(
 		return result
 	}
 
-	// Otherwise check for route attachement with all listeners.
+	// Otherwise check for route attachment with all listeners.
 	hostnamesSet := set.New[gateway_v1.Hostname](0)
 	var reason gateway_v1.RouteConditionReason
 	for _, l := range listeners {

--- a/controllers/gateway/httproute.go
+++ b/controllers/gateway/httproute.go
@@ -1,0 +1,303 @@
+package gateway
+
+import (
+	"strings"
+
+	"github.com/hashicorp/go-set/v3"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gateway_v1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+type httpRouteResult struct {
+	Hostnames        []gateway_v1.Hostname
+	ValidBackendRefs backendRefSet
+}
+
+// processHTTPRoute checks the validity of an HTTPRoute, updates its status accordingly, and
+// computes its matching hostnames (with "all" represented as "*").
+func processHTTPRoute(
+	o *objects,
+	g *gateway_v1.Gateway,
+	listeners map[string]listenerAndStatus,
+	r httpRouteInfo,
+) httpRouteResult {
+	var result httpRouteResult
+
+	// Reject this route early if it includes any per-backendRef filters as we don't support these.
+	if anyBackendRefHasFilters(r.route.Spec.Rules) {
+		upsertCondition(&r.status.Conditions, r.route.Generation, metav1.Condition{
+			Type:    string(gateway_v1.RouteConditionAccepted),
+			Status:  metav1.ConditionFalse,
+			Reason:  string(gateway_v1.RouteReasonUnsupportedValue),
+			Message: "backendRef filters are not supported",
+		})
+		return result
+	}
+
+	result.ValidBackendRefs = validateHTTPRouteBackendRefsResolved(o, r)
+
+	// An HTTPRoute may specify a listener name directly. In this case we should check for route
+	// attachment with just the one listener.
+	if r.parent.SectionName != nil {
+		l, ok := listeners[string(*r.parent.SectionName)]
+		if !ok {
+			setRouteStatusAccepted(r, gateway_v1.RouteReasonNoMatchingParent)
+			return result
+		}
+		ra := processHTTPRouteForListener(o, g, l, r.route)
+		setRouteStatusAccepted(r, ra.reason)
+		result.Hostnames = ra.hostnames
+		return result
+	}
+
+	// Otherwise check for route attachement with all listeners.
+	hostnamesSet := set.New[gateway_v1.Hostname](0)
+	var reason gateway_v1.RouteConditionReason
+	for _, l := range listeners {
+		ra := processHTTPRouteForListener(o, g, l, r.route)
+		hostnamesSet.InsertSlice(ra.hostnames)
+		// If the route attaches to any listener, we consider the route accepted.
+		// Otherwise we'll return the reason associated with the first listener.
+		if reason == "" || ra.reason == gateway_v1.RouteReasonAccepted {
+			reason = ra.reason
+		}
+	}
+	if reason == "" {
+		reason = gateway_v1.RouteReasonNoMatchingParent // no listeners at all
+	}
+	setRouteStatusAccepted(r, reason)
+	result.Hostnames = hostnamesSet.Slice()
+	return result
+}
+
+func anyBackendRefHasFilters(rules []gateway_v1.HTTPRouteRule) bool {
+	for i := range rules {
+		rule := &rules[i]
+		for i := range rule.BackendRefs {
+			if len(rule.BackendRefs[i].Filters) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func validateHTTPRouteBackendRefsResolved(
+	o *objects,
+	r httpRouteInfo,
+) (validRefs backendRefSet) {
+	// Check that all backendRefs can be resolved.
+	invalidRefs := make(map[gateway_v1.RouteConditionReason][]string)
+	invalid := func(reason gateway_v1.RouteConditionReason, name string) {
+		invalidRefs[reason] = append(invalidRefs[reason], name)
+	}
+	for i := range r.route.Spec.Rules {
+		rule := &r.route.Spec.Rules[i]
+		for i := range rule.BackendRefs {
+			refKey := refKeyForBackendRef(r.route, &rule.BackendRefs[i].BackendObjectReference)
+			if refKey.Group != corev1.GroupName || refKey.Kind != "Service" {
+				invalid(gateway_v1.RouteReasonInvalidKind, refKey.Name)
+				continue
+			}
+			if !o.ReferenceGrants.allowed(r.route, refKey) {
+				invalid(gateway_v1.RouteReasonRefNotPermitted, refKey.Name)
+				continue
+			}
+			if o.Services[types.NamespacedName{Namespace: refKey.Namespace, Name: refKey.Name}] == nil {
+				invalid(gateway_v1.RouteReasonBackendNotFound, refKey.Name)
+				continue
+			}
+			validRefs.insert(r.route, &rule.BackendRefs[i].BackendRef)
+		}
+	}
+
+	resolvedRefs := metav1.Condition{
+		Type:   string(gateway_v1.RouteConditionResolvedRefs),
+		Status: metav1.ConditionTrue,
+		Reason: string(gateway_v1.RouteReasonResolvedRefs),
+	}
+
+	var messages []string
+	for reason, refNames := range invalidRefs {
+		resolvedRefs.Status = metav1.ConditionFalse
+		resolvedRefs.Reason = string(reason) // if multiple reasons apply this will set one arbitrarily
+		messages = append(messages, "invalid refs ("+string(reason)+"): "+strings.Join(refNames, ", "))
+	}
+	resolvedRefs.Message = strings.Join(messages, "; ")
+
+	upsertCondition(&r.status.Conditions, r.route.Generation, resolvedRefs)
+
+	return validRefs
+}
+
+type routeAttachment struct {
+	// Resolved hostnames, with "all" represented as "*".
+	hostnames []gateway_v1.Hostname
+
+	// "Accepted" condition status reason.
+	reason gateway_v1.RouteConditionReason
+}
+
+func processHTTPRouteForListener(
+	o *objects,
+	g *gateway_v1.Gateway,
+	l listenerAndStatus,
+	r *gateway_v1.HTTPRoute,
+) routeAttachment {
+	if !isHTTPRouteAllowed(o, l.listener.AllowedRoutes, r, g.Namespace) {
+		return routeAttachment{reason: gateway_v1.RouteReasonNotAllowedByListeners}
+	}
+
+	hostnames := routeHostnames(l.listener.Hostname, r.Spec.Hostnames)
+	if len(hostnames) == 0 {
+		return routeAttachment{reason: gateway_v1.RouteReasonNoMatchingListenerHostname}
+	}
+
+	l.status.AttachedRoutes++
+
+	return routeAttachment{
+		hostnames: hostnames,
+		reason:    gateway_v1.RouteReasonAccepted,
+	}
+}
+
+func isHTTPRouteAllowed(
+	o *objects,
+	allowed *gateway_v1.AllowedRoutes,
+	r *gateway_v1.HTTPRoute,
+	gatewayNamespace string,
+) bool {
+	// This assumes we've already checked SupportedKinds in processGateway(), so we need only
+	// check that the route namespace is allowed.
+	from := gateway_v1.NamespacesFromSame
+	if allowed.Namespaces != nil && allowed.Namespaces.From != nil {
+		from = *allowed.Namespaces.From
+	}
+	switch from {
+	case gateway_v1.NamespacesFromAll:
+		return true
+	case gateway_v1.NamespacesFromSame:
+		return r.Namespace == gatewayNamespace
+	case gateway_v1.NamespacesFromSelector:
+		selector, err := metav1.LabelSelectorAsSelector(allowed.Namespaces.Selector)
+		if err != nil {
+			return false
+		}
+		routeNamespace := o.Namespaces[r.Namespace]
+		return selector.Matches(labels.Set(routeNamespace.Labels))
+	default:
+		return false
+	}
+}
+
+func routeHostnames(
+	listenerHostname *gateway_v1.Hostname,
+	routeHostnames []gateway_v1.Hostname,
+) []gateway_v1.Hostname {
+	// If the listener does not specify a hostname, it accepts any hostname.
+	if listenerHostname == nil {
+		// If the route also does not specify a hostname, it matches all hostnames.
+		if len(routeHostnames) == 0 {
+			return []gateway_v1.Hostname{"*"}
+		}
+		return routeHostnames
+	}
+
+	// If the listener specifies a hostname and the route does not, only the listener hostname matches.
+	if len(routeHostnames) == 0 {
+		return []gateway_v1.Hostname{*listenerHostname}
+	}
+
+	// If both the listener and route specify hostnames, compute the intersection.
+	var matching []gateway_v1.Hostname
+	for _, rh := range routeHostnames {
+		if h := hostnameIntersection(string(*listenerHostname), string(rh)); h != "" {
+			matching = append(matching, gateway_v1.Hostname(h))
+		}
+	}
+	return matching
+}
+
+func hostnameIntersection(a, b string) string {
+	// Simplest case: exact match.
+	if a == b {
+		return a
+	}
+
+	// From the spec:
+	//
+	// "Hostnames that are prefixed with a wildcard label (`*.`) are interpreted as
+	// a suffix match. That means that a match for `*.example.com` would match both
+	//`test.example.com`, and `foo.test.example.com`, but not `example.com`."
+	if strings.HasPrefix(a, "*.") && strings.HasSuffix(b, a[1:]) {
+		return b
+	}
+	if strings.HasPrefix(b, "*.") && strings.HasSuffix(a, b[1:]) {
+		return a
+	}
+
+	return "" // no intersection
+}
+
+func setRouteStatusAccepted(
+	r httpRouteInfo,
+	acceptedReason gateway_v1.RouteConditionReason,
+) (modified bool) {
+	acceptedStatus := metav1.ConditionTrue
+	if acceptedReason != gateway_v1.RouteReasonAccepted {
+		acceptedStatus = metav1.ConditionFalse
+	}
+	return upsertCondition(&r.status.Conditions, r.route.Generation, metav1.Condition{
+		Type:   string(gateway_v1.RouteConditionAccepted),
+		Status: acceptedStatus,
+		Reason: string(acceptedReason),
+	})
+}
+
+type backendRefSet struct {
+	c set.Collection[refKey]
+}
+
+func (b *backendRefSet) insert(obj client.Object, r *gateway_v1.BackendRef) {
+	if b.c == nil {
+		b.c = set.New[refKey](1)
+	}
+	b.c.Insert(refKeyForBackendRef(obj, &r.BackendObjectReference))
+}
+
+func (b backendRefSet) Valid(obj client.Object, r *gateway_v1.BackendRef) bool {
+	if b.c == nil {
+		return false
+	}
+	return b.c.Contains(refKeyForBackendRef(obj, &r.BackendObjectReference))
+}
+
+// ensureRouteParentStatusExists ensures that the elements of r.Status.Parents correspond to the
+// elements of r.Spec.ParentRef.
+func ensureRouteParentStatusExists(r *gateway_v1.HTTPRoute, controllerName string) {
+	// Check to see if the parent status items already match.
+	if len(r.Status.Parents) == len(r.Spec.ParentRefs) {
+		ok := true
+		for i := range r.Spec.ParentRefs {
+			if !equality.Semantic.DeepEqual(r.Spec.ParentRefs[i], r.Status.Parents[i].ParentRef) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return
+		}
+	}
+
+	// Allocate new parent status items.
+	r.Status.Parents = make([]gateway_v1.RouteParentStatus, len(r.Spec.ParentRefs))
+	for i := range r.Status.Parents {
+		r.Status.Parents[i].ParentRef = r.Spec.ParentRefs[i]
+		r.Status.Parents[i].ControllerName = gateway_v1.GatewayController(controllerName)
+	}
+}

--- a/controllers/gateway/listener.go
+++ b/controllers/gateway/listener.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-set/v3"
-	"github.com/pomerium/ingress-controller/model"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gateway_v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/pomerium/ingress-controller/model"
 )
 
 type listenerAndStatus struct {

--- a/controllers/gateway/listener.go
+++ b/controllers/gateway/listener.go
@@ -1,0 +1,178 @@
+package gateway
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-set/v3"
+	"github.com/pomerium/ingress-controller/model"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	gateway_v1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+type listenerAndStatus struct {
+	listener   *gateway_v1.Listener
+	status     *gateway_v1.ListenerStatus
+	generation int64
+}
+
+// processListener adds routes and certificates associated with a single Listener to the
+// GatewayConfig and updates the ListenerStatus.
+func processListener(
+	config *model.GatewayConfig,
+	o *objects,
+	gatewayKey refKey,
+	l listenerAndStatus,
+) {
+	l.status.Name = l.listener.Name
+
+	g := o.Gateways[gatewayKey]
+
+	// Some status conditions should always be present. Set them first to the optimistic value.
+	// The following steps will update these conditions if needed.
+	upsertConditions(&l.status.Conditions, g.Generation,
+		metav1.Condition{
+			Type:   string(gateway_v1.ListenerConditionAccepted),
+			Status: metav1.ConditionTrue,
+			Reason: string(gateway_v1.ListenerReasonAccepted),
+		},
+		metav1.Condition{
+			Type:   string(gateway_v1.ListenerConditionProgrammed),
+			Status: metav1.ConditionTrue,
+			Reason: string(gateway_v1.ListenerReasonProgrammed),
+		},
+		metav1.Condition{
+			Type:   string(gateway_v1.ListenerConditionResolvedRefs),
+			Status: metav1.ConditionTrue,
+			Reason: string(gateway_v1.ListenerConditionResolvedRefs),
+		},
+	)
+	setListenerStatusSupportedKinds(l)
+	processCertificateRefs(config, o, g, l)
+}
+
+// setListenerStatusSupportedKinds sets the status SupportedKinds and updates the conditions if any
+// allowedRoutes kinds are unsupported. (Currently the only supported kind is HTTPRoute.)
+func setListenerStatusSupportedKinds(l listenerAndStatus) {
+	// If allowedRoutes is unset, there is no restriction on allowed route kinds.
+	allowed := l.listener.AllowedRoutes
+	if allowed == nil || len(allowed.Kinds) == 0 {
+		l.status.SupportedKinds = []gateway_v1.RouteGroupKind{{Kind: "HTTPRoute"}}
+		return
+	}
+
+	supported := make([]gateway_v1.RouteGroupKind, 0)
+	unsupportedKinds := set.New[string](0)
+	for _, k := range allowed.Kinds {
+		if groupKindFromRouteGroupKind(&k) == (schema.GroupKind{
+			Group: gateway_v1.GroupName,
+			Kind:  "HTTPRoute",
+		}) {
+			supported = []gateway_v1.RouteGroupKind{k}
+		} else {
+			unsupportedKinds.Insert(string(k.Kind))
+		}
+	}
+	l.status.SupportedKinds = supported
+
+	if !unsupportedKinds.Empty() {
+		upsertConditions(&l.status.Conditions, l.generation,
+			metav1.Condition{
+				Type:   string(gateway_v1.ListenerConditionResolvedRefs),
+				Status: metav1.ConditionFalse,
+				Reason: string(gateway_v1.ListenerReasonInvalidRouteKinds),
+				Message: fmt.Sprintf("unsupported route kinds: %s (only HTTPRoute is supported)",
+					strings.Join(unsupportedKinds.Slice(), ", ")),
+			},
+			metav1.Condition{
+				Type:   string(gateway_v1.ListenerConditionProgrammed),
+				Status: metav1.ConditionFalse,
+				Reason: string(gateway_v1.ListenerReasonInvalid),
+			},
+		)
+	}
+}
+
+// processCertificateRefs checks that all specified certificateRefs can be matched to available
+// TLS Secrets and sets the "ResolvedRefs" status condition if any are invalid.
+func processCertificateRefs(
+	config *model.GatewayConfig,
+	o *objects,
+	g *gateway_v1.Gateway,
+	l listenerAndStatus,
+) {
+	if l.listener.TLS == nil {
+		return
+	}
+
+	var hasValidRef bool
+	invalidRefs := make(map[gateway_v1.ListenerConditionReason][]string)
+	invalid := func(reason gateway_v1.ListenerConditionReason, name string) {
+		invalidRefs[reason] = append(invalidRefs[reason], name)
+	}
+	for i := range l.listener.TLS.CertificateRefs {
+		k := refKeyForCertificateRef(g, &l.listener.TLS.CertificateRefs[i])
+		if !o.ReferenceGrants.allowed(g, k) {
+			invalid(gateway_v1.ListenerReasonRefNotPermitted, k.Name)
+			continue
+		}
+
+		secret, ok := o.TLSSecrets[k]
+		if !ok || validateTLSSecret(secret) != nil {
+			invalid(gateway_v1.ListenerReasonInvalidCertificateRef, k.Name)
+			continue
+		}
+
+		config.Certificates = append(config.Certificates, secret)
+		hasValidRef = true
+	}
+
+	resolvedRefs := metav1.Condition{
+		Type:   string(gateway_v1.RouteConditionResolvedRefs),
+		Status: metav1.ConditionTrue,
+		Reason: string(gateway_v1.RouteReasonResolvedRefs),
+	}
+
+	var messages []string
+	for reason, refNames := range invalidRefs {
+		resolvedRefs.Status = metav1.ConditionFalse
+		resolvedRefs.Reason = string(reason) // if multiple reasons apply this will set one arbitrarily
+		messages = append(messages, "invalid certificate refs ("+string(reason)+"): "+strings.Join(refNames, ", "))
+	}
+	resolvedRefs.Message = strings.Join(messages, "; ")
+
+	upsertCondition(&l.status.Conditions, l.generation, resolvedRefs)
+
+	if !hasValidRef {
+		upsertCondition(&l.status.Conditions, l.generation, metav1.Condition{
+			Type:   string(gateway_v1.ListenerConditionProgrammed),
+			Status: metav1.ConditionFalse,
+			Reason: string(gateway_v1.ListenerReasonInvalid),
+		})
+	}
+}
+
+// groupKindFromRouteGroupKind normalizes a RouteGroupKind by translating a nil Kind to its default
+// value. The result is suitable for equality comparison.
+func groupKindFromRouteGroupKind(rgk *gateway_v1.RouteGroupKind) schema.GroupKind {
+	group := gateway_v1.GroupName
+	if rgk.Group != nil {
+		group = string(*rgk.Group)
+	}
+	return schema.GroupKind{
+		Group: group,
+		Kind:  string(rgk.Kind),
+	}
+}
+
+// validateTLSSecret checks that a Secret has "tls.crt" and "tls.key" data fields that can be
+// parsed as an X.509 certificate and corresponding private key.
+func validateTLSSecret(s *corev1.Secret) error {
+	certPEM := s.Data["tls.crt"]
+	keyPEM := s.Data["tls.key"]
+	_, err := tls.X509KeyPair(certPEM, keyPEM)
+	return err
+}

--- a/controllers/gateway/referencegrant.go
+++ b/controllers/gateway/referencegrant.go
@@ -1,0 +1,58 @@
+package gateway
+
+import (
+	"github.com/hashicorp/go-set/v3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gateway_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// referenceGrantMap is a map representation of all ReferenceGrants. Keys represent a target object
+// (corresponding to a ReferenceGrantTo) and the values represent source objects (corresponding to
+// a ReferenceGrantFrom). There are a few subtleties:
+//   - A refKey with an empty Name represents any object of that kind within the namespace.
+//   - A refKey used as a key in this map may or may not have an empty Name, as a ReferenceGrantTo
+//     contains an optional Name field.
+//   - A refKey in one of the value collections should always have an empty Name, as a
+//     ReferenceGrantFrom cannot reference a specific object by name.
+type referenceGrantMap map[refKey]set.Collection[refKey]
+
+func buildReferenceGrantMap(grants []gateway_v1beta1.ReferenceGrant) referenceGrantMap {
+	m := referenceGrantMap{}
+	for i := range grants {
+		g := &grants[i]
+		sourceSet := set.FromFunc(g.Spec.From, refKeyForReferenceGrantFrom)
+		for _, to := range g.Spec.To {
+			k := refKeyForReferenceGrantTo(g.Namespace, to)
+			m[k] = safeUnion(m[k], sourceSet)
+		}
+	}
+	return m
+}
+
+func (m referenceGrantMap) allowed(from client.Object, toKey refKey) bool {
+	// A ReferenceGrant is not required for references within a single namespace.
+	if from.GetNamespace() == toKey.Namespace {
+		return true
+	}
+
+	fromKey := refKeyForObject(from)
+	fromKey.Name = ""
+
+	if s := m[toKey]; s != nil && s.Contains(fromKey) {
+		return true // specific "To" object is allowed
+	}
+	toKey.Name = ""
+	if s := m[toKey]; s != nil && s.Contains(fromKey) {
+		return true // entire "To" namespace is allowed
+	}
+	return false
+}
+
+func safeUnion[T comparable](a, b set.Collection[T]) set.Collection[T] {
+	if a == nil {
+		return b
+	} else if b == nil {
+		return a
+	}
+	return a.Union(b)
+}

--- a/controllers/gateway/refkey.go
+++ b/controllers/gateway/refkey.go
@@ -1,0 +1,122 @@
+package gateway
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gateway_v1 "sigs.k8s.io/gateway-api/apis/v1"
+	gateway_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// refKey is an object reference in a form suitable for use as a map key.
+// Gateway references have some optional fields with default values that vary by type.
+// In a refKey these defaults should be made explicit.
+type refKey struct {
+	Group     string
+	Kind      string
+	Namespace string
+	Name      string
+}
+
+func refKeyForObject(obj client.Object) refKey {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	return refKey{
+		Group:     gvk.Group,
+		Kind:      gvk.Kind,
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+}
+
+func refKeyForParentRef(obj client.Object, ref *gateway_v1.ParentReference) refKey {
+	// See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.ParentReference
+	// "When unspecified, “gateway.networking.k8s.io” is inferred."
+	group := gateway_v1.GroupName
+	if ref.Group != nil {
+		group = string(*ref.Group)
+	}
+	// Kind appears to have a default value but I don't see this clearly spelled out in the API
+	// reference. I think Gateway is the only kind we care about in practice.
+	kind := "Gateway"
+	if ref.Kind != nil {
+		kind = string(*ref.Kind)
+	}
+	namespace := obj.GetNamespace()
+	if ref.Namespace != nil {
+		namespace = string(*ref.Namespace)
+	}
+	return refKey{
+		Group:     group,
+		Kind:      kind,
+		Namespace: namespace,
+		Name:      string(ref.Name),
+	}
+}
+
+func refKeyForCertificateRef(obj client.Object, ref *gateway_v1.SecretObjectReference) refKey {
+	// See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.SecretObjectReference
+	// "When unspecified or empty string, core API group is inferred."
+	group := corev1.GroupName
+	if ref.Group != nil {
+		group = string(*ref.Group)
+	}
+	// "SecretObjectReference identifies an API object including its namespace, defaulting to Secret."
+	kind := "Secret"
+	if ref.Kind != nil {
+		kind = string(*ref.Kind)
+	}
+	namespace := obj.GetNamespace()
+	if ref.Namespace != nil {
+		namespace = string(*ref.Namespace)
+	}
+	return refKey{
+		Group:     group,
+		Kind:      kind,
+		Namespace: namespace,
+		Name:      string(ref.Name),
+	}
+}
+
+func refKeyForBackendRef(obj client.Object, ref *gateway_v1.BackendObjectReference) refKey {
+	// See https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.BackendObjectReference
+	// "When unspecified or empty string, core API group is inferred."
+	group := corev1.GroupName
+	if ref.Group != nil {
+		group = string(*ref.Group)
+	}
+	// "Defaults to "Service" when not specified."
+	kind := "Service"
+	if ref.Kind != nil {
+		kind = string(*ref.Kind)
+	}
+	namespace := obj.GetNamespace()
+	if ref.Namespace != nil {
+		namespace = string(*ref.Namespace)
+	}
+	return refKey{
+		Group:     group,
+		Kind:      kind,
+		Namespace: namespace,
+		Name:      string(ref.Name),
+	}
+}
+
+func refKeyForReferenceGrantFrom(from gateway_v1beta1.ReferenceGrantFrom) refKey {
+	return refKey{
+		Group:     string(from.Group),
+		Kind:      string(from.Kind),
+		Namespace: string(from.Namespace),
+	}
+}
+
+func refKeyForReferenceGrantTo(namespace string, to gateway_v1beta1.ReferenceGrantTo) refKey {
+	var name string
+	if to.Name != nil {
+		name = string(*to.Name)
+	}
+	return refKey{
+		Group:     string(to.Group),
+		Kind:      string(to.Kind),
+		Namespace: namespace,
+		Name:      name,
+	}
+}


### PR DESCRIPTION
## Summary

Add controllers for reconciling Gateway API objects. This consists of watching all object kinds that may participate in the dependency graph, validating the API specification requirements so to update the object status, and then building a model object with all relevant configuration information.

## Related issues

- https://github.com/pomerium/ingress-controller/issues/463

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
