### PR TITLE
[0.30.X] backport(ingress)  : add common_lb_config as an ingress config annotation

### DIFF
--- a/pomerium/ingress_annotations_test.go
+++ b/pomerium/ingress_annotations_test.go
@@ -223,6 +223,7 @@ func TestAnnotations(t *testing.T) {
 		envoy_config_core_v3.HealthCheck_HttpHealthCheck{},
 		envoy_config_cluster_v3.Cluster_LeastRequestLbConfig{},
 		envoy_config_core_v3.RuntimeDouble{},
+		envoy_config_cluster_v3.Cluster_CommonLbConfig{},
 		envoy_config_cluster_v3.Cluster_SlowStartConfig{},
 		wrapperspb.UInt32Value{},
 		pb.CircuitBreakerThresholds{},
@@ -583,5 +584,52 @@ func TestMCPAnnotations(t *testing.T) {
 		err := applyAnnotations(r, ic)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "mcp_client annotation should be 'true' or omitted")
+	})
+}
+
+func TestCommonLbAnnotation(t *testing.T) {
+	t.Run("healthy_panic_threshold annotation", func(t *testing.T) {
+		type testcase struct {
+			input    float64
+			expected float64
+		}
+
+		tcs := []testcase{
+			{
+				input:    50,
+				expected: 50,
+			},
+			{
+				input:    -15.0,
+				expected: -15.0,
+			},
+			{
+				input:    75.0,
+				expected: 75.0,
+			},
+		}
+
+		for _, tc := range tcs {
+			r := &pb.Route{}
+			ic := &model.IngressConfig{
+				AnnotationPrefix: "a",
+				Ingress: &networkingv1.Ingress{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "test-ingress",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"a/healthy_panic_threshold": fmt.Sprintf("%f", tc.input),
+						},
+					},
+				},
+			}
+			err := applyAnnotations(r, ic)
+			require.NoError(t, err)
+
+			require.NotNil(t, r.EnvoyOpts)
+			require.NotNil(t, r.EnvoyOpts.CommonLbConfig)
+			require.NotNil(t, r.EnvoyOpts.CommonLbConfig.HealthyPanicThreshold)
+			require.Equal(t, r.EnvoyOpts.CommonLbConfig.HealthyPanicThreshold.Value, tc.expected)
+		}
 	})
 }

--- a/pomerium/proto.go
+++ b/pomerium/proto.go
@@ -37,7 +37,8 @@ func unmarshalAnnotations(dst proto.Message, kvs map[string]string) error {
 }
 
 func preprocessAnnotationMessage(md protoreflect.MessageDescriptor, data any) any {
-	switch md.FullName() {
+	name := md.FullName()
+	switch name {
 	case "google.protobuf.Duration":
 		// convert go duration strings into protojson duration strings
 		if v, ok := data.(string); ok {
@@ -47,6 +48,15 @@ func preprocessAnnotationMessage(md protoreflect.MessageDescriptor, data any) an
 		if v, ok := data.([]any); ok {
 			return map[string]any{"values": v}
 		}
+	case "envoy.type.v3.Percent":
+		// convert percentage value to percentage message {"value" : <double>}
+		v, ok := data.(float64)
+		if ok {
+			return map[string]float64{
+				"value": v,
+			}
+		}
+		fallthrough
 	default:
 		// preprocess all the fields
 		if v, ok := data.(map[string]any); ok {


### PR DESCRIPTION
## Summary

Backport of : https://github.com/pomerium/ingress-controller/pull/1203

this allows healthy_panic_threshold to be set on pomerium routes, by exposing the `common_lb_config` on the ingress annotations:

```yaml
// ...
annotations:
  <ingress-prefix>/healthy_panic_threshold : <float64>
```


## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review

