### PR TITLE
ci: switch back to yarn for docs repo

### DIFF
--- a/scripts/open-docs-pull-request.sh
+++ b/scripts/open-docs-pull-request.sh
@@ -18,7 +18,7 @@ git clone --depth 1 \
 echo "Copying contents to git repo"
 cp -R "$source_path" "$clone_dir/$destination_path"
 cd "$clone_dir"
-npm ci && npm run prettier --write "$destination_path/$source_path"
+yarn && yarn prettier --write "$destination_path/$source_path"
 git checkout -b "$destination_head_branch"
 
 if [ -z "$(git status -z)" ]; then


### PR DESCRIPTION
## Summary

The documentation repo is still using `yarn`, so the `npm` command to run prettier was not working as intended. As a result the script generated a number of formatting-only PRs in the documentation repo. Switch back to `yarn` for now, until we update the documentation repo to use `npm`.

Error message from a recent [workflow run](https://github.com/pomerium/ingress-controller/actions/runs/19971900408/job/57278486872#step:5:13):
```
npm error code EUSAGE
npm error
npm error The `npm ci` command can only install with an existing package-lock.json or
npm error npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or
npm error later to generate a package-lock.json file, then try again.
```

## Related issues

https://linear.app/pomerium/issue/ENG-3286/docs-ingress-controller-automated-docs-prs-are-not-formatting

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
