### PR TITLE
add support for the route 'depends_on' option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pomerium/ingress-controller
 
-go 1.23.6
+go 1.23.8
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -16,7 +16,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v1.3.0
-	github.com/pomerium/pomerium v0.28.1-0.20250404232651-5f95dd32dba1
+	github.com/pomerium/pomerium v0.28.1-0.20250422154709-e71fca76f24a
 	github.com/rs/zerolog v1.34.0
 	github.com/sergi/go-diff v1.3.1
 	github.com/spf13/cobra v1.9.1
@@ -92,6 +92,7 @@ require (
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
+	github.com/gaissmai/bart v0.20.3 // indirect
 	github.com/go-chi/chi/v5 v5.2.1 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
+github.com/gaissmai/bart v0.20.3 h1:hZxPDasx5f2rmNsKwvNu5JMV0+SUs/uovkUNKN/807U=
+github.com/gaissmai/bart v0.20.3/go.mod h1:HRCXF6EPBV4dcRPUTZtjVx384e3RYVHJ5H22ApAqltA=
 github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
 github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -541,8 +543,8 @@ github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 h1:3YQY1sb5
 github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524/go.mod h1:7fGbUYJnU8RcxZJvUvhukOIBv1G7LWDAHMfDxAf5+Y0=
 github.com/pomerium/envoy-custom v1.33.0 h1:WK5f+mGIu6VcxYTTeZqth6If6EWHrxymfvc+Rwm5Vl8=
 github.com/pomerium/envoy-custom v1.33.0/go.mod h1:afbaKE6YfshVUOrYc6XWUWfZcXencWmi1jTc00ki0Oo=
-github.com/pomerium/pomerium v0.28.1-0.20250404232651-5f95dd32dba1 h1:nhxtHKIHvQ/wH+pnF0tV27QgQZGIIlOb0S/690Phqg4=
-github.com/pomerium/pomerium v0.28.1-0.20250404232651-5f95dd32dba1/go.mod h1:Xk9qEjztnOjPiVF2fbAIQsWjrsWmXeiNHHXgOFABbwA=
+github.com/pomerium/pomerium v0.28.1-0.20250422154709-e71fca76f24a h1:ZiCvpbak+hzuYiE11QvfJhVwS+liplssH5/mosSTGT0=
+github.com/pomerium/pomerium v0.28.1-0.20250422154709-e71fca76f24a/go.mod h1:bJsjBHowyIx1uitsOXN3Gy1iv5fiauAPfqH+O/tUwoo=
 github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46 h1:NRTg8JOXCxcIA1lAgD74iYud0rbshbWOB3Ou4+Huil8=
 github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46/go.mod h1:QqZmx6ZgPxz18va7kqoT4t/0yJtP7YFIDiT/W2n2fZ4=
 github.com/pomerium/webauthn v0.0.0-20240603205124-0428df511172 h1:TqoPqRgXSHpn+tEJq6H72iCS5pv66j3rPprThUEZg0E=

--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -27,6 +27,7 @@ var (
 		"bearer_token_format",
 		"cors_allow_preflight",
 		"description",
+		"depends_on",
 		"host_path_regex_rewrite_pattern",
 		"host_path_regex_rewrite_substitution",
 		"host_rewrite_header",

--- a/pomerium/ingress_annotations_test.go
+++ b/pomerium/ingress_annotations_test.go
@@ -48,6 +48,7 @@ func TestAnnotations(t *testing.T) {
 					"a/bearer_token_format":                     `idp_access_token`,
 					"a/cors_allow_preflight":                    "true",
 					"a/description":                             "DESCRIPTION",
+					"a/depends_on":                              `["foo.example.com", "bar.example.com", "baz.example.com"]`,
 					"a/health_checks":                           `[{"timeout": "10s", "interval": "1m", "healthy_threshold": 1, "unhealthy_threshold": 2, "http_health_check": {"path": "/"}}]`,
 					"a/host_path_regex_rewrite_pattern":         "rewrite-pattern",
 					"a/host_path_regex_rewrite_substitution":    "rewrite-sub",
@@ -199,6 +200,7 @@ func TestAnnotations(t *testing.T) {
 		LogoUrl:                        "LOGO_URL",
 		BearerTokenFormat:              pb.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_ACCESS_TOKEN.Enum(),
 		IdpAccessTokenAllowedAudiences: &pb.Route_StringList{Values: []string{"x", "y", "z"}},
+		DependsOn:                      []string{"foo.example.com", "bar.example.com", "baz.example.com"},
 	}, cmpopts.IgnoreUnexported(
 		pb.Route{},
 		pb.Route_StringList{},


### PR DESCRIPTION
## Summary

Add support for a new ingress annotation `ingress.pomerium.io/depends_on`, corresponding to the new route `depends_on` option. This can be used to set up a chain of login redirects through additional domains.

## Related issues

https://linear.app/pomerium/issue/ENG-2325/ingress-controller-add-support-for-additional-domain-login-redirects

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
