### PR TITLE
ports: use high ports, advertise http/3 port as 443

### DIFF
--- a/cmd/all_in_one.go
+++ b/cmd/all_in_one.go
@@ -11,6 +11,7 @@ import (
 
 	validate "github.com/go-playground/validator/v10"
 	"github.com/spf13/cobra"
+	"github.com/volatiletech/null/v9"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
@@ -114,8 +115,8 @@ func (s *allCmd) setupFlags() error {
 	flags.BoolVar(&s.debugEnvoy, debugEnvoy, false, "enable debug logging for envoy")
 	flags.StringVar(&s.metricsBindAddress, metricsBindAddress, "", "host:port for aggregate metrics. host is mandatory")
 	flags.StringVar(&s.adminBindAddr, debugAdminBindAddr, "", "host:port for admin server")
-	flags.StringVar(&s.serverAddr, "server-addr", ":443", "the address the HTTPS server would bind to")
-	flags.StringVar(&s.httpRedirectAddr, "http-redirect-addr", ":80", "the address HTTP redirect would bind to")
+	flags.StringVar(&s.serverAddr, "server-addr", ":8443", "the address the HTTPS server would bind to")
+	flags.StringVar(&s.httpRedirectAddr, "http-redirect-addr", ":8080", "the address HTTP redirect would bind to")
 	flags.StringVar(&s.deriveTLS, "databroker-auto-tls", "", "enable auto TLS and generate server certificate for the domain")
 	flags.DurationVar(&s.configControllerShutdownTimeout, configControllerShutdown, time.Second*30, "timeout waiting for graceful config controller shutdown")
 
@@ -265,6 +266,7 @@ func (s *allCmdParam) makeBootstrapConfig(opt allCmdOptions) error {
 		s.cfg.Options.LogLevel = "debug"
 	}
 	s.cfg.Options.EnvoyAdminAddress = opt.adminBindAddr
+	s.cfg.Options.HTTP3AdvertisePort = null.NewUint32(443, true)
 
 	return nil
 }

--- a/config/pomerium/deployment/no-root.yaml
+++ b/config/pomerium/deployment/no-root.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        sysctls:
-          - name: net.ipv4.ip_unprivileged_port_start
-            value: "80"
       containers:
         - name: pomerium
           securityContext:

--- a/config/pomerium/deployment/ports.yaml
+++ b/config/pomerium/deployment/ports.yaml
@@ -8,14 +8,14 @@ spec:
       containers:
         - name: pomerium
           ports:
-            - containerPort: 443
+            - containerPort: 8443
               name: https
               protocol: TCP
             - containerPort: 443
               name: quic
               protocol: UDP
             - name: http
-              containerPort: 80
+              containerPort: 8080
               protocol: TCP
             - name: metrics
               containerPort: 9090

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -770,13 +770,13 @@ spec:
         imagePullPolicy: Always
         name: pomerium
         ports:
-        - containerPort: 443
+        - containerPort: 8443
           name: https
           protocol: TCP
         - containerPort: 443
           name: quic
           protocol: UDP
-        - containerPort: 80
+        - containerPort: 8080
           name: http
           protocol: TCP
         - containerPort: 9090
@@ -805,9 +805,6 @@ spec:
         kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
-        sysctls:
-        - name: net.ipv4.ip_unprivileged_port_start
-          value: "80"
       serviceAccountName: pomerium-controller
       terminationGracePeriodSeconds: 10
       volumes:

--- a/go.mod
+++ b/go.mod
@@ -17,13 +17,15 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v1.1.0
-	github.com/pomerium/pomerium v0.28.1-0.20250127214108-332d3dc3345e
+	github.com/pomerium/csrf v1.7.0
+	github.com/pomerium/pomerium v0.28.1-0.20250204182906-81a52db74940
 	github.com/rs/zerolog v1.33.0
 	github.com/sergi/go-diff v1.3.1
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
+	github.com/volatiletech/null/v9 v9.0.0
 	go.uber.org/mock v0.5.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.10.0
@@ -89,6 +91,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.12.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.1.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
+	github.com/exaring/otelpgx v0.8.0 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
@@ -158,7 +161,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/pomerium/csrf v1.7.0 // indirect
 	github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 // indirect
 	github.com/pomerium/envoy-custom v1.32.4-0.20250114182541-6f6d2147bea6 // indirect
 	github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46 // indirect
@@ -184,13 +186,13 @@ require (
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.8.0 // indirect
 	github.com/tniswong/go.rfcx v0.0.0-20181019234604-07783c52761f // indirect
-	github.com/volatiletech/null/v9 v9.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zeebo/blake3 v0.2.4 // indirect
+	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.32.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/evanphx/json-patch v5.7.0+incompatible h1:vgGkfT/9f8zE6tvSCe74nfpAVDQ
 github.com/evanphx/json-patch v5.7.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
+github.com/exaring/otelpgx v0.8.0 h1:uqoDIW9qKkyz479z2cGrmJ8OJypydyEA+xwey4ukvNo=
+github.com/exaring/otelpgx v0.8.0/go.mod h1:ANkRZDfgfmN6yJS1xKMkshbnsHO8at5sYwtVEYOX8hc=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -539,8 +541,8 @@ github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 h1:3YQY1sb5
 github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524/go.mod h1:7fGbUYJnU8RcxZJvUvhukOIBv1G7LWDAHMfDxAf5+Y0=
 github.com/pomerium/envoy-custom v1.32.4-0.20250114182541-6f6d2147bea6 h1:QLVgpx23jcbgR9qJzIicJ+uXGjQXO0GAy55SCo0Jd9o=
 github.com/pomerium/envoy-custom v1.32.4-0.20250114182541-6f6d2147bea6/go.mod h1:afbaKE6YfshVUOrYc6XWUWfZcXencWmi1jTc00ki0Oo=
-github.com/pomerium/pomerium v0.28.1-0.20250127214108-332d3dc3345e h1:7MqaUPUOpZW8bBLPSAlwK9RTGEVjnxQ3ErT3lx3syQk=
-github.com/pomerium/pomerium v0.28.1-0.20250127214108-332d3dc3345e/go.mod h1:ujclJDq2BGZuSe2/9Lz2w4MpTVIR8DrR05qyjk1OcsU=
+github.com/pomerium/pomerium v0.28.1-0.20250204182906-81a52db74940 h1:Gi6ZFj2KUoI71thjzNKH4y13ip4LPLjABTQN+33P9IY=
+github.com/pomerium/pomerium v0.28.1-0.20250204182906-81a52db74940/go.mod h1:8Uf1ya/wSjJyeUo5X4TqctlrYxbc5iPfFG18x1t0Deo=
 github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46 h1:NRTg8JOXCxcIA1lAgD74iYud0rbshbWOB3Ou4+Huil8=
 github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46/go.mod h1:QqZmx6ZgPxz18va7kqoT4t/0yJtP7YFIDiT/W2n2fZ4=
 github.com/pomerium/webauthn v0.0.0-20240603205124-0428df511172 h1:TqoPqRgXSHpn+tEJq6H72iCS5pv66j3rPprThUEZg0E=


### PR DESCRIPTION
## Summary

Previously, pomerium container was configured as non-root and used 8443/8080 ports on the container level.
That did not exactly played well with http/3 and it was changed in #1085 to use 443/80, with addition of additional syscall permissions. 

As we learned, some K8S hosted offerings (i.e. GKE Autopilot) do not seem to allow that. 

This PR sets ports back to 8443/8080 and sets http/3 advertised port to 443 using a new option from https://github.com/pomerium/pomerium/pull/5466


## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
