### PR TITLE
route: add name annotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,8 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v1.6.0
-	github.com/pomerium/pomerium v0.28.1-0.20250703162811-59a1de4fb281
+	github.com/pomerium/csrf v1.7.0
+	github.com/pomerium/pomerium v0.28.1-0.20250708210333-36b568553013
 	github.com/rs/zerolog v1.34.0
 	github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cobra v1.9.1
@@ -189,7 +190,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/pomerium/csrf v1.7.0 // indirect
 	github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 // indirect
 	github.com/pomerium/envoy-custom v1.34.1-rc2.0.20250625214310-c029d58dae62 // indirect
 	github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46 // indirect

--- a/go.sum
+++ b/go.sum
@@ -632,8 +632,8 @@ github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 h1:3YQY1sb5
 github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524/go.mod h1:7fGbUYJnU8RcxZJvUvhukOIBv1G7LWDAHMfDxAf5+Y0=
 github.com/pomerium/envoy-custom v1.34.1-rc2.0.20250625214310-c029d58dae62 h1:H0UYd/lI+U/+TZC3vZ+6jeSCuaNiAc67GBhZuXbfEVw=
 github.com/pomerium/envoy-custom v1.34.1-rc2.0.20250625214310-c029d58dae62/go.mod h1:+wpbZvum83bq/OD4cp9/8IZiMV6boBkwDhlFPLOoWoI=
-github.com/pomerium/pomerium v0.28.1-0.20250703162811-59a1de4fb281 h1:qHi18uxnHn/5M3/y0XIVgndgrzsgKmbz0zUQBVXQQ18=
-github.com/pomerium/pomerium v0.28.1-0.20250703162811-59a1de4fb281/go.mod h1:mPpYBZUXh+TL6mMgDsSU383mG8JIhmStreLZYM5iiBo=
+github.com/pomerium/pomerium v0.28.1-0.20250708210333-36b568553013 h1:9pKhk7DeqtjxEtPMuAzcL3E3qJyKwkl9X73MPc5lUFI=
+github.com/pomerium/pomerium v0.28.1-0.20250708210333-36b568553013/go.mod h1:ByyYIMKnlZEh2StXmTNVXstjqGezqbrqIn8w4jOkVr4=
 github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46 h1:NRTg8JOXCxcIA1lAgD74iYud0rbshbWOB3Ou4+Huil8=
 github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46/go.mod h1:QqZmx6ZgPxz18va7kqoT4t/0yJtP7YFIDiT/W2n2fZ4=
 github.com/pomerium/webauthn v0.0.0-20240603205124-0428df511172 h1:TqoPqRgXSHpn+tEJq6H72iCS5pv66j3rPprThUEZg0E=

--- a/model/ingress_config.go
+++ b/model/ingress_config.go
@@ -14,6 +14,8 @@ import (
 )
 
 const (
+	// Name allows customizing the human-readable route name
+	Name = "name"
 	// TLSCustomCASecret replaces https://pomerium.io/reference/#tls-custom-certificate-authority
 	//nolint: gosec
 	TLSCustomCASecret = "tls_custom_ca_secret"

--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -37,6 +37,7 @@ var (
 		"idle_timeout",
 		"idp_access_token_allowed_audiences",
 		"logo_url",
+		"name",
 		"pass_identity_headers",
 		"prefix_rewrite",
 		"preserve_host_header",

--- a/pomerium/ingress_annotations_test.go
+++ b/pomerium/ingress_annotations_test.go
@@ -585,3 +585,46 @@ func TestMCPAnnotations(t *testing.T) {
 		assert.Contains(t, err.Error(), "mcp_client annotation should be 'true' or omitted")
 	})
 }
+
+func TestNameAnnotation(t *testing.T) {
+	t.Run("custom name annotation", func(t *testing.T) {
+		r := &pb.Route{}
+		ic := &model.IngressConfig{
+			AnnotationPrefix: "ingress.pomerium.io",
+			Ingress: &networkingv1.Ingress{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"ingress.pomerium.io/name": "My Custom Route Name",
+					},
+				},
+			},
+		}
+
+		err := applyAnnotations(r, ic)
+		require.NoError(t, err)
+		assert.Equal(t, "My Custom Route Name", r.Name)
+	})
+
+	t.Run("no name annotation uses generated name", func(t *testing.T) {
+		r := &pb.Route{}
+		ic := &model.IngressConfig{
+			AnnotationPrefix: "ingress.pomerium.io",
+			Ingress: &networkingv1.Ingress{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"ingress.pomerium.io/allow_any_authenticated_user": "true",
+					},
+				},
+			},
+		}
+
+		err := applyAnnotations(r, ic)
+		require.NoError(t, err)
+		// Name should be empty here since setRouteNameID hasn't been called yet
+		assert.Equal(t, "", r.Name)
+	})
+}


### PR DESCRIPTION
## Summary

Adds `ingress.pomerium.io/name` annotation that allows to set a human-readable name to a route. 

## Related issues

Fix https://github.com/pomerium/ingress-controller/issues/1189

## Checklist

- [x] reference any related issues
- [x] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
