### PR TITLE
pomerium: Fix Enpoints port mapping

### DIFF
--- a/pomerium/routes_test.go
+++ b/pomerium/routes_test.go
@@ -1011,7 +1011,7 @@ func TestServicePortsAndEndpoints(t *testing.T) {
 			[]corev1.ServicePort{{
 				Name:       "http",
 				Port:       8000,
-				TargetPort: intstr.IntOrString{StrVal: "http", Type: intstr.String},
+				TargetPort: intstr.IntOrString{StrVal: "grafana-http", Type: intstr.String},
 			}},
 			[]corev1.EndpointSubset{{
 				Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}},
@@ -1019,6 +1019,25 @@ func TestServicePortsAndEndpoints(t *testing.T) {
 			}},
 			[]string{
 				"http://1.2.3.4:80",
+			},
+			false,
+		},
+		{
+			"unnamed port and named target port",
+			networkingv1.ServiceBackendPort{Number: 80},
+			[]corev1.ServicePort{{
+				Port:       80,
+				TargetPort: intstr.IntOrString{StrVal: "backend-http", Type: intstr.String},
+			}},
+			[]corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{IP: "192.0.2.1"}},
+				Ports:     []corev1.EndpointPort{{Port: 8080}},
+			}},
+			// In that case we can't easily determine which Endpoints port
+			// corresponds to the Service port, so we need to fallback to using the
+			// Service instead.
+			[]string{
+				"http://service.default.svc.cluster.local:80",
 			},
 			false,
 		},


### PR DESCRIPTION
## Summary

When trying to determine which Endpoints port to use based on a named
Service port, we weren't finding the right one when the Service
`spec.ports[].name` didn't match the Service `spec.ports[].targetPort`
name.

This commit simplifies the mapping logic, and ensure the extended test
from the previous commit all succeed.

Here's an example of a Service and its associated Endpoints:

```yaml
kind: Service
spec:
  ports:
  - name: grafana
    port: 80
    targetPort: grafana-http
```

```yaml
kind: Endpoints
subsets:
- ports:
  - name: grafana
    port: 3000
```

An Ingress refers to the Service by name, and to a specific port either by
name or by number.

If by name (`grafana` in the example above), then it's always the same as
the port name on the Endpoints.

But if by number (`80` in the example above), then we need to find the
correct Endpoints port by matching the Service targetPort.

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
