### PR TITLE
add support for route idp_client_id and idp_client_secret

### DIFF
--- a/model/ingress_config.go
+++ b/model/ingress_config.go
@@ -74,6 +74,12 @@ const (
 	MCPServerUpstreamOAuth2ClientIDKey = "client_id"
 	// MCPServerUpstreamOAuth2ClientSecretKey defines the key within the OAuth2 secret that contains the client secret
 	MCPServerUpstreamOAuth2ClientSecretKey = "client_secret"
+	// IdentityProviderSecret defines a secret to set the idp_client_id and idp_client_secret from.
+	IdentityProviderSecret = "identity_provider_secret"
+	// IdentityProviderClientIDKey is the client id key in the IdentityProviderSecret.
+	IdentityProviderClientIDKey = "client_id"
+	// IdentityProviderClientSecretKey is the client secret key in the IdentityProviderSecret.
+	IdentityProviderClientSecretKey = "client_secret"
 )
 
 // SSHSecrets is a grouping of ssh-related secrets.

--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -78,6 +78,7 @@ var (
 		model.SetRequestHeadersSecret,
 		model.SetResponseHeadersSecret,
 		model.MCPServerUpstreamOAuth2Secret,
+		model.IdentityProviderSecret,
 	})
 	mcpServerAnnotations = boolMap([]string{
 		model.MCPServer,
@@ -354,6 +355,25 @@ func applySecretAnnotations(
 				}
 				if hasClientSecret {
 					server.UpstreamOauth2.ClientSecret = string(clientSecret)
+				}
+
+				return nil
+			},
+		},
+		model.IdentityProviderSecret: {
+			corev1.SecretTypeOpaque,
+			func(data map[string][]byte) error {
+				// client id and client secret are both optional
+				// if not set the global will be used
+
+				clientID, hasClientID := data[model.IdentityProviderClientIDKey]
+				if hasClientID {
+					r.IdpClientId = proto.String(string(clientID))
+				}
+
+				clientSecret, hasClientSecret := data[model.IdentityProviderClientSecretKey]
+				if hasClientSecret {
+					r.IdpClientSecret = proto.String(string(clientSecret))
 				}
 
 				return nil

--- a/pomerium/ingress_annotations_test.go
+++ b/pomerium/ingress_annotations_test.go
@@ -55,6 +55,7 @@ func TestAnnotations(t *testing.T) {
 					"a/host_path_regex_rewrite_substitution":    "rewrite-sub",
 					"a/host_rewrite_header":                     "rewrite-header",
 					"a/host_rewrite":                            "rewrite",
+					"a/identity_provider_secret":                "identity_provider_secret",
 					"a/idle_timeout":                            `60s`,
 					"a/idp_access_token_allowed_audiences":      `["x","y","z"]`,
 					"a/kubernetes_service_account_token_secret": "k8s_token",
@@ -118,6 +119,13 @@ func TestAnnotations(t *testing.T) {
 				Data: map[string][]byte{
 					"res_key_1": []byte("res_data1"),
 					"res_key_2": []byte("res_data2"),
+				},
+				Type: corev1.SecretTypeOpaque,
+			},
+			{Name: "identity_provider_secret", Namespace: "test"}: {
+				Data: map[string][]byte{
+					"client_id":     []byte("CLIENT_ID"),
+					"client_secret": []byte("CLIENT_SECRET"),
 				},
 				Type: corev1.SecretTypeOpaque,
 			},
@@ -201,6 +209,8 @@ func TestAnnotations(t *testing.T) {
 		LogoUrl:                        "LOGO_URL",
 		BearerTokenFormat:              pb.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_ACCESS_TOKEN.Enum(),
 		IdpAccessTokenAllowedAudiences: &pb.Route_StringList{Values: []string{"x", "y", "z"}},
+		IdpClientId:                    proto.String("CLIENT_ID"),
+		IdpClientSecret:                proto.String("CLIENT_SECRET"),
 		DependsOn:                      []string{"foo.example.com", "bar.example.com", "baz.example.com"},
 		CircuitBreakerThresholds: &pb.CircuitBreakerThresholds{
 			MaxConnections:     proto.Uint32(1),


### PR DESCRIPTION
## Summary
Add support for route `idp_client_id` and `idp_client_secret`. This is done with an annotation like:

```yaml
ingress.pomerium.io/identity_provider_secret: idp-secret
```

And a corresponding secret:

```yaml
apiVersion: v1
kind: Secret
type: Opaque
data:
  client_id: ''
  client_secret: ''
metadata:
  name: idp-secret
  namespace: pomerium
```

## Related issues
- https://github.com/pomerium/pomerium/issues/5954


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
