### PR TITLE
translate Ingress to unified API Policy entity

### DIFF
--- a/pomerium/ingress_to_policy.go
+++ b/pomerium/ingress_to_policy.go
@@ -1,0 +1,71 @@
+package pomerium
+
+import (
+	"fmt"
+
+	"github.com/gosimple/slug"
+	"gopkg.in/yaml.v3"
+
+	"github.com/pomerium/pomerium/config"
+	pomerium "github.com/pomerium/pomerium/pkg/grpc/config"
+	"github.com/pomerium/pomerium/pkg/identity"
+	"github.com/pomerium/pomerium/pkg/policy/parser"
+
+	"github.com/pomerium/ingress-controller/model"
+)
+
+// ingressToPolicy translates Ingress annotations to a Policy proto compatible
+// with the unified API.
+func ingressToPolicy(ic *model.IngressConfig) (*pomerium.Policy, error) {
+	kv, err := removeKeyPrefix(ic.Ingress.Annotations, ic.AnnotationPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	p := new(pomerium.Policy)
+	if err := unmarshalPolicyAnnotations(p, kv.Policy); err != nil {
+		return nil, fmt.Errorf("couldn't unmarshal policy annotations: %w", err)
+	}
+
+	// Use the same conversion logic from Core to translate the legacy
+	// allowlist fields.
+	configPolicy := config.Policy{
+		AllowedDomains:   p.AllowedDomains,
+		AllowedUsers:     p.AllowedUsers,
+		AllowedIDPClaims: identity.NewFlattenedClaimsFromPB(p.AllowedIdpClaims),
+	}
+	// Include any user-defined PPL.
+	if p.SourcePpl != nil {
+		configPolicy.Policy = new(config.PPLPolicy)
+		if err := yaml.Unmarshal([]byte(*p.SourcePpl), configPolicy.Policy); err != nil {
+			return nil, fmt.Errorf("couldn't parse PPL policy: %w", err)
+		}
+	}
+
+	ppl := configPolicy.ToPPL()
+	if isNoOpPolicy(ppl) {
+		return nil, nil
+	}
+
+	pplBytes, err := ppl.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal translated PPL: %w", err)
+	}
+	pplString := string(pplBytes)
+
+	// TODO: consider deriving a name based on policy criteria?
+	name := slug.Make(fmt.Sprintf("%s %s policy", ic.Namespace, ic.Name))
+	return &pomerium.Policy{
+		Name:      &name,
+		SourcePpl: &pplString,
+	}, nil
+}
+
+func isNoOpPolicy(ppl *parser.Policy) bool {
+	for _, r := range ppl.Rules {
+		if len(r.And) > 0 || len(r.Or) > 0 || len(r.Not) > 0 || len(r.Nor) > 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/pomerium/ingress_to_policy_test.go
+++ b/pomerium/ingress_to_policy_test.go
@@ -1,0 +1,104 @@
+package pomerium
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/pomerium/ingress-controller/model"
+)
+
+func TestIngressToPolicy(t *testing.T) {
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-ingress",
+			Namespace: "my-namespace",
+			Annotations: map[string]string{
+				"a/allowed_users":      `["user-id-1", "user-email-2@example.com"]`,
+				"a/allowed_domains":    `["a.example.com", "b.example.com"]`,
+				"a/allowed_idp_claims": `{ "foo": ["bar", "baz"] }`,
+				"a/policy": `deny:
+  or:
+    - source_ip: 1.2.3.4`,
+			},
+		},
+	}
+	ic := &model.IngressConfig{
+		AnnotationPrefix: "a",
+		Ingress:          ingress,
+	}
+	p, err := ingressToPolicy(ic)
+	require.NoError(t, err)
+	require.NotNil(t, p.Name)
+	assert.Equal(t, "my-namespace-my-ingress-policy", *p.Name)
+	require.NotNil(t, p.SourcePpl)
+	assert.JSONEq(t, `[
+  {
+    "allow": {
+      "or": [
+        {
+          "domain": {
+            "is": "a.example.com"
+          }
+        },
+        {
+          "domain": {
+            "is": "b.example.com"
+          }
+        },
+        {
+          "claim/foo": "bar"
+        },
+        {
+          "claim/foo": "baz"
+        },
+        {
+          "user": {
+            "is": "user-id-1"
+          }
+        },
+        {
+          "email": {
+            "is": "user-id-1"
+          }
+        },
+        {
+          "user": {
+            "is": "user-email-2@example.com"
+          }
+        },
+        {
+          "email": {
+            "is": "user-email-2@example.com"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "deny": {
+      "or": [
+        {
+          "source_ip": "1.2.3.4"
+        }
+      ]
+    }
+  }
+]`, *p.SourcePpl)
+}
+
+func TestIngressToPolicy_Empty(t *testing.T) {
+	// ingressToPolicy should return nil when called with an Ingress with no
+	// Pomerium policy annotations.
+	ingress := &networkingv1.Ingress{}
+	ic := &model.IngressConfig{
+		AnnotationPrefix: "a",
+		Ingress:          ingress,
+	}
+	p, err := ingressToPolicy(ic)
+	require.NoError(t, err)
+	assert.Nil(t, p)
+}


### PR DESCRIPTION
## Summary

Add a helper method for translating an Ingress object's policy annotations into a Policy proto that is compatible with the unified API.

The unified API does not support the legacy allowlist fields (`allowed_users`, `allowed_domains`, and `allowed_idp_claims`), but we can reuse the translation logic from Pomerium Core to convert these fields into the equivalent PPL.

## Related issues

https://linear.app/pomerium/issue/ENG-3576/ingress-controller-use-consolidated-api

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
