### PR TITLE
gateway: new command-line options

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -17,6 +17,8 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	gateway_v1 "sigs.k8s.io/gateway-api/apis/v1"
+	gateway_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	icsv1 "github.com/pomerium/ingress-controller/apis/ingress/v1"
 )
@@ -55,6 +57,8 @@ func getScheme() (*runtime.Scheme, error) {
 	}{
 		{"core", clientgoscheme.AddToScheme},
 		{"settings", icsv1.AddToScheme},
+		{"gateway_v1", gateway_v1.Install},
+		{"gateway_v1beta1", gateway_v1beta1.Install},
 	} {
 		if err := apply.fn(scheme); err != nil {
 			return nil, fmt.Errorf("%s: %w", apply.name, err)

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -129,6 +129,11 @@ func (s *controllerCmd) buildController(ctx context.Context) (*controllers.Contr
 		return nil, fmt.Errorf("ingress controller opts: %w", err)
 	}
 
+	gatewayConfig, err := s.getGatewayControllerConfig()
+	if err != nil {
+		return nil, fmt.Errorf("gateway controller opts: %w", err)
+	}
+
 	scheme, err := getScheme()
 	if err != nil {
 		return nil, fmt.Errorf("get scheme: %w", err)
@@ -153,13 +158,20 @@ func (s *controllerCmd) buildController(ctx context.Context) (*controllers.Contr
 			DebugDumpConfigDiff:     s.debug,
 			RemoveUnreferencedCerts: false,
 		},
+		GatewayReconciler: &pomerium.DataBrokerReconciler{
+			ConfigID:                pomerium.GatewayControllerConfigID,
+			DataBrokerServiceClient: client,
+			DebugDumpConfigDiff:     s.debug,
+			RemoveUnreferencedCerts: false,
+		},
 		DataBrokerServiceClient: client,
 		MgrOpts: ctrl.Options{
 			Scheme:         scheme,
 			Metrics:        metricsserver.Options{BindAddress: s.metricsAddr},
 			LeaderElection: false,
 		},
-		IngressCtrlOpts: opts,
+		IngressCtrlOpts:         opts,
+		GatewayControllerConfig: gatewayConfig,
 	}
 
 	c.GlobalSettings, err = s.getGlobalSettings()

--- a/cmd/ingress_opts.go
+++ b/cmd/ingress_opts.go
@@ -8,12 +8,15 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	icsv1 "github.com/pomerium/ingress-controller/apis/ingress/v1"
+	"github.com/pomerium/ingress-controller/controllers/gateway"
 	"github.com/pomerium/ingress-controller/controllers/ingress"
 	"github.com/pomerium/ingress-controller/util"
 )
 
 type ingressControllerOpts struct {
 	ClassName               string `validate:"required"`
+	GatewayAPIEnabled       bool
+	GatewayClassName        string `validate:"required"`
 	AnnotationPrefix        string `validate:"required"`
 	Namespaces              []string
 	UpdateStatusFromService string ``
@@ -22,6 +25,8 @@ type ingressControllerOpts struct {
 
 const (
 	ingressClassControllerName = "name"
+	experimentalGatewayAPI     = "experimental-gateway-api"
+	gatewayClassControllerName = "gateway-class-controller-name"
 	annotationPrefix           = "prefix"
 	namespaces                 = "namespaces"
 	sharedSecret               = "shared-secret"
@@ -31,6 +36,8 @@ const (
 
 func (s *ingressControllerOpts) setupFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&s.ClassName, ingressClassControllerName, ingress.DefaultClassControllerName, "IngressClass controller name")
+	flags.BoolVar(&s.GatewayAPIEnabled, experimentalGatewayAPI, false, "experimental support for the Kubernetes Gateway API")
+	flags.StringVar(&s.GatewayClassName, gatewayClassControllerName, gateway.DefaultClassControllerName, "GatewayClass controller name")
 	flags.StringVar(&s.AnnotationPrefix, annotationPrefix, ingress.DefaultAnnotationPrefix, "Ingress annotation prefix")
 	flags.StringSliceVar(&s.Namespaces, namespaces, nil, "namespaces to watch, or none to watch all namespaces")
 	flags.StringVar(&s.UpdateStatusFromService, updateStatusFromService, "", "update ingress status from given service status (pomerium-proxy)")
@@ -73,4 +80,22 @@ func (s *ingressControllerOpts) getIngressControllerOptions() ([]ingress.Option,
 		opts = append(opts, ingress.WithUpdateIngressStatusFromService(*name))
 	}
 	return opts, nil
+}
+
+func (s *ingressControllerOpts) getGatewayControllerConfig() (*gateway.ControllerConfig, error) {
+	if !s.GatewayAPIEnabled {
+		return nil, nil
+	}
+
+	cfg := &gateway.ControllerConfig{
+		ControllerName: s.GatewayClassName,
+	}
+	if s.UpdateStatusFromService != "" {
+		name, err := util.ParseNamespacedName(s.UpdateStatusFromService)
+		if err != nil {
+			return cfg, fmt.Errorf("update status from service: %q: %w", s.UpdateStatusFromService, err)
+		}
+		cfg.ServiceName = *name
+	}
+	return cfg, nil
 }

--- a/controllers/gateway/controller.go
+++ b/controllers/gateway/controller.go
@@ -41,7 +41,7 @@ func NewControllers(
 		return fmt.Errorf("couldn't create GatewayClass controller: %w", err)
 	}
 	if err := NewGatewayController(ctx, mgr, pgr, config); err != nil {
-		return fmt.Errorf("create gateway controller: %w", err)
+		return fmt.Errorf("couldn't create Gateway controller: %w", err)
 	}
 	return nil
 }

--- a/controllers/gateway/controller.go
+++ b/controllers/gateway/controller.go
@@ -30,6 +30,22 @@ type ControllerConfig struct {
 	ServiceName types.NamespacedName
 }
 
+// NewControllers sets up GatewayClass and Gateway controllers.
+func NewControllers(
+	ctx context.Context,
+	mgr ctrl.Manager,
+	pgr pomerium.GatewayReconciler,
+	config ControllerConfig,
+) error {
+	if err := NewGatewayClassController(mgr, config.ControllerName); err != nil {
+		return fmt.Errorf("couldn't create GatewayClass controller: %w", err)
+	}
+	if err := NewGatewayController(ctx, mgr, pgr, config); err != nil {
+		return fmt.Errorf("create gateway controller: %w", err)
+	}
+	return nil
+}
+
 type gatewayController struct {
 	client.Client
 	pomerium.GatewayReconciler


### PR DESCRIPTION
## Summary

Introduce an `--experimental-gateway-api` command-line flag to guard the new Gateway API code paths. Add a `--gateway-class-controller-name` flag to allow customizing the ControllerName used with GatewayClass objects.

When Gateway API support is enabled, initialize the Gateway controllers alongside the existing IngressController and SettingsController.

## Related issues

- https://github.com/pomerium/ingress-controller/issues/463

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
