### PR TITLE
rename codec_type to codecType

### DIFF
--- a/apis/ingress/v1/pomerium_types.go
+++ b/apis/ingress/v1/pomerium_types.go
@@ -288,7 +288,7 @@ type PomeriumSpec struct {
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum=auto;http1;http2;http3
-	CodecType *string `json:"codec_type,omitempty"`
+	CodecType *string `json:"codecType,omitempty"`
 }
 
 // Timeouts allows to configure global timeouts for all routes.

--- a/config/crd/bases/ingress.pomerium.io_pomerium.yaml
+++ b/config/crd/bases/ingress.pomerium.io_pomerium.yaml
@@ -95,7 +95,7 @@ spec:
                 items:
                   type: string
                 type: array
-              codec_type:
+              codecType:
                 description: CodecType sets the <a href="https://www.pomerium.com/docs/reference/codec-type">Codec
                   Type</a>.
                 enum:

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -237,7 +237,7 @@ spec:
                 items:
                   type: string
                 type: array
-              codec_type:
+              codecType:
                 description: CodecType sets the <a href="https://www.pomerium.com/docs/reference/codec-type">Codec
                   Type</a>.
                 enum:

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v1.0.0
+	github.com/pomerium/csrf v1.7.0
 	github.com/pomerium/pomerium v0.28.1-0.20250108215757-21b9e7890c75
 	github.com/rs/zerolog v1.33.0
 	github.com/sergi/go-diff v1.3.1
@@ -164,7 +165,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/pomerium/csrf v1.7.0 // indirect
 	github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 // indirect
 	github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46 // indirect
 	github.com/pomerium/webauthn v0.0.0-20240603205124-0428df511172 // indirect

--- a/pomerium/config.go
+++ b/pomerium/config.go
@@ -114,7 +114,7 @@ func applySetOtherOptions(_ context.Context, p *pb.Config, c *model.Config) erro
 		case "http3":
 			p.Settings.CodecType = http_connection_managerv3.HttpConnectionManager_HTTP3.Enum()
 		default:
-			return fmt.Errorf("unknown codec_type %s", *c.Spec.CodecType)
+			return fmt.Errorf("unknown codecType %s", *c.Spec.CodecType)
 		}
 	}
 	if c.Spec.AccessLogFields != nil {

--- a/reference.md
+++ b/reference.md
@@ -110,6 +110,22 @@ PomeriumSpec defines Pomerium-specific configuration parameters.
         <tr>
             <td>
                 <p>
+                <code>codecType</code>&#160;&#160;
+
+                    <strong>string</strong>&#160;
+
+                </p>
+                <p>
+
+                    CodecType sets the <a href="https://www.pomerium.com/docs/reference/codec-type">Codec Type</a>.
+                </p>
+
+            </td>
+        </tr>
+
+        <tr>
+            <td>
+                <p>
                 <code>cookie</code>&#160;&#160;
 
                     <strong>object</strong>&#160;
@@ -184,6 +200,22 @@ PomeriumSpec defines Pomerium-specific configuration parameters.
                 <p>
 
                     ProgrammaticRedirectDomains specifies a list of domains that can be used for <a href="https://www.pomerium.com/docs/capabilities/programmatic-access">programmatic redirects</a>.
+                </p>
+
+            </td>
+        </tr>
+
+        <tr>
+            <td>
+                <p>
+                <code>runtimeFlags</code>&#160;&#160;
+
+                    <strong>map[string]boolean</strong>
+
+                </p>
+                <p>
+
+                    RuntimeFlags sets the <a href="https://www.pomerium.com/docs/reference/runtime-flags">runtime flags</a> to enable/disable certain features.
                 </p>
 
             </td>


### PR DESCRIPTION
## Summary
Rename `codec_type` to `codecType` to be consistent with other options.
 


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
