### PR TITLE
revert 1030

### DIFF
--- a/config/pomerium/service/proxy.yaml
+++ b/config/pomerium/service/proxy.yaml
@@ -4,7 +4,6 @@ metadata:
   name: pomerium-proxy
 spec:
   type: LoadBalancer
-  externalTrafficPolicy: Local
   ports:
     - port: 443
       targetPort: https

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -785,7 +785,6 @@ metadata:
   name: pomerium-proxy
   namespace: pomerium
 spec:
-  externalTrafficPolicy: Local
   ports:
   - name: https
     port: 443


### PR DESCRIPTION
## Summary

This PR restores a default `externalTrafficPolicy` for the proxy service (`cluster`), as setting it to Local should also have additional configuration to the `healthCheckNodePort` and load balancer configuration.

## Related issues

Revert #1030

<!-- For example...
Fixes #159
-->


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
