### PR TITLE
gateway: add GatewayClass to kustomization

### DIFF
--- a/config/gateway-api/gatewayclass.yaml
+++ b/config/gateway-api/gatewayclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: pomerium-gateway
+spec:
+  controllerName: "pomerium.io/gateway-controller"

--- a/config/gateway-api/kustomization.yaml
+++ b/config/gateway-api/kustomization.yaml
@@ -3,6 +3,7 @@ commonLabels:
   app.kubernetes.io/name: pomerium
 resources:
   - ../default
+  - gatewayclass.yaml
 patches:
   - path: role_patch.yaml
     target:


### PR DESCRIPTION
## Summary

Add a GatewayClass object to the gateway-api kustomization.

## Related issues

- https://github.com/pomerium/ingress-controller/issues/463

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
