### PR TITLE
Makefile: unset GOOS for get-envoy command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ envoy-ci: envoy
 .PHONY: envoy
 envoy:
 	@echo "==> $@"
-	mkdir -p ./pomerium/envoy/bin && cd ./pomerium/envoy/bin && go run github.com/pomerium/pomerium/pkg/envoy/get-envoy
+	mkdir -p ./pomerium/envoy/bin && cd ./pomerium/envoy/bin && env -u GOOS go run github.com/pomerium/pomerium/pkg/envoy/get-envoy
 
 UI_DIR = $(shell go list -f {{.Dir}} github.com/pomerium/pomerium/ui)
 internal/ui:


### PR DESCRIPTION
## Summary

Ingress Controller can be built on macOS by running a command like

    GOOS=linux make build && docker build . -t ingress-controller:dev

except that this will attempt to build and run the `get-envoy` command for Linux as well, which won't work. Let's update the Makefile 'envoy' target to unset the GOOS variable so that the get-envoy command is always built for the host OS.

## Related issues

- see also https://github.com/pomerium/pomerium/pull/5300

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
