### PR TITLE
Revert "ci: update docs script destination path (#990)"

### DIFF
--- a/scripts/open-docs-pull-request.sh
+++ b/scripts/open-docs-pull-request.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 source_path="reference.md"
 destination_repo="pomerium/documentation"
-destination_path="content/docs/k8s"
+destination_path="content/docs/deploy/k8s"
 destination_base_branch="main"
 destination_head_branch="update-k8s-reference-$GITHUB_SHA"
 


### PR DESCRIPTION
## Summary

This reverts commit d10ad6d7d4f2249d70ca46f46b947202442f3249.

The reference.md file was moved back to content/docs/deploy/k8s in https://github.com/pomerium/documentation/pull/1726.

This should fix the failing [Docs](https://github.com/pomerium/ingress-controller/actions/workflows/docs.yaml) workflow.

## Related issues

n/a

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
