### PR TITLE
add example of a second ingress controller installation to a cluster

### DIFF
--- a/config/custom-example/README.md
+++ b/config/custom-example/README.md
@@ -1,0 +1,18 @@
+This is an example configuration how you can deploy another version of Pomerium Ingress Controller into the cluster,
+which may be useful if you're testing a new version upgrade.
+
+# Configuration
+
+Each deployment of Pomerium should have their own global settings.
+Make sure different deployments of Pomerium never share the same database if you use persistent storage.
+
+```yaml
+apiVersion: ingress.pomerium.io/v1
+kind: Pomerium
+metadata:
+  name: global-2
+spec:
+  runtimeFlags:
+    mcp: true
+  secrets: pomerium-2/bootstrap
+```

--- a/config/custom-example/ingressclass.yaml
+++ b/config/custom-example/ingressclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: pomerium-2
+spec:
+  controller: pomerium.io/ingress-controller-2

--- a/config/custom-example/kustomization.yaml
+++ b/config/custom-example/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: pomerium-2
+commonLabels:
+  app.kubernetes.io/name: pomerium-2
+resources:
+  - ../pomerium/deployment
+  - ../pomerium/service
+  - ../pomerium/rbac
+  - ../gen_secrets
+  - ingressclass.yaml
+  - namespace.yaml
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: '--name=pomerium.io/ingress-controller-2'
+      - op: replace
+        path: /spec/template/spec/containers/0/args/1
+        value: '--pomerium-config=global-2'
+    target:
+      group: apps
+      kind: Deployment
+      name: pomerium
+      version: v1

--- a/config/custom-example/namespace.yaml
+++ b/config/custom-example/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pomerium-custom

--- a/config/gen_secrets/kustomization.yaml
+++ b/config/gen_secrets/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: pomerium
 resources:
 - job.yaml
 - role_binding.yaml


### PR DESCRIPTION
## Summary

This PR demonstrates how a second instance of Pomerium Ingress Controller may be deployed to the cluster, which may be useful when testing version upgrades or using experimental features from `main` alongside the stable release. 

Please note that CRD definitions are global and cannot be namespaced. 

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
