### PR TITLE
ci: testing changes to test.yaml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,22 +35,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          fetch-depth: 0
 
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
           go-version: 1.24.x
 
-      - name: set env vars
-        run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-
       - name: test
         if: runner.os == 'Linux'
         run: make test
-        env:
-          # Remove this override when 1.31.1 is available for envtest
-          ENVTEST_K8S_VERSION: 1.31.0
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

See if the GITHUB_PATH step is still needed after recent Makefile changes. Also try a shallow clone and see if envtest supports 1.31.1 now.

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
