### PR TITLE
fix standalone mode health checks

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -20,6 +20,8 @@ import (
 	gateway_v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gateway_v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	"github.com/pomerium/pomerium/pkg/endpoints"
+
 	icgv1alpha1 "github.com/pomerium/ingress-controller/apis/gateway/v1alpha1"
 	icsv1 "github.com/pomerium/ingress-controller/apis/ingress/v1"
 )
@@ -91,6 +93,7 @@ func runHealthz(ctx context.Context, addr string, readyChecks ...healthz.HealthC
 
 	mux := http.NewServeMux()
 	healthz.InstallHandler(mux)
+	healthz.InstallPathHandler(mux, endpoints.PathStartupz)
 	healthz.InstallReadyzHandler(mux, readyChecks...)
 
 	srv := http.Server{

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -99,7 +99,7 @@ func (s *controllerCmd) exec(*cobra.Command, []string) error {
 
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		return runHealthz(ctx, s.probeAddr, healthz.NamedCheck("acquire databroker lease", c.ReadyzCheck))
+		return runHealthz(ctx, s.probeAddr, healthz.NamedCheck("acquire-databroker-lease", c.ReadyzCheck))
 	})
 	eg.Go(func() error { return c.Run(ctx) })
 


### PR DESCRIPTION
## Summary

Rename the "acquire databroker lease" ready check to "acquire-databroker-lease" as this name is used as a URL path component.

Register a (no-op) /startupz handler to satisfy the startup probe from the default kustomize configuration.

Unfortunately I could not figure out a good way to test either of these changes.

## Related issues

https://linear.app/pomerium/issue/ENG-3918/ingress-controller-standalone-mode-health-checks-not-working

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
