### PR TITLE
pin setup-envtest module version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CRD_BASE=github.com/pomerium/ingress-controller/apis/
 IMG?=ingress-controller:latest
 CRD_OPTIONS?=
 ENVTEST_K8S_VERSION?=$(shell go list -f '{{.Module.Version}}' k8s.io/api | sed -E 's/v0/1/; s/([0-9]+\.[0-9]+)\.[0-9]+/\1.x/')
-SETUP_ENVTEST=go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+SETUP_ENVTEST=go run sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20251010203701-b9bccfd41914
 CONTROLLER_GEN=go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.18.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)


### PR DESCRIPTION
## Summary

Recent test runs are failing with an error from the integration tests:

> unable to start control plane itself: failed to start the controlplane. retried 5 times: exec: "etcd": executable file not found in $PATH

Pin the setup-envtest module to a previous, compatible version.

## Related issues

https://linear.app/pomerium/issue/ENG-3085/ingress-controller-integration-test-failing-due-to-missing-etcd

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
