### PR TITLE
mcp: add mcp_server_upstream_oauth2_auth_url annotation

### DIFF
--- a/model/ingress_config.go
+++ b/model/ingress_config.go
@@ -62,6 +62,8 @@ const (
 	MCPServerMaxRequestBytes = "mcp_server_max_request_bytes"
 	// MCPServerUpstreamOAuth2Secret references a secret containing OAuth2 configuration for MCP server upstream authentication
 	MCPServerUpstreamOAuth2Secret = "mcp_server_upstream_oauth2_secret" //nolint: gosec
+	// MCPServerUpstreamOAuth2AuthURL sets the OAuth2 token URL for MCP server upstream authentication
+	MCPServerUpstreamOAuth2AuthURL = "mcp_server_upstream_oauth2_auth_url"
 	// MCPServerUpstreamOAuth2TokenURL sets the OAuth2 token URL for MCP server upstream authentication
 	MCPServerUpstreamOAuth2TokenURL = "mcp_server_upstream_oauth2_token_url" //nolint: gosec
 	// MCPServerUpstreamOAuth2Scopes sets the OAuth2 scopes for MCP server upstream authentication

--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -80,6 +80,7 @@ var (
 		model.MCPServer,
 		model.MCPServerMaxRequestBytes,
 		model.MCPServerUpstreamOAuth2TokenURL,
+		model.MCPServerUpstreamOAuth2AuthURL,
 		model.MCPServerUpstreamOAuth2Scopes,
 	})
 	mcpClientAnnotations = boolMap([]string{
@@ -416,6 +417,14 @@ func applyMCPServerAnnotations(r *pomerium.Route, kvs map[string]string) error {
 			}
 			maxBytes := uint32(val)
 			serverConfig.MaxRequestBytes = &maxBytes
+		case model.MCPServerUpstreamOAuth2AuthURL:
+			if serverConfig.UpstreamOauth2 == nil {
+				serverConfig.UpstreamOauth2 = &pomerium.UpstreamOAuth2{}
+			}
+			if serverConfig.UpstreamOauth2.Oauth2Endpoint == nil {
+				serverConfig.UpstreamOauth2.Oauth2Endpoint = &pomerium.OAuth2Endpoint{}
+			}
+			serverConfig.UpstreamOauth2.Oauth2Endpoint.AuthUrl = v
 		case model.MCPServerUpstreamOAuth2TokenURL:
 			if serverConfig.UpstreamOauth2 == nil {
 				serverConfig.UpstreamOauth2 = &pomerium.UpstreamOAuth2{}

--- a/pomerium/ingress_annotations_test.go
+++ b/pomerium/ingress_annotations_test.go
@@ -298,6 +298,7 @@ func TestMCPAnnotations(t *testing.T) {
 						"a/mcp_server_max_request_bytes":         "1048576",
 						"a/mcp_server_upstream_oauth2_secret":    "mcp-oauth2-secret",
 						"a/mcp_server_upstream_oauth2_token_url": "https://auth.example.com/token",
+						"a/mcp_server_upstream_oauth2_auth_url":  "https://auth.example.com/auth",
 						"a/mcp_server_upstream_oauth2_scopes":    "read,write,admin",
 					},
 				},
@@ -326,6 +327,7 @@ func TestMCPAnnotations(t *testing.T) {
 		assert.Equal(t, "test-client-secret", server.UpstreamOauth2.ClientSecret)
 		require.NotNil(t, server.UpstreamOauth2.Oauth2Endpoint)
 		assert.Equal(t, "https://auth.example.com/token", server.UpstreamOauth2.Oauth2Endpoint.TokenUrl)
+		assert.Equal(t, "https://auth.example.com/auth", server.UpstreamOauth2.Oauth2Endpoint.AuthUrl)
 		assert.Equal(t, []string{"read", "write", "admin"}, server.UpstreamOauth2.Scopes)
 	})
 


### PR DESCRIPTION
## Summary

Fix omission from #1178

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
