### PR TITLE
ci: ignore pomerium/pomerium dependency

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,13 +23,14 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 50
+    ignore:
+      - dependency-name: "github.com/pomerium/pomerium"
     groups:
       go:
         patterns:
           - "*"
         exclude-patterns:
           - "*k8s.io*"
-          - "github.com/pomerium/pomerium"
       k8s:
         patterns:
           - "*k8s.io*"


### PR DESCRIPTION
## Summary

We have a separate [workflow](https://github.com/pomerium/ingress-controller/blob/main/.github/workflows/update-core.yaml) for updating the pomerium/pomerium dependency, so we don't want dependabot to manage this dependency.

However, even though we have this dependency excluded in the `groups` section of the dependabot config, it looks like dependabot is still opening PRs for it (most recently https://github.com/pomerium/ingress-controller/pull/1154).

I think we can use the `ignore` property for this instead. See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#ignoring-specific-dependencies.

## Related issues

- https://github.com/pomerium/ingress-controller/pull/951


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
