### PR TITLE
ingress-controller/gateway: fix missing source ppl

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -17,6 +17,7 @@ words:
   - protobuf
   - protojson
   - readyz
+  - rego
   - sharedkey
   - sslcert
   - sslkey

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,0 +1,29 @@
+package policy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-policy-agent/opa/ast"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/pomerium/pomerium/pkg/policy"
+)
+
+// Parse parses PPL into rego.
+func Parse(src string) (ppl *string, rego []string, err error) {
+	regoSrc, err := policy.GenerateRegoFromReader(strings.NewReader(src))
+	if err != nil {
+		return nil, nil, fmt.Errorf("couldn't parse policy: %w", err)
+	}
+
+	_, err = ast.ParseModule("policy.rego", regoSrc)
+	if err != nil && strings.Contains(err.Error(), "package expected") {
+		_, err = ast.ParseModule("policy.rego", "package pomerium.policy\n\n"+regoSrc)
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("internal error: %w", err)
+	}
+
+	return proto.String(src), []string{regoSrc}, nil
+}

--- a/pomerium/gateway/translate_test.go
+++ b/pomerium/gateway/translate_test.go
@@ -1,0 +1,73 @@
+package gateway_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	icgv1alpha1 "github.com/pomerium/ingress-controller/apis/gateway/v1alpha1"
+	"github.com/pomerium/ingress-controller/model"
+	"github.com/pomerium/ingress-controller/pomerium/gateway"
+)
+
+func TestTranslate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fills source ppl", func(t *testing.T) {
+		t.Parallel()
+
+		var policy icgv1alpha1.PolicyFilter
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"metadata": {
+				"name": "example"
+			},
+			"spec": {
+				"ppl": "allow:\n  and:\n    - email:\n        is: user@example.com"
+			}
+		}`), &policy))
+		policyFilter, err := gateway.NewPolicyFilter(&policy)
+		require.NoError(t, err)
+
+		var route v1.HTTPRoute
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"spec": {
+				"hostnames": ["example.com"],
+				"rules": [{
+					"matches": [{
+						"path": {
+							"value": "/"
+						}
+					}],
+					"filters": [{
+						"type": "ExtensionRef",
+						"extensionRef": {
+							"group": "gateway.pomerium.io",
+							"kind": "PolicyFilter",
+							"name": "example"
+						}
+					}]
+				}]
+			}
+		}`), &route))
+
+		result := gateway.TranslateRoutes(t.Context(),
+			&model.GatewayConfig{
+				ExtensionFilters: map[model.ExtensionFilterKey]model.ExtensionFilter{
+					{Kind: "PolicyFilter", Namespace: "", Name: "example"}: policyFilter,
+				},
+			},
+			&model.GatewayHTTPRouteConfig{
+				HTTPRoute: &route,
+				Hostnames: []v1.Hostname{"example.com"},
+			})
+		if assert.Len(t, result, 1) {
+			if assert.Len(t, result[0].Policies, 1) {
+				assert.Equal(t, policy.Spec.PPL, result[0].Policies[0].GetSourcePpl(),
+					"should fill source ppl")
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary
The `SourcePpl` field was not being set by the gateway controller. As a consequence the routes index wasn't working for gateway routes.

## Related issues
- [ENG-3598](https://linear.app/pomerium/issue/ENG-3598/routes-portal-returns-empty-routes-when-using-gateway-api-mode)

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
