### PR TITLE
upgrade to core 0.30.2

### DIFF
--- a/config/pomerium/deployment/image.yaml
+++ b/config/pomerium/deployment/image.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
         - name: pomerium
-          image: pomerium/ingress-controller:v0.30.1
+          image: pomerium/ingress-controller:v0.30.2
           imagePullPolicy: Always

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -933,7 +933,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: pomerium/ingress-controller:v0.30.1
+        image: pomerium/ingress-controller:v0.30.2
         imagePullPolicy: Always
         name: pomerium
         ports:

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v1.6.0
 	github.com/pomerium/csrf v1.7.0
-	github.com/pomerium/pomerium v0.30.1
+	github.com/pomerium/pomerium v0.30.2
 	github.com/rs/zerolog v1.34.0
 	github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -632,8 +632,8 @@ github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 h1:3YQY1sb5
 github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524/go.mod h1:7fGbUYJnU8RcxZJvUvhukOIBv1G7LWDAHMfDxAf5+Y0=
 github.com/pomerium/envoy-custom v1.34.1-rc2.0.20250625214310-c029d58dae62 h1:H0UYd/lI+U/+TZC3vZ+6jeSCuaNiAc67GBhZuXbfEVw=
 github.com/pomerium/envoy-custom v1.34.1-rc2.0.20250625214310-c029d58dae62/go.mod h1:+wpbZvum83bq/OD4cp9/8IZiMV6boBkwDhlFPLOoWoI=
-github.com/pomerium/pomerium v0.30.1 h1:SbUFhFf3+mpKdELwI4ESwhfxQwPLkIZzOAOFrkgV2rw=
-github.com/pomerium/pomerium v0.30.1/go.mod h1:ByyYIMKnlZEh2StXmTNVXstjqGezqbrqIn8w4jOkVr4=
+github.com/pomerium/pomerium v0.30.2 h1:6wcjotNfbzZh5465df2/hxLQMwPImDn/krIPiyinrkM=
+github.com/pomerium/pomerium v0.30.2/go.mod h1:ByyYIMKnlZEh2StXmTNVXstjqGezqbrqIn8w4jOkVr4=
 github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46 h1:NRTg8JOXCxcIA1lAgD74iYud0rbshbWOB3Ou4+Huil8=
 github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46/go.mod h1:QqZmx6ZgPxz18va7kqoT4t/0yJtP7YFIDiT/W2n2fZ4=
 github.com/pomerium/webauthn v0.0.0-20240603205124-0428df511172 h1:TqoPqRgXSHpn+tEJq6H72iCS5pv66j3rPprThUEZg0E=


### PR DESCRIPTION
## Summary
Upgrade Pomerium to v0.30.2.


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
