### PR TITLE
build health checks into default deployment

### DIFF
--- a/config/pomerium/deployment/healthcheck.yaml
+++ b/config/pomerium/deployment/healthcheck.yaml
@@ -11,6 +11,8 @@ spec:
             httpGet:
               path: /startupz
               port : 28080
+            failureThreshold: 40
+            periodSeconds: 15
           livenessProbe:
             httpGet:
               path: /healthz

--- a/config/pomerium/deployment/kustomization.yaml
+++ b/config/pomerium/deployment/kustomization.yaml
@@ -9,3 +9,4 @@ patches:
 - path: resources.yaml
 - path: no-root.yaml
 - path: readonly-root-fs.yaml
+- path: healthcheck.yaml

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -990,6 +990,13 @@ spec:
               fieldPath: status.podIP
         image: pomerium/ingress-controller:main
         imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz
+            port: 28080
+          initialDelaySeconds: 15
+          periodSeconds: 60
         name: pomerium
         ports:
         - containerPort: 8443
@@ -1004,6 +1011,13 @@ spec:
         - containerPort: 9090
           name: metrics
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: 28080
+          initialDelaySeconds: 15
+          periodSeconds: 60
         resources:
           limits:
             cpu: 5000m
@@ -1020,6 +1034,12 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+        startupProbe:
+          failureThreshold: 40
+          httpGet:
+            path: /startupz
+            port: 28080
+          periodSeconds: 15
         volumeMounts:
         - mountPath: /tmp
           name: tmp


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
