### PR TITLE
gateway: add config/gateway-api kustomization

### DIFF
--- a/config/gateway-api/kustomization.yaml
+++ b/config/gateway-api/kustomization.yaml
@@ -1,0 +1,21 @@
+namespace: pomerium
+commonLabels:
+  app.kubernetes.io/name: pomerium
+resources:
+  - ../default
+patches:
+  - path: role_patch.yaml
+    target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: pomerium-controller
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: '--experimental-gateway-api'
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: pomerium

--- a/config/gateway-api/role_patch.yaml
+++ b/config/gateway-api/role_patch.yaml
@@ -36,3 +36,25 @@
       - get
       - patch
       - update
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - gateway.pomerium.io
+    resources:
+      - policyfilters
+    verbs:
+      - get
+      - list
+      - watch
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - gateway.pomerium.io
+    resources:
+      - policyfilters/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/config/gateway-api/role_patch.yaml
+++ b/config/gateway-api/role_patch.yaml
@@ -1,0 +1,38 @@
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses
+      - gateways
+      - httproutes
+      - referencegrants
+    verbs:
+      - get
+      - list
+      - watch
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gatewayclasses/status
+      - gateways/status
+      - httproutes/status
+    verbs:
+      - get
+      - patch
+      - update


### PR DESCRIPTION
## Summary

Add a config/gateway-api kustomization to install Ingress Controller with the `--experimental-gateway-api` flag and to add some necessary ClusterRole permissions to be able to reconcile Gateway API objects.

## Related issues

- https://github.com/pomerium/ingress-controller/issues/463

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
