### PR TITLE
feat(ingress) : add common_lb_config as an ingress config annotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v1.7.1
+	github.com/pomerium/csrf v1.7.0
 	github.com/pomerium/pomerium v0.28.1-0.20250717151855-4de63aa74657
 	github.com/rs/zerolog v1.34.0
 	github.com/sergi/go-diff v1.4.0
@@ -177,7 +178,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/pomerium/csrf v1.7.0 // indirect
 	github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 // indirect
 	github.com/pomerium/envoy-custom v1.34.1-rc3 // indirect
 	github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46 // indirect

--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -65,6 +65,9 @@ var (
 		"outlier_detection",
 		"ring_hash_lb_config",
 	})
+	commonLbConfig = boolMap([]string{
+		"healthy_panic_threshold",
+	})
 	tlsAnnotations = boolMap([]string{
 		model.TLSClientSecret,
 		model.TLSCustomCASecret,
@@ -109,7 +112,7 @@ func boolMap(keys []string) map[string]bool {
 }
 
 type keys struct {
-	Base, Envoy, Policy, TLS, Etc, Secret, MCPServer, MCPClient map[string]string
+	Base, Envoy, Policy, CommonLb, TLS, Etc, Secret, MCPServer, MCPClient map[string]string
 }
 
 func removeKeyPrefix(src map[string]string, prefix string) (*keys, error) {
@@ -118,6 +121,7 @@ func removeKeyPrefix(src map[string]string, prefix string) (*keys, error) {
 		Base:      make(map[string]string),
 		Envoy:     make(map[string]string),
 		Policy:    make(map[string]string),
+		CommonLb:  make(map[string]string),
 		TLS:       make(map[string]string),
 		Etc:       make(map[string]string),
 		Secret:    make(map[string]string),
@@ -142,6 +146,7 @@ func removeKeyPrefix(src map[string]string, prefix string) (*keys, error) {
 		}{
 			{baseAnnotations, kv.Base},
 			{envoyAnnotations, kv.Envoy},
+			{commonLbConfig, kv.CommonLb},
 			{policyAnnotations, kv.Policy},
 			{tlsAnnotations, kv.TLS},
 			{secretAnnotations, kv.Secret},
@@ -179,6 +184,13 @@ func applyAnnotations(
 	if err = unmarshalAnnotations(r.EnvoyOpts, kv.Envoy); err != nil {
 		return err
 	}
+	if len(kv.CommonLb) > 0 {
+		r.EnvoyOpts.CommonLbConfig = new(envoy_config_cluster_v3.Cluster_CommonLbConfig)
+		if err := unmarshalAnnotations(r.EnvoyOpts.CommonLbConfig, kv.CommonLb); err != nil {
+			return err
+		}
+	}
+
 	if err = applyTLSAnnotations(r, kv.TLS, ic.Secrets, ic.Ingress.Namespace); err != nil {
 		return err
 	}

--- a/pomerium/proto.go
+++ b/pomerium/proto.go
@@ -37,7 +37,8 @@ func unmarshalAnnotations(dst proto.Message, kvs map[string]string) error {
 }
 
 func preprocessAnnotationMessage(md protoreflect.MessageDescriptor, data any) any {
-	switch md.FullName() {
+	name := md.FullName()
+	switch name {
 	case "google.protobuf.Duration":
 		// convert go duration strings into protojson duration strings
 		if v, ok := data.(string); ok {
@@ -47,6 +48,15 @@ func preprocessAnnotationMessage(md protoreflect.MessageDescriptor, data any) an
 		if v, ok := data.([]any); ok {
 			return map[string]any{"values": v}
 		}
+	case "envoy.type.v3.Percent":
+		// convert percentage value to percentage message {"value" : <double>}
+		v, ok := data.(float64)
+		if ok {
+			return map[string]float64{
+				"value": v,
+			}
+		}
+		fallthrough
 	default:
 		// preprocess all the fields
 		if v, ok := data.(map[string]any); ok {


### PR DESCRIPTION
## Summary

this allows healthy_panic_threshold to be set on pomerium routes, by exposing the `common_lb_config` on the ingress annotations:

```yaml
// ...
annotations:
  <ingress-prefix>/healthy_panic_threshold : <float64>
```


## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
