### PR TITLE
fix: persistence docs link in pomerium CR status

### DIFF
--- a/pomerium/config.go
+++ b/pomerium/config.go
@@ -71,7 +71,7 @@ func checkForWarnings(ctx context.Context, _ *pb.Config, c *model.Config) error 
 	if c.Spec.Storage == nil || c.Spec.Storage.Postgres == nil {
 		util.Add(ctx, config.FieldMsg{
 			Key:           "storage",
-			DocsURL:       "https://www.pomerium.com/docs/topics/data-storage#persistence",
+			DocsURL:       "https://www.pomerium.com/docs/internals/data-storage",
 			FieldCheckMsg: "please specify a persistent storage backend",
 			KeyAction:     config.KeyActionWarn,
 		})


### PR DESCRIPTION
## Summary

When persistence is not configured for pomerium, (in this case, using the defaults in the docs https://www.pomerium.com/docs/deploy/k8s/quickstart#install-pomerium) the status field will direct users to the following link :
```yaml
Status:
  Settings Status:
    Observed At:          2025-07-06T13:57:16Z
    Observed Generation:  1
    Reconciled:           true
    Warnings:
      storage: please specify a persistent storage backend, please see https://www.pomerium.com/docs/topics/data-storage#persistence
```

This link appears outdated, and the topic now resides at https://www.pomerium.com/docs/internals/data-storage

Tested using `docker.io/alex7285/ingress-controller:dev@sha256:1452c5fbc640d2cb0530684b2f796bd0eaf0453c177770943a78a93c27095725` that the link now correctly shows up on the CR when persistence is not enabled:

```yaml
Status:
  Settings Status:
    Observed At:          2025-07-06T16:55:03Z
    Observed Generation:  1
    Reconciled:           true
    Warnings:
      storage: please specify a persistent storage backend, please see https://www.pomerium.com/docs/internals/data-storage
Events:
  Type     Reason      Age    From                                     Message
  ----     ------      ----   ----                                     -------
  Normal   Updated     2m36s  bootstrap pod/pomerium-7786f999cb-xx28g  config updated
  Warning  Validation  2m24s  pomerium-crd                             storage: please specify a persistent storage backend, please see https://www.pomerium.com/docs/internals/data-storage
  Normal   Updated     2m24s  pomerium-crd                             config updated
```

⚠️ Note : I also noticed that the Pomerium CRs do not get enqueued on startup, only when the resources change (this means that changes to internal controller logic will only be applied if the resource changes). That may or may not be intentional, in this case it means the link doesn't change automatically if you upgrade the image, which isn't a very big deal

## Related issues

N/A


## Checklist

- [X] reference any related issues
- [X] updated docs
- [X] updated unit tests
- [X] updated UPGRADING.md
- [X] add appropriate tag (`improvement` / `bug` / etc)
- [X] ready for review
