### PR TITLE
api sync: recover from a failed metadata update

### DIFF
--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -84,7 +84,7 @@ func (r *APIReconciler) Upsert(ctx context.Context, ic *model.IngressConfig) (bo
 			tlsSecrets = append(tlsSecrets, s)
 		}
 	}
-	changed, err := r.upsertKeyPairs(ctx, tlsSecrets)
+	changed, err := r.syncSecrets(ctx, tlsSecrets)
 	if err != nil {
 		return anyChanges, err
 	}
@@ -121,7 +121,7 @@ func (r *APIReconciler) Set(ctx context.Context, ics []*model.IngressConfig) (bo
 		}
 	}
 
-	anyChanges, err := r.upsertKeyPairs(ctx, slices.Collect(maps.Values(tlsSecrets)))
+	anyChanges, err := r.syncSecrets(ctx, slices.Collect(maps.Values(tlsSecrets)))
 	if err != nil {
 		return anyChanges, err
 	}
@@ -263,13 +263,13 @@ func (r *APIReconciler) upsertOneIngress(ctx context.Context, ic *model.IngressC
 	return anyChanges, nil
 }
 
-func (r *APIReconciler) upsertKeyPairs(
+func (r *APIReconciler) syncSecrets(
 	ctx context.Context,
 	secrets []*corev1.Secret,
 ) (bool, error) {
 	var anyChanges bool
 	for _, secret := range secrets {
-		changed, err := r.upsertOneKeyPair(ctx, secret)
+		changed, err := r.syncOneSecret(ctx, secret)
 		if err != nil {
 			return anyChanges, err
 		}
@@ -278,7 +278,7 @@ func (r *APIReconciler) upsertKeyPairs(
 	return anyChanges, nil
 }
 
-func (r *APIReconciler) upsertOneKeyPair(
+func (r *APIReconciler) syncOneSecret(
 	ctx context.Context,
 	secret *corev1.Secret,
 ) (bool, error) {
@@ -302,10 +302,11 @@ func (r *APIReconciler) upsertOneKeyPair(
 	changed, err := r.upsertKeyPair(ctx, keyPair)
 	if err != nil {
 		return false, nil
+	} else if changed {
+		setAnnotation(secret, apiKeyPairIDAnnotation, keyPair.GetId())
+		controllerutil.AddFinalizer(secret, apiFinalizer)
+		err = r.k8sClient.Patch(ctx, secret, client.MergeFrom(originalSecret))
 	}
-	setAnnotation(secret, apiKeyPairIDAnnotation, keyPair.GetId())
-	controllerutil.AddFinalizer(secret, apiFinalizer)
-	err = r.k8sClient.Patch(ctx, secret, client.MergeFrom(originalSecret))
 	return changed, err
 }
 
@@ -323,7 +324,7 @@ func (r *APIReconciler) SetConfig(ctx context.Context, cfg *model.Config) (chang
 	allCertSecrets := make([]*corev1.Secret, 0, len(cfg.CASecrets)+len(cfg.Certs))
 	allCertSecrets = append(allCertSecrets, cfg.CASecrets...)
 	allCertSecrets = append(allCertSecrets, slices.Collect(maps.Values(cfg.Certs))...)
-	changedKeyPair, err := r.upsertKeyPairs(ctx, allCertSecrets)
+	changedKeyPair, err := r.syncSecrets(ctx, allCertSecrets)
 	if err != nil {
 		return changes, err
 	}
@@ -438,7 +439,7 @@ func (r *APIReconciler) SetGatewayConfig(
 	}
 	changes = changes || anyDeletes
 
-	changedKeyPair, err := r.upsertKeyPairs(ctx, gatewayConfig.Certificates)
+	changedKeyPair, err := r.syncSecrets(ctx, gatewayConfig.Certificates)
 	if err != nil {
 		return changes, err
 	}
@@ -884,6 +885,7 @@ func (r *APIReconciler) upsertKeyPair(ctx context.Context, keyPair *pomerium.Key
 			return false, err
 		}
 		keyPair.Id = existing.Id
+		changed = true
 	}
 
 	// Zero out fields that should be ignored when looking for changes.
@@ -896,7 +898,7 @@ func (r *APIReconciler) upsertKeyPair(ctx context.Context, keyPair *pomerium.Key
 
 	if proto.Equal(existing, keyPair) {
 		// No changes needed.
-		return false, nil
+		return changed, nil
 	}
 
 	logger := log.FromContext(ctx).WithName("APIReconciler.upsertKeyPair")
@@ -907,7 +909,10 @@ func (r *APIReconciler) upsertKeyPair(ctx context.Context, keyPair *pomerium.Key
 	_, err = r.apiClient.UpdateKeyPair(ctx, connect.NewRequest(&pomerium.UpdateKeyPairRequest{
 		KeyPair: keyPair,
 	}))
-	return err == nil, err
+	if err != nil {
+		return changed, err
+	}
+	return true, nil
 }
 
 func (r *APIReconciler) findKeyPairByName(

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -142,39 +142,36 @@ func (r *APIReconciler) Set(ctx context.Context, ics []*model.IngressConfig) (bo
 	return anyChanges, errors.Join(errs...)
 }
 
-func (r *APIReconciler) upsertOneIngress(ctx context.Context, ic *model.IngressConfig) (bool, error) {
-	logger := log.FromContext(ctx).WithName("APIReconciler.upsertOneIngress")
-
+func (r *APIReconciler) upsertOneIngress(
+	ctx context.Context, ic *model.IngressConfig,
+) (changed bool, err error) {
 	routes, err := ingressToRoutes(ctx, ic)
 	if err != nil {
 		return false, fmt.Errorf("couldn't convert ingress to routes: %w", err)
 	}
 
-	var anyChanges bool
-
 	originalIngress := ic.Ingress.DeepCopy()
 	defer func() {
-		if !anyChanges {
+		if !changed {
 			return
 		}
-		err := r.k8sClient.Patch(ctx, ic.Ingress, client.MergeFrom(originalIngress))
-		if err != nil {
-			logger.Error(err, "couldn't patch ingress", "ingress", ic.Name)
-		}
+		// Merge any error from Patch() with the named return parameter 'err' to
+		// ensure that it will propagate to the caller.
+		err = errors.Join(err, r.k8sClient.Patch(ctx, ic.Ingress, client.MergeFrom(originalIngress)))
 	}()
 
-	anyChanges = anyChanges || controllerutil.AddFinalizer(ic.Ingress, apiFinalizer)
+	changed = changed || controllerutil.AddFinalizer(ic.Ingress, apiFinalizer)
 
 	kv, err := removeKeyPrefix(ic.Ingress.Annotations, ic.AnnotationPrefix)
 	if err != nil {
-		return anyChanges, err
+		return changed, err
 	}
 
-	changed, updatedPolicyID, err := r.syncIngressPolicy(ctx, ic.Ingress, kv)
+	changedPolicy, updatedPolicyID, err := r.syncIngressPolicy(ctx, ic.Ingress, kv)
 	if err != nil {
-		return anyChanges, err
+		return changed, err
 	}
-	anyChanges = anyChanges || changed
+	changed = changed || changedPolicy
 
 	var policyIDs []string
 	if updatedPolicyID != "" {
@@ -207,7 +204,7 @@ func (r *APIReconciler) upsertOneIngress(ctx context.Context, ic *model.IngressC
 	tlsClientKeyPairID := keyPairIDForAnnotation(model.TLSClientSecret)
 	tlsDownstreamClientCAKeyPairID := keyPairIDForAnnotation(model.TLSDownstreamClientCASecret)
 	if len(keypairErrs) > 0 {
-		return anyChanges, errors.Join(keypairErrs...)
+		return changed, errors.Join(keypairErrs...)
 	}
 
 	unusedRouteIDAnnotations := allRouteIDAnnotations(ic.Annotations)
@@ -231,14 +228,14 @@ func (r *APIReconciler) upsertOneIngress(ctx context.Context, ic *model.IngressC
 		// Clear the route StatName as it can't currently be set in Pomerium Zero.
 		route.StatName = nil
 
-		changed, err := r.upsertOneRoute(ctx, ic.Annotations[k], route)
+		changedRoute, err := r.upsertOneRoute(ctx, ic.Annotations[k], route)
 		if err != nil {
-			return anyChanges, err
+			return changed, err
 		}
 		if ic.Annotations[k] == "" {
 			setAnnotation(ic, k, *route.Id)
 		}
-		anyChanges = anyChanges || changed
+		changed = changed || changedRoute
 	}
 
 	// If the Ingress object has any other route ID annotations, these indicate
@@ -246,9 +243,9 @@ func (r *APIReconciler) upsertOneIngress(ctx context.Context, ic *model.IngressC
 	// the case when an existing Rule is deleted from an Ingress.)
 	anyDeletes, err := r.deleteRoutes(ctx, ic.Ingress, unusedRouteIDAnnotations)
 	if err != nil {
-		return anyChanges, err
+		return changed, err
 	}
-	anyChanges = anyChanges || anyDeletes
+	changed = changed || anyDeletes
 
 	// If there was a linked policy that is no no longer needed, delete it.
 	// (This cannot be done until all of the linked routes are updated to no
@@ -256,12 +253,12 @@ func (r *APIReconciler) upsertOneIngress(ctx context.Context, ic *model.IngressC
 	if ic.Annotations[apiPolicyIDAnnotation] != "" && updatedPolicyID == "" {
 		deleted, err := r.deletePolicy(ctx, ic.Ingress)
 		if err != nil {
-			return anyChanges, err
+			return changed, err
 		}
-		anyChanges = anyChanges || deleted
+		changed = changed || deleted
 	}
 
-	return anyChanges, nil
+	return changed, nil
 }
 
 func (r *APIReconciler) syncSecrets(
@@ -385,9 +382,9 @@ func (r *APIReconciler) SetConfig(ctx context.Context, cfg *model.Config) (chang
 }
 
 // Delete removes pomerium routes corresponding to this ingress.
-func (r *APIReconciler) Delete(ctx context.Context, name types.NamespacedName) (bool, error) {
+func (r *APIReconciler) Delete(ctx context.Context, name types.NamespacedName) (changed bool, err error) {
 	ingress := new(networkingv1.Ingress)
-	err := r.k8sClient.Get(ctx, name, ingress)
+	err = r.k8sClient.Get(ctx, name, ingress)
 	if apierrors.IsNotFound(err) {
 		return false, nil
 	} else if err != nil {
@@ -396,39 +393,41 @@ func (r *APIReconciler) Delete(ctx context.Context, name types.NamespacedName) (
 
 	originalIngress := ingress.DeepCopy()
 	defer func() {
-		err := r.k8sClient.Patch(ctx, ingress, client.MergeFrom(originalIngress))
-		if err != nil {
-			logger := log.FromContext(ctx).WithName("APIReconciler.Delete")
-			logger.Error(err, "couldn't patch ingress", "name", ingress.Name)
+		if !changed {
+			return
 		}
+		// Merge any error from Patch() with the named return parameter 'err' to
+		// ensure that it will propagate to the caller.
+		err = errors.Join(err, r.k8sClient.Patch(ctx, ingress, client.MergeFrom(originalIngress)))
 	}()
 
 	routeAnnotations := allRouteIDAnnotations(ingress.Annotations)
-	anyDeletes, err := r.deleteRoutes(ctx, ingress, routeAnnotations)
+	anyRouteDeleted, err := r.deleteRoutes(ctx, ingress, routeAnnotations)
+	changed = changed || anyRouteDeleted
 	if err != nil {
-		return anyDeletes, err
+		return changed, err
 	}
 
 	policyDeleted, err := r.deletePolicy(ctx, ingress)
 	if err != nil {
-		return anyDeletes, err
+		return changed, err
 	}
-	anyDeletes = anyDeletes || policyDeleted
+	changed = changed || policyDeleted
 
 	// Remove keypairs corresponding to any newly-unreferenced TLS secrets.
 	unreferencedSecrets := r.secretsMap.RemoveEntity(model.Key{
 		Kind:           ingress.Kind,
 		NamespacedName: name,
 	})
-	anyKeyPairDeletes, err := r.deleteKeyPairs(ctx, unreferencedSecrets...)
+	anyKeyPairDeleted, err := r.deleteKeyPairs(ctx, unreferencedSecrets...)
 	if err != nil {
-		return anyDeletes, err
+		return changed, err
 	}
-	anyDeletes = anyDeletes || anyKeyPairDeletes
+	changed = changed || anyKeyPairDeleted
 
-	controllerutil.RemoveFinalizer(ingress, apiFinalizer)
+	changed = changed || controllerutil.RemoveFinalizer(ingress, apiFinalizer)
 
-	return anyDeletes, nil
+	return changed, nil
 }
 
 // SetGatewayConfig applies Gateway-defined configuration.
@@ -492,8 +491,6 @@ func (r *APIReconciler) SetGatewayConfig(
 		}
 
 		if err := r.k8sClient.Patch(ctx, gr.HTTPRoute, client.MergeFrom(originalRoute)); err != nil {
-			logger := log.FromContext(ctx).WithName("APIReconciler.SetGatewayConfig")
-			logger.Error(err, "couldn't patch httproute", "name", gr.Name)
 			return changes, err
 		}
 	}
@@ -553,8 +550,6 @@ func (r *APIReconciler) syncGatewayPolicies(
 		policyIDs[policy.GetSourcePpl()] = policy.GetId()
 
 		if err := r.k8sClient.Patch(ctx, obj, client.MergeFrom(originalObj)); err != nil {
-			logger := log.FromContext(ctx).WithName("APIReconciler.syncGatewayPolicies")
-			logger.Error(err, "couldn't patch policyfilter", "name", obj.Name)
 			return changes, nil, err
 		}
 	}
@@ -585,8 +580,6 @@ func (r *APIReconciler) removeDeletedGatewayPolicies(
 		originalObj := obj.DeepCopy()
 		controllerutil.RemoveFinalizer(obj, apiFinalizer)
 		if err := r.k8sClient.Patch(ctx, obj, client.MergeFrom(originalObj)); err != nil {
-			logger := log.FromContext(ctx).WithName("APIReconciler.removeDeletedGatewayPolicies")
-			logger.Error(err, "couldn't patch policyfilter", "name", obj.Name)
 			return changes, err
 		}
 	}

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/pomerium/ingress-controller/model"
 	"github.com/pomerium/ingress-controller/pomerium/gateway"
+	"github.com/pomerium/ingress-controller/util"
 )
 
 // NewAPIReconciler initializes a reconciler that syncs using the unified API,
@@ -278,6 +279,10 @@ func (r *APIReconciler) syncSecrets(
 	return anyChanges, nil
 }
 
+func keyPairName(n types.NamespacedName) string {
+	return slug.Make(fmt.Sprintf("%s %s", n.Namespace, n.Name))
+}
+
 func (r *APIReconciler) syncOneSecret(
 	ctx context.Context,
 	secret *corev1.Secret,
@@ -287,7 +292,7 @@ func (r *APIReconciler) syncOneSecret(
 		cert = secret.Data[model.CAKey]
 	}
 
-	name := slug.Make(fmt.Sprintf("%s %s", secret.Namespace, secret.Name))
+	name := keyPairName(util.GetNamespacedName(secret))
 	keyPair := &pomerium.KeyPair{
 		Name:         &name,
 		Certificate:  cert,
@@ -652,6 +657,7 @@ func (r *APIReconciler) upsertOneRoute(ctx context.Context, id string, route *pb
 		if err != nil {
 			return false, err
 		}
+		apiRoute.Id = existing.Id
 		route.Id = existing.Id
 	}
 
@@ -788,6 +794,7 @@ func (r *APIReconciler) upsertPolicy(ctx context.Context, policy *pomerium.Polic
 			return false, err
 		}
 		policy.Id = existing.Id
+		changed = true
 	}
 
 	// Zero out fields that should be ignored when looking for changes.
@@ -799,7 +806,7 @@ func (r *APIReconciler) upsertPolicy(ctx context.Context, policy *pomerium.Polic
 
 	if proto.Equal(existing, policy) {
 		// No changes needed.
-		return false, nil
+		return changed, nil
 	}
 
 	logger := log.FromContext(ctx).WithName("APIReconciler.upsertPolicy")
@@ -808,7 +815,10 @@ func (r *APIReconciler) upsertPolicy(ctx context.Context, policy *pomerium.Polic
 	_, err = r.apiClient.UpdatePolicy(ctx, connect.NewRequest(&pomerium.UpdatePolicyRequest{
 		Policy: policy,
 	}))
-	return err == nil, err
+	if err != nil {
+		return changed, err
+	}
+	return true, nil
 }
 
 func (r *APIReconciler) findPolicyByName(
@@ -942,35 +952,41 @@ func (r *APIReconciler) findKeyPairByName(
 func (r *APIReconciler) deleteKeyPairs(
 	ctx context.Context, secretNames ...types.NamespacedName,
 ) (bool, error) {
-	logger := log.FromContext(ctx).WithName("APIReconciler.deleteKeyPairs")
 	var anyDeletes bool
 	for _, n := range secretNames {
+		var keyPairID string
+
 		secret := new(corev1.Secret)
 		err := r.k8sClient.Get(ctx, n, secret)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				// If we can't retrieve this Secret, we won't know the ID of the
-				// keypair to delete. There's not much we can do in this case.
-				logger.Info("could not delete keypair (secret not found)", "secret", n)
-				continue
+		if err == nil {
+			keyPairID = secret.Annotations[apiKeyPairIDAnnotation]
+		} else if apierrors.IsNotFound(err) {
+			secret = nil
+
+			// Try to look up the keypair by name.
+			keypair, err := r.findKeyPairByName(ctx, keyPairName(n))
+			if err != nil {
+				return anyDeletes, err
 			}
+			keyPairID = keypair.GetId()
+		} else {
 			return anyDeletes, err
 		}
-		keyPairID := secret.Annotations[apiKeyPairIDAnnotation]
-		if keyPairID == "" {
-			continue
-		}
+
 		_, err = r.apiClient.DeleteKeyPair(ctx, connect.NewRequest(&pomerium.DeleteKeyPairRequest{
 			Id: keyPairID,
 		}))
 		if err != nil && connect.CodeOf(err) != connect.CodeNotFound {
 			return anyDeletes, err
 		}
-		originalSecret := secret.DeepCopy()
-		delete(secret.Annotations, apiKeyPairIDAnnotation)
-		controllerutil.RemoveFinalizer(secret, apiFinalizer)
-		if err := r.k8sClient.Patch(ctx, secret, client.MergeFrom(originalSecret)); err != nil {
-			return anyDeletes, err
+
+		if secret != nil {
+			originalSecret := secret.DeepCopy()
+			delete(secret.Annotations, apiKeyPairIDAnnotation)
+			controllerutil.RemoveFinalizer(secret, apiFinalizer)
+			if err := r.k8sClient.Patch(ctx, secret, client.MergeFrom(originalSecret)); err != nil {
+				return anyDeletes, err
+			}
 		}
 		anyDeletes = true
 	}

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -212,6 +212,7 @@ func (r *APIReconciler) upsertOneIngress(
 	for i, route := range routes {
 		k := routeIDAnnotationForIndex(i)
 		delete(unusedRouteIDAnnotations, k)
+		route.Id = emptyToNil(ic.Annotations[k])
 
 		// Swap out any inline policies for the policy ID reference, and swap
 		// out any TLS secrets for keypair ID references.
@@ -228,11 +229,11 @@ func (r *APIReconciler) upsertOneIngress(
 		// Clear the route StatName as it can't currently be set in Pomerium Zero.
 		route.StatName = nil
 
-		changedRoute, err := r.upsertOneRoute(ctx, ic.Annotations[k], route)
+		changedRoute, err := r.upsertOneRoute(ctx, route)
 		if err != nil {
 			return changed, err
 		}
-		if ic.Annotations[k] == "" {
+		if ic.Annotations[k] != *route.Id {
 			setAnnotation(ic, k, *route.Id)
 		}
 		changed = changed || changedRoute
@@ -303,7 +304,7 @@ func (r *APIReconciler) syncOneSecret(
 	originalSecret := secret.DeepCopy()
 	changed, err := r.upsertKeyPair(ctx, keyPair)
 	if err != nil {
-		return false, nil
+		return false, err
 	} else if changed {
 		setAnnotation(secret, apiKeyPairIDAnnotation, keyPair.GetId())
 		controllerutil.AddFinalizer(secret, apiFinalizer)
@@ -469,12 +470,13 @@ func (r *APIReconciler) SetGatewayConfig(
 				}
 
 				k := routeIDAnnotationForIndex(i)
-				routeChanged, err := r.upsertOneRoute(ctx, gr.Annotations[k], route)
+				route.Id = emptyToNil(gr.Annotations[k])
+				routeChanged, err := r.upsertOneRoute(ctx, route)
 				if err != nil {
 					return changes, err
 				}
 				changes = changes || routeChanged
-				if gr.Annotations[k] == "" {
+				if gr.Annotations[k] != *route.Id {
 					setAnnotation(gr, k, *route.Id)
 				}
 			}
@@ -603,7 +605,7 @@ func replaceInlinePolicies(route *pb.Route, policyIDs map[string]string) error {
 	return nil
 }
 
-func (r *APIReconciler) upsertOneRoute(ctx context.Context, id string, route *pb.Route) (bool, error) {
+func (r *APIReconciler) upsertOneRoute(ctx context.Context, route *pb.Route) (bool, error) {
 	logger := log.FromContext(ctx).WithName("APIReconciler.upsertOneRoute")
 
 	apiRoute, err := convertProto[*pomerium.Route](route)
@@ -613,7 +615,7 @@ func (r *APIReconciler) upsertOneRoute(ctx context.Context, id string, route *pb
 	apiRoute.OriginatorId = &originatorID
 
 	var existing *pomerium.Route
-	if id != "" {
+	if id := route.GetId(); id != "" {
 		resp, err := r.apiClient.GetRoute(ctx, connect.NewRequest(&pomerium.GetRouteRequest{
 			Id: id,
 		}))
@@ -622,12 +624,6 @@ func (r *APIReconciler) upsertOneRoute(ctx context.Context, id string, route *pb
 		} else if err == nil {
 			existing = resp.Msg.Route
 		}
-
-		apiRoute.Id = new(id)
-	} else {
-		// The ID must be assigned during route creation. (We can't use the
-		// derived ID from the conversion logic.)
-		apiRoute.Id = nil
 	}
 
 	if existing == nil {
@@ -934,7 +930,7 @@ func (r *APIReconciler) findKeyPairByName(
 	if err != nil {
 		return nil, err
 	} else if len(resp.Msg.KeyPairs) == 0 {
-		return nil, fmt.Errorf("could not find keypair by name")
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("could not find keypair by name"))
 	}
 	return resp.Msg.KeyPairs[0], nil
 }
@@ -951,26 +947,33 @@ func (r *APIReconciler) deleteKeyPairs(
 
 		secret := new(corev1.Secret)
 		err := r.k8sClient.Get(ctx, n, secret)
-		if err == nil {
-			keyPairID = secret.Annotations[apiKeyPairIDAnnotation]
-		} else if apierrors.IsNotFound(err) {
-			secret = nil
-
-			// Try to look up the keypair by name.
-			keypair, err := r.findKeyPairByName(ctx, keyPairName(n))
-			if err != nil {
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				secret = nil
+			} else {
 				return anyDeletes, err
 			}
-			keyPairID = keypair.GetId()
 		} else {
-			return anyDeletes, err
+			keyPairID = secret.Annotations[apiKeyPairIDAnnotation]
 		}
 
-		_, err = r.apiClient.DeleteKeyPair(ctx, connect.NewRequest(&pomerium.DeleteKeyPairRequest{
-			Id: keyPairID,
-		}))
-		if err != nil && connect.CodeOf(err) != connect.CodeNotFound {
-			return anyDeletes, err
+		// If we don't have a keypair ID, try to look up the keypair by name.
+		if keyPairID == "" {
+			keypair, err := r.findKeyPairByName(ctx, keyPairName(n))
+			if err != nil && connect.CodeOf(err) != connect.CodeNotFound {
+				return anyDeletes, err
+			} else if err == nil {
+				keyPairID = keypair.GetId()
+			}
+		}
+
+		if keyPairID != "" {
+			_, err = r.apiClient.DeleteKeyPair(ctx, connect.NewRequest(&pomerium.DeleteKeyPairRequest{
+				Id: keyPairID,
+			}))
+			if err != nil && connect.CodeOf(err) != connect.CodeNotFound {
+				return anyDeletes, err
+			}
 		}
 
 		if secret != nil {
@@ -1026,4 +1029,11 @@ func falseToNil(x *bool) *bool {
 		return nil
 	}
 	return x
+}
+
+func emptyToNil(x string) *string {
+	if x == "" {
+		return nil
+	}
+	return new(x)
 }

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -1013,18 +1013,3 @@ func falseToNil(x *bool) *bool {
 	}
 	return x
 }
-
-type hasName interface {
-	GetName() string
-}
-
-func filterFor(entity hasName) (*structpb.Struct, error) {
-	f, err := structpb.NewStruct(map[string]any{
-		"originatorId": originatorID,
-		"name":         entity.GetName(),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("internal error: %w", err)
-	}
-	return f, nil
-}

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gosimple/slug"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/structpb"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -281,8 +282,6 @@ func (r *APIReconciler) upsertOneKeyPair(
 	ctx context.Context,
 	secret *corev1.Secret,
 ) (bool, error) {
-	logger := log.FromContext(ctx).WithName("APIReconciler.upsertOneKeyPair")
-
 	cert, hasTLSCert := secret.Data[corev1.TLSCertKey]
 	if !hasTLSCert {
 		cert = secret.Data[model.CAKey]
@@ -295,27 +294,19 @@ func (r *APIReconciler) upsertOneKeyPair(
 		Key:          secret.Data[corev1.TLSPrivateKeyKey],
 		OriginatorId: &originatorID,
 	}
-
-	existingKeyPairID := secret.Annotations[apiKeyPairIDAnnotation]
-	if existingKeyPairID == "" {
-		// No linked keypair, so we need to create one.
-		updatedKeyPairID, err := r.createKeyPair(ctx, keyPair)
-		if err != nil {
-			return false, fmt.Errorf("couldn't create key pair: %w", err)
-		}
-
-		originalSecret := secret.DeepCopy()
-		setAnnotation(secret, apiKeyPairIDAnnotation, updatedKeyPairID)
-		controllerutil.AddFinalizer(secret, apiFinalizer)
-		err = r.k8sClient.Patch(ctx, secret, client.MergeFrom(originalSecret))
-		if err != nil {
-			logger.Error(err, "couldn't patch secret", "name", secret.Name)
-		}
-		return true, err
+	if id := secret.Annotations[apiKeyPairIDAnnotation]; id != "" {
+		keyPair.Id = &id
 	}
 
-	keyPair.Id = &existingKeyPairID
-	return r.upsertKeyPair(ctx, keyPair)
+	originalSecret := secret.DeepCopy()
+	changed, err := r.upsertKeyPair(ctx, keyPair)
+	if err != nil {
+		return false, nil
+	}
+	setAnnotation(secret, apiKeyPairIDAnnotation, keyPair.GetId())
+	controllerutil.AddFinalizer(secret, apiFinalizer)
+	err = r.k8sClient.Patch(ctx, secret, client.MergeFrom(originalSecret))
+	return changed, err
 }
 
 // SetConfig updates just the shared config settings
@@ -647,11 +638,20 @@ func (r *APIReconciler) upsertOneRoute(ctx context.Context, id string, route *pb
 		resp, err := r.apiClient.CreateRoute(ctx, connect.NewRequest(&pomerium.CreateRouteRequest{
 			Route: apiRoute,
 		}))
+		if err == nil {
+			route.Id = resp.Msg.Route.Id
+			return true, nil
+		} else if connect.CodeOf(err) != connect.CodeAlreadyExists {
+			return false, err
+		}
+
+		// If we already created a route, but failed to save the ID annotation,
+		// attempt to look up the route by name.
+		existing, err = r.findRouteByName(ctx, route.GetName())
 		if err != nil {
 			return false, err
 		}
-		route.Id = resp.Msg.Route.Id
-		return true, nil
+		route.Id = existing.Id
 	}
 
 	// Clear the fields that should be ignored when looking for changes.
@@ -675,6 +675,27 @@ func (r *APIReconciler) upsertOneRoute(ctx context.Context, id string, route *pb
 		Route: apiRoute,
 	}))
 	return err == nil, err
+}
+
+func (r *APIReconciler) findRouteByName(
+	ctx context.Context, name string,
+) (existing *pomerium.Route, err error) {
+	filter, err := structpb.NewStruct(map[string]any{
+		"originatorId": originatorID,
+		"name":         name,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("internal error - couldn't create ListRoutes filter: %w", err)
+	}
+	resp, err := r.apiClient.ListRoutes(ctx, connect.NewRequest(&pomerium.ListRoutesRequest{
+		Filter: filter,
+	}))
+	if err != nil {
+		return nil, err
+	} else if len(resp.Msg.Routes) == 0 {
+		return nil, fmt.Errorf("could not find route by name")
+	}
+	return resp.Msg.Routes[0], nil
 }
 
 // deleteRoutes deletes routes corresponding to the keys in annotationKeys and
@@ -752,11 +773,20 @@ func (r *APIReconciler) upsertPolicy(ctx context.Context, policy *pomerium.Polic
 		resp, err := r.apiClient.CreatePolicy(ctx, connect.NewRequest(&pomerium.CreatePolicyRequest{
 			Policy: policy,
 		}))
+		if err == nil {
+			policy.Id = resp.Msg.Policy.Id
+			return true, nil
+		} else if connect.CodeOf(err) != connect.CodeAlreadyExists {
+			return false, err
+		}
+
+		// If we already created a policy, but failed to save the ID annotation,
+		// attempt to look up the policy by name.
+		existing, err = r.findPolicyByName(ctx, policy.GetName())
 		if err != nil {
 			return false, err
 		}
-		policy.Id = resp.Msg.Policy.Id
-		return true, nil
+		policy.Id = existing.Id
 	}
 
 	// Zero out fields that should be ignored when looking for changes.
@@ -780,9 +810,30 @@ func (r *APIReconciler) upsertPolicy(ctx context.Context, policy *pomerium.Polic
 	return err == nil, err
 }
 
-// deletePolicy deletes the policy for the ingress and clears its policy ID
-// annotation. Returns true if any changes were made, or an error if the delete
-// operation failed.
+func (r *APIReconciler) findPolicyByName(
+	ctx context.Context, name string,
+) (existing *pomerium.Policy, err error) {
+	filter, err := structpb.NewStruct(map[string]any{
+		"originatorId": originatorID,
+		"name":         name,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("internal error - couldn't create ListPolicies filter: %w", err)
+	}
+	resp, err := r.apiClient.ListPolicies(ctx, connect.NewRequest(&pomerium.ListPoliciesRequest{
+		Filter: filter,
+	}))
+	if err != nil {
+		return nil, err
+	} else if len(resp.Msg.Policies) == 0 {
+		return nil, fmt.Errorf("could not find policy by name")
+	}
+	return resp.Msg.Policies[0], nil
+}
+
+// deletePolicy deletes the policy for obj and clears its policy ID annotation.
+// Returns true if any changes were made, or an error if the delete operation
+// failed.
 func (r *APIReconciler) deletePolicy(
 	ctx context.Context, obj client.Object,
 ) (deleted bool, err error) {
@@ -801,31 +852,41 @@ func (r *APIReconciler) deletePolicy(
 	return true, nil
 }
 
-func (r *APIReconciler) createKeyPair(ctx context.Context, keyPair *pomerium.KeyPair) (newID string, err error) {
-	resp, err := r.apiClient.CreateKeyPair(ctx, connect.NewRequest(&pomerium.CreateKeyPairRequest{
-		KeyPair: keyPair,
-	}))
-	if err != nil {
-		return "", err
-	}
-	return resp.Msg.GetKeyPair().GetId(), nil
-}
-
 func (r *APIReconciler) upsertKeyPair(ctx context.Context, keyPair *pomerium.KeyPair) (changed bool, err error) {
-	resp, err := r.apiClient.GetKeyPair(ctx, connect.NewRequest(&pomerium.GetKeyPairRequest{
-		Id: keyPair.GetId(),
-	}))
-	if err != nil {
-		if connect.CodeOf(err) == connect.CodeNotFound {
-			// If the existing key pair was deleted, recreate it.
-			_, err := r.createKeyPair(ctx, keyPair)
-			return err == nil, err
+	var existing *pomerium.KeyPair
+	if id := keyPair.GetId(); id != "" {
+		resp, err := r.apiClient.GetKeyPair(ctx, connect.NewRequest(&pomerium.GetKeyPairRequest{
+			Id: id,
+		}))
+		if err == nil {
+			existing = resp.Msg.KeyPair
+		} else if connect.CodeOf(err) != connect.CodeNotFound {
+			return false, err
 		}
-		return false, err
+	}
+
+	// If there is no existing keypair, create one.
+	if existing == nil {
+		resp, err := r.apiClient.CreateKeyPair(ctx, connect.NewRequest(&pomerium.CreateKeyPairRequest{
+			KeyPair: keyPair,
+		}))
+		if err == nil {
+			keyPair.Id = resp.Msg.KeyPair.Id
+			return true, nil
+		} else if connect.CodeOf(err) != connect.CodeAlreadyExists {
+			return false, err
+		}
+
+		// If we already created a keypair, but failed to save the ID annotation,
+		// attempt to look up the keypair by name.
+		existing, err = r.findKeyPairByName(ctx, keyPair.GetName())
+		if err != nil {
+			return false, err
+		}
+		keyPair.Id = existing.Id
 	}
 
 	// Zero out fields that should be ignored when looking for changes.
-	existing := resp.Msg.KeyPair
 	existing.NamespaceId = nil
 	existing.CreatedAt = nil
 	existing.ModifiedAt = nil
@@ -847,6 +908,27 @@ func (r *APIReconciler) upsertKeyPair(ctx context.Context, keyPair *pomerium.Key
 		KeyPair: keyPair,
 	}))
 	return err == nil, err
+}
+
+func (r *APIReconciler) findKeyPairByName(
+	ctx context.Context, name string,
+) (existing *pomerium.KeyPair, err error) {
+	filter, err := structpb.NewStruct(map[string]any{
+		"originatorId": originatorID,
+		"name":         name,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("internal error - couldn't create ListKeyPairs filter: %w", err)
+	}
+	resp, err := r.apiClient.ListKeyPairs(ctx, connect.NewRequest(&pomerium.ListKeyPairsRequest{
+		Filter: filter,
+	}))
+	if err != nil {
+		return nil, err
+	} else if len(resp.Msg.KeyPairs) == 0 {
+		return nil, fmt.Errorf("could not find keypair by name")
+	}
+	return resp.Msg.KeyPairs[0], nil
 }
 
 // deleteKeyPairs deletes the keypairs corresponding to the given Secret names,
@@ -883,7 +965,6 @@ func (r *APIReconciler) deleteKeyPairs(
 		delete(secret.Annotations, apiKeyPairIDAnnotation)
 		controllerutil.RemoveFinalizer(secret, apiFinalizer)
 		if err := r.k8sClient.Patch(ctx, secret, client.MergeFrom(originalSecret)); err != nil {
-			logger.Error(err, "couldn't patch secret", "name", secret.Name)
 			return anyDeletes, err
 		}
 		anyDeletes = true
@@ -931,4 +1012,19 @@ func falseToNil(x *bool) *bool {
 		return nil
 	}
 	return x
+}
+
+type hasName interface {
+	GetName() string
+}
+
+func filterFor(entity hasName) (*structpb.Struct, error) {
+	f, err := structpb.NewStruct(map[string]any{
+		"originatorId": originatorID,
+		"name":         entity.GetName(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("internal error: %w", err)
+	}
+	return f, nil
 }

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -58,9 +58,9 @@ func setupReconciler(t *testing.T) (
 
 	r := &APIReconciler{
 		apiClient:  apiClient,
-		k8sClient:  k8sClient,
 		secretsMap: model.NewTLSSecretsMap(),
 	}
+	r.SetK8sClient(k8sClient)
 	return apiClient, k8sClient, r
 }
 
@@ -1100,7 +1100,7 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 		},
 	}
 
-	t.Run("create new keypair", func(t *testing.T) {
+	t.Run("create new cert keypair", func(t *testing.T) {
 		apiClient, k8sClient, r := setupReconciler(t)
 		ctx := t.Context()
 
@@ -1115,17 +1115,38 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 				Certificate:  []byte("cert-data"),
 				Key:          []byte("key-data"),
 			},
-		})).Return(&connect.Response[pomerium.CreateKeyPairResponse]{
-			Msg: &pomerium.CreateKeyPairResponse{
-				KeyPair: &pomerium.KeyPair{
-					Id: new("new-keypair-id"),
-					// rest of the data omitted (not currently read)
-				},
-			},
-		}, nil)
+		})).Return(createKeyPairResponseWithID("new-keypair-id"), nil)
 
 		// APIReconciler should make a Patch() request to record the
 		// newly-assigned ID in the keypair ID annotation (verified below).
+		k8sClient.EXPECT().Patch(ctx, secret, gomock.Any()).Return(nil)
+
+		changed, err := r.syncOneSecret(ctx, secret)
+		assert.True(t, changed)
+		require.NoError(t, err)
+		assert.Equal(t, "new-keypair-id", secret.Annotations[apiKeyPairIDAnnotation])
+		assert.Contains(t, secret.Finalizers, apiFinalizer)
+	})
+
+	t.Run("create new CA keypair", func(t *testing.T) {
+		apiClient, k8sClient, r := setupReconciler(t)
+		ctx := t.Context()
+
+		// APIReconciler should also be able to sync a CA certificate, which
+		// has a different representation in the Secret data.
+		secret := secretTemplate.DeepCopy()
+		secret.Data = map[string][]byte{
+			"ca.crt": []byte("ca-cert-data"),
+		}
+
+		apiClient.EXPECT().CreateKeyPair(ctx, RequestEq(&pomerium.CreateKeyPairRequest{
+			KeyPair: &pomerium.KeyPair{
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-secret-1"),
+				Certificate:  []byte("ca-cert-data"),
+			},
+		})).Return(createKeyPairResponseWithID("new-keypair-id"), nil)
+
 		k8sClient.EXPECT().Patch(ctx, secret, gomock.Any()).Return(nil)
 
 		changed, err := r.syncOneSecret(ctx, secret)
@@ -1177,6 +1198,47 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 		changed, err := r.syncOneSecret(ctx, secret)
 		assert.True(t, changed)
 		assert.NoError(t, err)
+	})
+
+	t.Run("update error", func(t *testing.T) {
+		apiClient, _, r := setupReconciler(t)
+		ctx := t.Context()
+
+		secret := secretTemplate.DeepCopy()
+		secret.Annotations = map[string]string{
+			apiKeyPairIDAnnotation: "existing-keypair-id",
+		}
+
+		// APIReconciler should first call GetKeyPair() to determine if it needs to sync any changes...
+		apiClient.EXPECT().GetKeyPair(ctx, RequestEq(&pomerium.GetKeyPairRequest{
+			Id: "existing-keypair-id",
+		})).Return(&connect.Response[pomerium.GetKeyPairResponse]{
+			Msg: &pomerium.GetKeyPairResponse{
+				KeyPair: &pomerium.KeyPair{
+					OriginatorId: new("ingress-controller"),
+					Id:           new("existing-keypair-id"),
+					Name:         new("test-secret-1"),
+					Certificate:  []byte("different-cert-data"),
+					Key:          []byte("different-key-data"),
+				},
+			},
+		}, nil)
+
+		// ...and then UpdateKeyPair() to sync changes. If this returns an error, it
+		// should be surfaced.
+		apiClient.EXPECT().UpdateKeyPair(ctx, RequestEq(&pomerium.UpdateKeyPairRequest{
+			KeyPair: &pomerium.KeyPair{
+				OriginatorId: new("ingress-controller"),
+				Id:           new("existing-keypair-id"),
+				Name:         new("test-secret-1"),
+				Certificate:  []byte("cert-data"),
+				Key:          []byte("key-data"),
+			},
+		})).Return(nil, connect.NewError(connect.CodeDeadlineExceeded, context.DeadlineExceeded))
+
+		changed, err := r.syncOneSecret(ctx, secret)
+		assert.False(t, changed)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 
 	t.Run("existing keypair unchanged", func(t *testing.T) {
@@ -1299,6 +1361,37 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 		changed, err := r.syncOneSecret(ctx, secret)
 		assert.True(t, changed)
 		assert.NoError(t, err)
+	})
+
+	t.Run("patch error", func(t *testing.T) {
+		apiClient, k8sClient, r := setupReconciler(t)
+		ctx := t.Context()
+
+		secret := secretTemplate.DeepCopy()
+
+		apiClient.EXPECT().CreateKeyPair(ctx, RequestEq(&pomerium.CreateKeyPairRequest{
+			KeyPair: &pomerium.KeyPair{
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-secret-1"),
+				Certificate:  []byte("cert-data"),
+				Key:          []byte("key-data"),
+			},
+		})).Return(&connect.Response[pomerium.CreateKeyPairResponse]{
+			Msg: &pomerium.CreateKeyPairResponse{
+				KeyPair: &pomerium.KeyPair{
+					Id: new("new-keypair-id"),
+					// rest of the data omitted (not currently read)
+				},
+			},
+		}, nil)
+
+		// If the metadata patch operation fails, this error should be surfaced.
+		patchErr := fmt.Errorf("failed to patch")
+		k8sClient.EXPECT().Patch(ctx, secret, gomock.Any()).Return(patchErr)
+
+		changed, err := r.syncOneSecret(ctx, secret)
+		assert.True(t, changed)
+		require.ErrorIs(t, err, patchErr)
 	})
 }
 

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -193,6 +193,56 @@ func TestAPIReconcilerBasicIngressLifecycle(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAPIReconciler_Delete(t *testing.T) {
+	apiClient, k8sClient, r := setupReconciler(t)
+
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-ingress",
+			Namespace: "test",
+			Annotations: map[string]string{
+				"api.pomerium.io/route-id-0": "existing-route-id",
+			},
+		},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: new("pomerium"),
+			Rules: []networkingv1.IngressRule{{
+				Host:             "a.localhost.pomerium.io",
+				IngressRuleValue: exampleIngressRuleValue,
+			}},
+		},
+	}
+	ic := &model.IngressConfig{
+		AnnotationPrefix: "a",
+		Ingress:          ingress,
+		Services: map[types.NamespacedName]*corev1.Service{
+			{Name: "example-svc", Namespace: "test"}: {},
+		},
+	}
+
+	ctx := t.Context()
+
+	k8sClient.EXPECT().Get(ctx, types.NamespacedName{
+		Name: "my-ingress", Namespace: "test",
+	}, gomock.AssignableToTypeOf((*networkingv1.Ingress)(nil))).DoAndReturn(
+		func(_ context.Context, _ types.NamespacedName, dst *networkingv1.Ingress, _ ...client.GetOption) error {
+			*dst = *ic.Ingress
+			return nil
+		})
+
+	apiClient.EXPECT().DeleteRoute(ctx, RequestEq(&pomerium.DeleteRouteRequest{
+		Id: "existing-route-id",
+	})).Return(connect.NewResponse(&pomerium.DeleteRouteResponse{}), nil)
+
+	// If the metadata patch operation fails, this error should be surfaced.
+	patchErr := fmt.Errorf("failed to patch")
+	k8sClient.EXPECT().Patch(ctx, ingress, gomock.Any()).Return(patchErr)
+
+	changed, err := r.Delete(ctx, types.NamespacedName{Name: "my-ingress", Namespace: "test"})
+	assert.True(t, changed)
+	assert.ErrorIs(t, err, patchErr)
+}
+
 func TestAPIReconciler_upsertOneIngress(t *testing.T) {
 	ingressTemplate := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -560,6 +610,37 @@ func TestAPIReconciler_upsertOneIngress(t *testing.T) {
 		assert.True(t, changed)
 		assert.NoError(t, err)
 		assert.Equal(t, "missing-route-id", ic.Annotations["api.pomerium.io/route-id-0"])
+	})
+
+	t.Run("patch error", func(t *testing.T) {
+		ingress := ingressTemplate.DeepCopy()
+		ic := &model.IngressConfig{
+			AnnotationPrefix: "a", Ingress: ingress,
+			Services: map[types.NamespacedName]*corev1.Service{
+				{Name: "example-svc", Namespace: "test"}: {},
+			},
+		}
+
+		apiClient, k8sClient, r := setupReconciler(t)
+		ctx := t.Context()
+
+		apiClient.EXPECT().CreateRoute(ctx, RequestEq(&pomerium.CreateRouteRequest{
+			Route: &pomerium.Route{
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-my-ingress-a-localhost-pomerium-io"),
+				From:         "https://a.localhost.pomerium.io",
+				To:           []string{"http://example-svc.test.svc.cluster.local:8080"},
+				Prefix:       "/",
+			},
+		})).Return(createRouteResponseWithID("new-route-id"), nil)
+
+		// If the metadata patch operation fails, this error should be surfaced.
+		patchErr := fmt.Errorf("failed to patch")
+		k8sClient.EXPECT().Patch(ctx, ingress, gomock.Any()).Return(patchErr)
+
+		changed, err := r.upsertOneIngress(ctx, ic)
+		assert.True(t, changed)
+		assert.ErrorIs(t, err, patchErr)
 	})
 }
 

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -951,7 +951,7 @@ func TestAPIReconciler_upsertOneKeyPair(t *testing.T) {
 	})
 
 	t.Run("update existing keypair", func(t *testing.T) {
-		apiClient, _, r := setupReconciler(t)
+		apiClient, k8sClient, r := setupReconciler(t)
 		ctx := t.Context()
 
 		secret := secretTemplate.DeepCopy()
@@ -987,13 +987,15 @@ func TestAPIReconciler_upsertOneKeyPair(t *testing.T) {
 			Msg: &pomerium.UpdateKeyPairResponse{},
 		}, nil)
 
+		k8sClient.EXPECT().Patch(ctx, secret, gomock.Any()).Return(nil)
+
 		changed, err := r.upsertOneKeyPair(ctx, secret)
 		assert.True(t, changed)
 		assert.NoError(t, err)
 	})
 
 	t.Run("existing keypair unchanged", func(t *testing.T) {
-		apiClient, _, r := setupReconciler(t)
+		apiClient, k8sClient, r := setupReconciler(t)
 		ctx := t.Context()
 
 		secret := secretTemplate.DeepCopy()
@@ -1024,13 +1026,15 @@ func TestAPIReconciler_upsertOneKeyPair(t *testing.T) {
 			},
 		}, nil)
 
+		k8sClient.EXPECT().Patch(ctx, secret, gomock.Any()).Return(nil)
+
 		changed, err := r.upsertOneKeyPair(ctx, secret)
 		assert.False(t, changed)
 		assert.NoError(t, err)
 	})
 
 	t.Run("existing keypair not found", func(t *testing.T) {
-		apiClient, _, r := setupReconciler(t)
+		apiClient, k8sClient, r := setupReconciler(t)
 		ctx := t.Context()
 
 		secret := secretTemplate.DeepCopy()
@@ -1060,6 +1064,8 @@ func TestAPIReconciler_upsertOneKeyPair(t *testing.T) {
 				},
 			},
 		}, nil)
+
+		k8sClient.EXPECT().Patch(ctx, secret, gomock.Any()).Return(nil)
 
 		changed, err := r.upsertOneKeyPair(ctx, secret)
 		assert.True(t, changed)

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -14,7 +14,9 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gateway_v1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -538,6 +540,7 @@ func TestAPIReconciler_upsertOneIngress(t *testing.T) {
 		changed, err := r.upsertOneIngress(ctx, ic)
 		assert.True(t, changed)
 		assert.NoError(t, err)
+		assert.Equal(t, "recreated-route-id", ic.Annotations["api.pomerium.io/route-id-0"])
 	})
 
 	t.Run("other error on update", func(t *testing.T) {
@@ -947,6 +950,61 @@ func TestAPIReconciler_SetGatewayConfig(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAPIReconciler_SetGatewayConfig_routeRecreated(t *testing.T) {
+	httpRouteObject := &gateway_v1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route-a",
+			Namespace: "test",
+			Annotations: map[string]string{
+				"api.pomerium.io/route-id-0": "existing-route-id",
+			},
+		},
+		Spec: gateway_v1.HTTPRouteSpec{
+			CommonRouteSpec: gateway_v1.CommonRouteSpec{},
+			Hostnames:       []gateway_v1.Hostname{},
+			Rules: []gateway_v1.HTTPRouteRule{{
+				BackendRefs: []gateway_v1.HTTPBackendRef{{
+					BackendRef: gateway_v1.BackendRef{
+						BackendObjectReference: gateway_v1.BackendObjectReference{
+							Name: "example-svc",
+							Port: new(gateway_v1.PortNumber(8000)),
+						},
+					},
+				}},
+			}},
+		},
+	}
+
+	gc := &model.GatewayConfig{
+		Routes: []model.GatewayHTTPRouteConfig{{
+			HTTPRoute:        httpRouteObject,
+			Hostnames:        []gateway_v1.Hostname{"a.localhost.pomerium.io"},
+			ValidBackendRefs: noopBackendRefChecker{},
+			Services: map[types.NamespacedName]*corev1.Service{
+				{Name: "example-svc", Namespace: "test"}: {},
+			},
+		}},
+	}
+
+	apiClient, k8sClient, r := setupReconciler(t)
+	ctx := t.Context()
+
+	// If the GetRoute() call returns a Not Found error, the route should be
+	// recreated using CreateRoute().
+	apiClient.EXPECT().GetRoute(ctx, RequestEq(&pomerium.GetRouteRequest{
+		Id: "existing-route-id",
+	})).Return(nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("not found")))
+	apiClient.EXPECT().CreateRoute(ctx, gomock.Any()).
+		Return(createRouteResponseWithID("recreated-route-id"), nil)
+
+	k8sClient.EXPECT().Patch(ctx, httpRouteObject, gomock.Any()).Return(nil)
+
+	changed, err := r.SetGatewayConfig(ctx, gc)
+	assert.True(t, changed)
+	require.NoError(t, err)
+	assert.Equal(t, "recreated-route-id", httpRouteObject.Annotations["api.pomerium.io/route-id-0"])
+}
+
 func TestAPIReconciler_SetConfig(t *testing.T) {
 	cfg := &model.Config{
 		Pomerium: icsv1.Pomerium{
@@ -1240,6 +1298,49 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 
 		changed, err := r.syncOneSecret(ctx, secret)
 		assert.True(t, changed)
+		assert.NoError(t, err)
+	})
+}
+
+func TestAPIReconciler_deleteKeyPairs(t *testing.T) {
+	t.Run("secret missing", func(t *testing.T) {
+		apiClient, k8sClient, r := setupReconciler(t)
+		ctx := t.Context()
+		n := types.NamespacedName{Namespace: "test", Name: "my-secret"}
+
+		// If a Secret was already deleted, we should look for a corresponding
+		// keypair by name.
+		k8sClient.EXPECT().Get(ctx, n, gomock.AssignableToTypeOf((*corev1.Secret)(nil))).
+			Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, n.Name))
+		apiClient.EXPECT().ListKeyPairs(ctx, connect.NewRequest(&pomerium.ListKeyPairsRequest{
+			Filter: filterByName(t, "test-my-secret"),
+		})).Return(connect.NewResponse(&pomerium.ListKeyPairsResponse{
+			KeyPairs: []*pomerium.KeyPair{{
+				Id: new("my-keypair-id"),
+			}},
+		}), nil)
+		apiClient.EXPECT().DeleteKeyPair(ctx, connect.NewRequest(&pomerium.DeleteKeyPairRequest{
+			Id: "my-keypair-id",
+		}))
+
+		_, err := r.deleteKeyPairs(ctx, n)
+		assert.NoError(t, err)
+	})
+
+	t.Run("secret and keypair missing", func(t *testing.T) {
+		apiClient, k8sClient, r := setupReconciler(t)
+		ctx := t.Context()
+		n := types.NamespacedName{Namespace: "test", Name: "my-secret"}
+
+		// If a Secret was already deleted, and no matching keypair exists,
+		// there should be no error returned.
+		k8sClient.EXPECT().Get(ctx, n, gomock.AssignableToTypeOf((*corev1.Secret)(nil))).
+			Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, n.Name))
+		apiClient.EXPECT().ListKeyPairs(ctx, connect.NewRequest(&pomerium.ListKeyPairsRequest{
+			Filter: filterByName(t, "test-my-secret"),
+		})).Return(connect.NewResponse(&pomerium.ListKeyPairsResponse{KeyPairs: nil}), nil)
+
+		_, err := r.deleteKeyPairs(ctx, n)
 		assert.NoError(t, err)
 	})
 }

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -77,7 +77,7 @@ func TestAPIReconcilerBasicIngressLifecycle(t *testing.T) {
 			Namespace: "test",
 		},
 		Spec: networkingv1.IngressSpec{
-			IngressClassName: proto.String("pomerium"),
+			IngressClassName: new("pomerium"),
 			Rules: []networkingv1.IngressRule{{
 				Host:             "a.localhost.pomerium.io",
 				IngressRuleValue: exampleIngressRuleValue,
@@ -200,7 +200,7 @@ func TestAPIReconciler_upsertOneIngress(t *testing.T) {
 			Namespace: "test",
 		},
 		Spec: networkingv1.IngressSpec{
-			IngressClassName: proto.String("pomerium"),
+			IngressClassName: new("pomerium"),
 			Rules: []networkingv1.IngressRule{{
 				Host:             "a.localhost.pomerium.io",
 				IngressRuleValue: exampleIngressRuleValue,
@@ -516,6 +516,51 @@ func TestAPIReconciler_upsertOneIngress(t *testing.T) {
 		require.Error(t, err)
 		assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
 	})
+
+	t.Run("already exists", func(t *testing.T) {
+		ingress := ingressTemplate.DeepCopy()
+		ic := &model.IngressConfig{
+			AnnotationPrefix: "a", Ingress: ingress,
+			Services: map[types.NamespacedName]*corev1.Service{
+				{Name: "example-svc", Namespace: "test"}: {},
+			},
+		}
+
+		apiClient, k8sClient, r := setupReconciler(t)
+		ctx := t.Context()
+
+		// If we try to create a route but it already exists, we should attempt
+		// to look up the existing route by name.
+		apiClient.EXPECT().CreateRoute(ctx, RequestEq(&pomerium.CreateRouteRequest{
+			Route: &pomerium.Route{
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-my-ingress-a-localhost-pomerium-io"),
+				From:         "https://a.localhost.pomerium.io",
+				To:           []string{"http://example-svc.test.svc.cluster.local:8080"},
+				Prefix:       "/",
+			},
+		})).Return(nil, connect.NewError(connect.CodeAlreadyExists, fmt.Errorf("already exists")))
+
+		apiClient.EXPECT().ListRoutes(ctx, RequestEq(&pomerium.ListRoutesRequest{
+			Filter: filterByName(t, "test-my-ingress-a-localhost-pomerium-io"),
+		})).Return(connect.NewResponse(&pomerium.ListRoutesResponse{
+			Routes: []*pomerium.Route{{
+				Id:           new("missing-route-id"),
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-my-ingress-a-localhost-pomerium-io"),
+				From:         "https://a.localhost.pomerium.io",
+				To:           []string{"http://example-svc.test.svc.cluster.local:8080"},
+				Prefix:       "/",
+			}},
+		}), nil)
+
+		k8sClient.EXPECT().Patch(ctx, ingress, gomock.Any()).Return(nil)
+
+		changed, err := r.upsertOneIngress(ctx, ic)
+		assert.True(t, changed)
+		assert.NoError(t, err)
+		assert.Equal(t, "missing-route-id", ic.Annotations["api.pomerium.io/route-id-0"])
+	})
 }
 
 func TestAPIReconciler_upsertOneIngress_multipleRoutes(t *testing.T) {
@@ -527,7 +572,7 @@ func TestAPIReconciler_upsertOneIngress_multipleRoutes(t *testing.T) {
 			Namespace: "test",
 		},
 		Spec: networkingv1.IngressSpec{
-			IngressClassName: proto.String("pomerium"),
+			IngressClassName: new("pomerium"),
 			Rules: []networkingv1.IngressRule{
 				{
 					Host:             "a.localhost.pomerium.io",
@@ -830,10 +875,10 @@ func TestAPIReconciler_SetConfig(t *testing.T) {
 				},
 				IdentityProvider: &icsv1.IdentityProvider{
 					Provider: "oidc",
-					URL:      proto.String("https://idp.example.com"),
+					URL:      new("https://idp.example.com"),
 					Secret:   "test/idp-client-secret",
 				},
-				PassIdentityHeaders: proto.Bool(true),
+				PassIdentityHeaders: new(true),
 			},
 		},
 		IdpSecret: &corev1.Secret{
@@ -853,7 +898,7 @@ func TestAPIReconciler_SetConfig(t *testing.T) {
 			Return(&connect.Response[pomerium.GetSettingsResponse]{
 				Msg: &pomerium.GetSettingsResponse{
 					Settings: &pomerium.Settings{
-						Id: proto.String("settings-id-123"),
+						Id: new("settings-id-123"),
 					},
 				},
 			}, nil)
@@ -861,12 +906,12 @@ func TestAPIReconciler_SetConfig(t *testing.T) {
 		// ...and then call UpdateSettings() once it knows there are changes to sync.
 		apiClient.EXPECT().UpdateSettings(ctx, RequestEq(&pomerium.UpdateSettingsRequest{
 			Settings: &pomerium.Settings{
-				AuthenticateServiceUrl: proto.String("https://authenticate.localhost.pomerium.io"),
-				IdpClientId:            proto.String("CLIENT_ID"),
-				IdpClientSecret:        proto.String("CLIENT_SECRET"),
-				IdpProvider:            proto.String("oidc"),
-				IdpProviderUrl:         proto.String("https://idp.example.com"),
-				PassIdentityHeaders:    proto.Bool(true),
+				AuthenticateServiceUrl: new("https://authenticate.localhost.pomerium.io"),
+				IdpClientId:            new("CLIENT_ID"),
+				IdpClientSecret:        new("CLIENT_SECRET"),
+				IdpProvider:            new("oidc"),
+				IdpProviderUrl:         new("https://idp.example.com"),
+				PassIdentityHeaders:    new(true),
 			},
 		})).Return(&connect.Response[pomerium.UpdateSettingsResponse]{
 			Msg: &pomerium.UpdateSettingsResponse{},
@@ -886,14 +931,14 @@ func TestAPIReconciler_SetConfig(t *testing.T) {
 			Return(&connect.Response[pomerium.GetSettingsResponse]{
 				Msg: &pomerium.GetSettingsResponse{
 					Settings: &pomerium.Settings{
-						Id: proto.String("settings-id-123"),
+						Id: new("settings-id-123"),
 
-						AuthenticateServiceUrl: proto.String("https://authenticate.localhost.pomerium.io"),
-						IdpClientId:            proto.String("CLIENT_ID"),
-						IdpClientSecret:        proto.String("CLIENT_SECRET"),
-						IdpProvider:            proto.String("oidc"),
-						IdpProviderUrl:         proto.String("https://idp.example.com"),
-						PassIdentityHeaders:    proto.Bool(true)},
+						AuthenticateServiceUrl: new("https://authenticate.localhost.pomerium.io"),
+						IdpClientId:            new("CLIENT_ID"),
+						IdpClientSecret:        new("CLIENT_SECRET"),
+						IdpProvider:            new("oidc"),
+						IdpProviderUrl:         new("https://idp.example.com"),
+						PassIdentityHeaders:    new(true)},
 				},
 			}, nil)
 
@@ -926,15 +971,15 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 		// create a new keypair.
 		apiClient.EXPECT().CreateKeyPair(ctx, RequestEq(&pomerium.CreateKeyPairRequest{
 			KeyPair: &pomerium.KeyPair{
-				OriginatorId: proto.String("ingress-controller"),
-				Name:         proto.String("test-secret-1"),
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-secret-1"),
 				Certificate:  []byte("cert-data"),
 				Key:          []byte("key-data"),
 			},
 		})).Return(&connect.Response[pomerium.CreateKeyPairResponse]{
 			Msg: &pomerium.CreateKeyPairResponse{
 				KeyPair: &pomerium.KeyPair{
-					Id: proto.String("new-keypair-id"),
+					Id: new("new-keypair-id"),
 					// rest of the data omitted (not currently read)
 				},
 			},
@@ -966,9 +1011,9 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 		})).Return(&connect.Response[pomerium.GetKeyPairResponse]{
 			Msg: &pomerium.GetKeyPairResponse{
 				KeyPair: &pomerium.KeyPair{
-					OriginatorId: proto.String("ingress-controller"),
-					Id:           proto.String("existing-keypair-id"),
-					Name:         proto.String("test-secret-1"),
+					OriginatorId: new("ingress-controller"),
+					Id:           new("existing-keypair-id"),
+					Name:         new("test-secret-1"),
 					Certificate:  []byte("different-cert-data"),
 					Key:          []byte("different-key-data"),
 				},
@@ -978,9 +1023,9 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 		// ...and then UpdateKeyPair() to sync changes.
 		apiClient.EXPECT().UpdateKeyPair(ctx, RequestEq(&pomerium.UpdateKeyPairRequest{
 			KeyPair: &pomerium.KeyPair{
-				OriginatorId: proto.String("ingress-controller"),
-				Id:           proto.String("existing-keypair-id"),
-				Name:         proto.String("test-secret-1"),
+				OriginatorId: new("ingress-controller"),
+				Id:           new("existing-keypair-id"),
+				Name:         new("test-secret-1"),
 				Certificate:  []byte("cert-data"),
 				Key:          []byte("key-data"),
 			},
@@ -1010,9 +1055,9 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 		})).Return(&connect.Response[pomerium.GetKeyPairResponse]{
 			Msg: &pomerium.GetKeyPairResponse{
 				KeyPair: &pomerium.KeyPair{
-					OriginatorId: proto.String("ingress-controller"),
-					Id:           proto.String("existing-keypair-id"),
-					Name:         proto.String("test-secret-1"),
+					OriginatorId: new("ingress-controller"),
+					Id:           new("existing-keypair-id"),
+					Name:         new("test-secret-1"),
 					Certificate:  []byte("cert-data"),
 					Key:          []byte("key-data"),
 
@@ -1032,7 +1077,7 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("missing ID annotation", func(t *testing.T) {
+	t.Run("already exists", func(t *testing.T) {
 		apiClient, k8sClient, r := setupReconciler(t)
 		ctx := t.Context()
 
@@ -1042,8 +1087,8 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 		// should still be able to look up thte keypair by name.
 		apiClient.EXPECT().CreateKeyPair(ctx, RequestEq(&pomerium.CreateKeyPairRequest{
 			KeyPair: &pomerium.KeyPair{
-				OriginatorId: proto.String("ingress-controller"),
-				Name:         proto.String("test-secret-1"),
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-secret-1"),
 				Certificate:  []byte("cert-data"),
 				Key:          []byte("key-data"),
 			},
@@ -1053,9 +1098,9 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 			Filter: filterByName(t, "test-secret-1"),
 		})).Return(connect.NewResponse(&pomerium.ListKeyPairsResponse{
 			KeyPairs: []*pomerium.KeyPair{{
-				OriginatorId: proto.String("ingress-controller"),
-				Id:           proto.String("missing-keypair-id"),
-				Name:         proto.String("test-secret-1"),
+				OriginatorId: new("ingress-controller"),
+				Id:           new("missing-keypair-id"),
+				Name:         new("test-secret-1"),
 				Certificate:  []byte("cert-data"),
 				Key:          []byte("key-data"),
 
@@ -1095,16 +1140,16 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 
 		apiClient.EXPECT().CreateKeyPair(ctx, RequestEq(&pomerium.CreateKeyPairRequest{
 			KeyPair: &pomerium.KeyPair{
-				Id:           proto.String("existing-keypair-id"),
-				OriginatorId: proto.String("ingress-controller"),
-				Name:         proto.String("test-secret-1"),
+				Id:           new("existing-keypair-id"),
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-secret-1"),
 				Certificate:  []byte("cert-data"),
 				Key:          []byte("key-data"),
 			},
 		})).Return(&connect.Response[pomerium.CreateKeyPairResponse]{
 			Msg: &pomerium.CreateKeyPairResponse{
 				KeyPair: &pomerium.KeyPair{
-					Id: proto.String("existing-keypair-id"),
+					Id: new("existing-keypair-id"),
 					// rest of the data omitted (not currently read)
 				},
 			},
@@ -1185,6 +1230,40 @@ func TestAPIReconciler_upsertPolicy(t *testing.T) {
 		changed, err := r.upsertPolicy(ctx, policy)
 		assert.False(t, changed)
 		assert.NoError(t, err)
+	})
+
+	t.Run("already exists", func(t *testing.T) {
+		policy := &pomerium.Policy{
+			OriginatorId: new("originator-id"),
+			Name:         new("policy-name"),
+		}
+
+		apiClient, _, r := setupReconciler(t)
+		ctx := t.Context()
+
+		// If we try to create a policy but it already exists, we should attempt
+		// to look up the existing policy by name.
+		apiClient.EXPECT().CreatePolicy(ctx, RequestEq(&pomerium.CreatePolicyRequest{
+			Policy: &pomerium.Policy{
+				OriginatorId: new("originator-id"),
+				Name:         new("policy-name"),
+			},
+		})).Return(nil, connect.NewError(connect.CodeAlreadyExists, fmt.Errorf("already exists")))
+
+		apiClient.EXPECT().ListPolicies(ctx, RequestEq(&pomerium.ListPoliciesRequest{
+			Filter: filterByName(t, "policy-name"),
+		})).Return(connect.NewResponse(&pomerium.ListPoliciesResponse{
+			Policies: []*pomerium.Policy{{
+				OriginatorId: new("originator-id"),
+				Id:           new("missing-policy-id"),
+				Name:         new("policy-name"),
+			}},
+		}), nil)
+
+		changed, err := r.upsertPolicy(ctx, policy)
+		assert.True(t, changed)
+		assert.NoError(t, err)
+		assert.Equal(t, "missing-policy-id", policy.GetId())
 	})
 }
 

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -902,7 +903,7 @@ func TestAPIReconciler_SetConfig(t *testing.T) {
 	})
 }
 
-func TestAPIReconciler_upsertOneKeyPair(t *testing.T) {
+func TestAPIReconciler_syncOneSecret(t *testing.T) {
 	secretTemplate := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "secret-1",
@@ -943,7 +944,7 @@ func TestAPIReconciler_upsertOneKeyPair(t *testing.T) {
 		// newly-assigned ID in the keypair ID annotation (verified below).
 		k8sClient.EXPECT().Patch(ctx, secret, gomock.Any()).Return(nil)
 
-		changed, err := r.upsertOneKeyPair(ctx, secret)
+		changed, err := r.syncOneSecret(ctx, secret)
 		assert.True(t, changed)
 		require.NoError(t, err)
 		assert.Equal(t, "new-keypair-id", secret.Annotations[apiKeyPairIDAnnotation])
@@ -989,13 +990,13 @@ func TestAPIReconciler_upsertOneKeyPair(t *testing.T) {
 
 		k8sClient.EXPECT().Patch(ctx, secret, gomock.Any()).Return(nil)
 
-		changed, err := r.upsertOneKeyPair(ctx, secret)
+		changed, err := r.syncOneSecret(ctx, secret)
 		assert.True(t, changed)
 		assert.NoError(t, err)
 	})
 
 	t.Run("existing keypair unchanged", func(t *testing.T) {
-		apiClient, k8sClient, r := setupReconciler(t)
+		apiClient, _, r := setupReconciler(t)
 		ctx := t.Context()
 
 		secret := secretTemplate.DeepCopy()
@@ -1026,11 +1027,55 @@ func TestAPIReconciler_upsertOneKeyPair(t *testing.T) {
 			},
 		}, nil)
 
-		k8sClient.EXPECT().Patch(ctx, secret, gomock.Any()).Return(nil)
-
-		changed, err := r.upsertOneKeyPair(ctx, secret)
+		changed, err := r.syncOneSecret(ctx, secret)
 		assert.False(t, changed)
 		assert.NoError(t, err)
+	})
+
+	t.Run("missing ID annotation", func(t *testing.T) {
+		apiClient, k8sClient, r := setupReconciler(t)
+		ctx := t.Context()
+
+		secret := secretTemplate.DeepCopy()
+
+		// If there is a keypair but we failed to save the ID annotation, we
+		// should still be able to look up thte keypair by name.
+		apiClient.EXPECT().CreateKeyPair(ctx, RequestEq(&pomerium.CreateKeyPairRequest{
+			KeyPair: &pomerium.KeyPair{
+				OriginatorId: proto.String("ingress-controller"),
+				Name:         proto.String("test-secret-1"),
+				Certificate:  []byte("cert-data"),
+				Key:          []byte("key-data"),
+			},
+		})).Return(nil, connect.NewError(connect.CodeAlreadyExists, fmt.Errorf("already exists")))
+
+		apiClient.EXPECT().ListKeyPairs(ctx, RequestEq(&pomerium.ListKeyPairsRequest{
+			Filter: filterByName(t, "test-secret-1"),
+		})).Return(connect.NewResponse(&pomerium.ListKeyPairsResponse{
+			KeyPairs: []*pomerium.KeyPair{{
+				OriginatorId: proto.String("ingress-controller"),
+				Id:           proto.String("missing-keypair-id"),
+				Name:         proto.String("test-secret-1"),
+				Certificate:  []byte("cert-data"),
+				Key:          []byte("key-data"),
+
+				// these fields should be ignored
+				CertificateInfo: []*pomerium.CertificateInfo{{
+					Version: 1234,
+					Serial:  "ABCD",
+				}},
+				Status: pomerium.KeyPairStatus_KEY_PAIR_STATUS_READY,
+				Origin: pomerium.KeyPairOrigin_KEY_PAIR_ORIGIN_USER,
+			}},
+		}), nil)
+
+		k8sClient.EXPECT().Patch(ctx, secret, gomock.Any()).Return(nil)
+
+		changed, err := r.syncOneSecret(ctx, secret)
+		assert.True(t, changed)
+		assert.NoError(t, err)
+		assert.Equal(t, "missing-keypair-id", secret.Annotations["api.pomerium.io/keypair-id"])
+		assert.Contains(t, secret.Finalizers, apiFinalizer)
 	})
 
 	t.Run("existing keypair not found", func(t *testing.T) {
@@ -1067,7 +1112,7 @@ func TestAPIReconciler_upsertOneKeyPair(t *testing.T) {
 
 		k8sClient.EXPECT().Patch(ctx, secret, gomock.Any()).Return(nil)
 
-		changed, err := r.upsertOneKeyPair(ctx, secret)
+		changed, err := r.syncOneSecret(ctx, secret)
 		assert.True(t, changed)
 		assert.NoError(t, err)
 	})
@@ -1258,4 +1303,13 @@ type noopBackendRefChecker struct{}
 
 func (noopBackendRefChecker) Valid(_ client.Object, _ *gateway_v1.BackendRef) bool {
 	return true
+}
+
+func filterByName(t *testing.T, name string) *structpb.Struct {
+	f, err := structpb.NewStruct(map[string]any{
+		"originatorId": "ingress-controller",
+		"name":         name,
+	})
+	require.NoError(t, err)
+	return f
 }

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -1084,7 +1084,7 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 		secret := secretTemplate.DeepCopy()
 
 		// If there is a keypair but we failed to save the ID annotation, we
-		// should still be able to look up thte keypair by name.
+		// should still be able to look up the keypair by name.
 		apiClient.EXPECT().CreateKeyPair(ctx, RequestEq(&pomerium.CreateKeyPairRequest{
 			KeyPair: &pomerium.KeyPair{
 				OriginatorId: new("ingress-controller"),

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -1083,7 +1083,7 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 
 		secret := secretTemplate.DeepCopy()
 
-		// If there is a keypair but we failed to save the ID annotation, we
+		// If the keypair already exists, but we failed to save its ID, we
 		// should still be able to look up the keypair by name.
 		apiClient.EXPECT().CreateKeyPair(ctx, RequestEq(&pomerium.CreateKeyPairRequest{
 			KeyPair: &pomerium.KeyPair{


### PR DESCRIPTION
## Summary

During API sync, if we successfully create a Pomerium entity, but fail to store the assigned ID in the custom k8s annotation, subsequent modifications would fail to sync when we try to create an entity that already exists.

Add error handling for this case: if we get an already_exists error code when attempting to create a Pomerium entity, attempt to look up the entity by the entity name.

Make sure we surface any errors returned by a Patch() call to the reconciler loop.

## Related issues

https://linear.app/pomerium/issue/ENG-3855/ingress-controller-apireconciler-needs-idempotent-entity-creation-and

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
