### PR TITLE
controller: skip name check

### DIFF
--- a/cmd/all_in_one.go
+++ b/cmd/all_in_one.go
@@ -16,7 +16,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	runtime_ctrl "sigs.k8s.io/controller-runtime"
+	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -349,6 +351,9 @@ func (s *allCmdParam) buildController(ctx context.Context, cfg *config.Config) (
 				BindAddress: s.ingressMetricsAddr,
 			},
 			LeaderElection: false,
+			Controller: controllerconfig.Controller{
+				SkipNameValidation: ptr.To(true),
+			},
 		},
 		IngressCtrlOpts:         s.ingressOpts,
 		GlobalSettings:          &s.settings,

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -10,7 +10,9 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"k8s.io/apiserver/pkg/server/healthz"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/config"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
@@ -169,6 +171,9 @@ func (s *controllerCmd) buildController(ctx context.Context) (*controllers.Contr
 			Scheme:         scheme,
 			Metrics:        metricsserver.Options{BindAddress: s.metricsAddr},
 			LeaderElection: false,
+			Controller: config.Controller{
+				SkipNameValidation: ptr.To(true),
+			},
 		},
 		IngressCtrlOpts:         opts,
 		GatewayControllerConfig: gatewayConfig,

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v1.7.1
+	github.com/pomerium/csrf v1.7.0
 	github.com/pomerium/pomerium v0.28.1-0.20250811173331-9eabe50e6751
 	github.com/rs/zerolog v1.34.0
 	github.com/sergi/go-diff v1.4.0
@@ -36,6 +37,7 @@ require (
 	k8s.io/apimachinery v0.33.3
 	k8s.io/apiserver v0.33.3
 	k8s.io/client-go v0.33.3
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/gateway-api v1.3.0
 )
@@ -179,7 +181,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/pomerium/csrf v1.7.0 // indirect
 	github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 // indirect
 	github.com/pomerium/envoy-custom v1.34.1-rc3 // indirect
 	github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46 // indirect
@@ -263,7 +264,6 @@ require (
 	k8s.io/component-base v0.33.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect


### PR DESCRIPTION
## Summary

k8s controller-runtime introduced a global check for the controller name uniquness, which does not account for controllers being shut down, which caused an false positive reporting of duplicate controllers when pomerium IC restarts due to some bootstrap parameters change such as shared secret. 
This PR sets an option to bypass this check. 

## Related issues

Fix #1170

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
