### PR TITLE
Allowing to have 2 pomerium ICs in a same cluster

### DIFF
--- a/config/pomerium-mcp/ingressclass.yaml
+++ b/config/pomerium-mcp/ingressclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: pomerium-mcp
+spec:
+  controller: pomerium.io/ingress-controller-mcp

--- a/config/pomerium-mcp/inner/kustomization.yaml
+++ b/config/pomerium-mcp/inner/kustomization.yaml
@@ -1,0 +1,14 @@
+#
+# Inner overlay: bundles the StatefulSet with the reused RBAC + gen-secrets
+# resources, applying namePrefix so the cluster-scoped resources don't collide
+# with the default install. Because the StatefulSet is in the same kustomize
+# unit as the renamed ServiceAccount, kustomize's name-reference transformer
+# rewrites the StatefulSet's serviceAccountName automatically.
+#
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: pomerium-mcp-
+resources:
+  - ../../pomerium/rbac
+  - ../../gen_secrets
+  - statefulset.yaml

--- a/config/pomerium-mcp/inner/statefulset.yaml
+++ b/config/pomerium-mcp/inner/statefulset.yaml
@@ -1,0 +1,102 @@
+#
+# StatefulSet variant of the all-in-one pomerium pod, with a PVC mounted at
+# /data so the file-based databroker survives pod restarts.
+#
+# Lives inside `inner/` so the inner kustomization's namePrefix rewrites
+# `serviceAccountName: pomerium-controller` to the renamed SA from
+# ../../pomerium/rbac. The top-level `images:` directive pins the image tag.
+#
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pomerium
+  labels:
+    app.kubernetes.io/component: proxy
+spec:
+  serviceName: pomerium-proxy
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: proxy
+    spec:
+      serviceAccountName: pomerium-controller
+      terminationGracePeriodSeconds: 10
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+      containers:
+        - name: pomerium
+          image: pomerium/ingress-controller
+          imagePullPolicy: IfNotPresent
+          args:
+            - all-in-one
+            - --name=pomerium.io/ingress-controller-mcp
+            - --pomerium-config=global-mcp
+            - --update-status-from-service=$(POMERIUM_NAMESPACE)/pomerium-proxy
+            - --metrics-bind-address=$(POD_IP):9090
+            - --health-probe-bind-address=$(POD_IP):28080
+          env:
+            - name: GOLANG_PROTOBUF_REGISTRATION_CONFLICT
+              value: warn
+            - name: POMERIUM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: TMPDIR
+              value: /tmp
+            - name: XDG_CACHE_HOME
+              value: /tmp
+          ports:
+            - { containerPort: 8443, name: https,   protocol: TCP }
+            - { containerPort: 8443, name: quic,    protocol: UDP }
+            - { containerPort: 8080, name: http,    protocol: TCP }
+            - { containerPort: 9090, name: metrics, protocol: TCP }
+          resources:
+            requests: { cpu: 300m,  memory: 200Mi }
+            limits:   { cpu: 5000m, memory: 1Gi   }
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: [ALL] }
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+          startupProbe:
+            httpGet: { path: /startupz, port: 28080 }
+            failureThreshold: 40
+            periodSeconds: 15
+          livenessProbe:
+            httpGet: { path: /healthz, port: 28080 }
+            initialDelaySeconds: 15
+            periodSeconds: 60
+            failureThreshold: 10
+          readinessProbe:
+            httpGet: { path: /readyz, port: 28080 }
+            initialDelaySeconds: 15
+            periodSeconds: 60
+            failureThreshold: 5
+          volumeMounts:
+            - { name: tmp,  mountPath: /tmp  }
+            - { name: data, mountPath: /data }
+      volumes:
+        - name: tmp
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests: { storage: 1Gi }

--- a/config/pomerium-mcp/kustomization.yaml
+++ b/config/pomerium-mcp/kustomization.yaml
@@ -1,0 +1,30 @@
+#
+# Second Pomerium Ingress Controller instance, fully segregated from the default install:
+#   namespace          pomerium-mcp
+#   IngressClass       pomerium-mcp        (controller: pomerium.io/ingress-controller-mcp)
+#   StatefulSet + PVC  for file-based databroker persistence
+#   global config CR   global-mcp           (applied separately via pomerium-crd.yaml)
+#
+# Layout:
+#   namespace.yaml + ingressclass.yaml are unique to this overlay (cluster-scoped names
+#     must NOT be prefixed, so they live at the top level outside the namePrefix scope).
+#   ../pomerium/service/proxy.yaml is reused as-is — commonLabels rewrites the selector
+#     so it matches our renamed pods, and the metrics Service is intentionally skipped.
+#   ./inner pulls in ../../pomerium/rbac and ../../gen_secrets and applies a namePrefix
+#     so the cluster-scoped ClusterRole/Binding don't collide with the default install.
+#   The image override is set once here so both the StatefulSet and the gen-secrets Job
+#     pick up the same SHA.
+#
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: pomerium-mcp
+commonLabels:
+  app.kubernetes.io/name: pomerium-mcp
+images:
+  - name: pomerium/ingress-controller
+    newTag: sha-3fddd34
+resources:
+  - namespace.yaml
+  - ingressclass.yaml
+  - ../pomerium/service
+  - ./inner

--- a/config/pomerium-mcp/kustomization.yaml
+++ b/config/pomerium-mcp/kustomization.yaml
@@ -3,17 +3,21 @@
 #   namespace          pomerium-mcp
 #   IngressClass       pomerium-mcp        (controller: pomerium.io/ingress-controller-mcp)
 #   StatefulSet + PVC  for file-based databroker persistence
-#   global config CR   global-mcp           (applied separately via pomerium-crd.yaml)
+#
+# The Pomerium global config CR (`global-mcp`) is customer-specific and lives
+# in pomerium-crd.yaml as a sibling — applied separately, not via this kustomization.
 #
 # Layout:
-#   namespace.yaml + ingressclass.yaml are unique to this overlay (cluster-scoped names
-#     must NOT be prefixed, so they live at the top level outside the namePrefix scope).
-#   ../pomerium/service/proxy.yaml is reused as-is — commonLabels rewrites the selector
-#     so it matches our renamed pods, and the metrics Service is intentionally skipped.
-#   ./inner pulls in ../../pomerium/rbac and ../../gen_secrets and applies a namePrefix
-#     so the cluster-scoped ClusterRole/Binding don't collide with the default install.
-#   The image override is set once here so both the StatefulSet and the gen-secrets Job
-#     pick up the same SHA.
+#   ../crd installs the CRD schemas, mirroring config/default.
+#   namespace.yaml + ingressclass.yaml are top-level resources whose names must
+#     stay exact, so they sit outside the inner namePrefix scope.
+#   ../pomerium/service is reused as-is — commonLabels rewrites the selector so
+#     it matches our renamed pods.
+#   ./inner pulls in ../../pomerium/rbac and ../../gen_secrets and applies a
+#     namePrefix so the cluster-scoped ClusterRole/Binding don't collide with
+#     the default install.
+#   The image override is set once here so both the StatefulSet and the
+#     gen-secrets Job pick up the same SHA.
 #
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -24,6 +28,7 @@ images:
   - name: pomerium/ingress-controller
     newTag: sha-3fddd34
 resources:
+  - ../crd
   - namespace.yaml
   - ingressclass.yaml
   - ../pomerium/service

--- a/config/pomerium-mcp/namespace.yaml
+++ b/config/pomerium-mcp/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pomerium-mcp

--- a/config/pomerium-mcp/pomerium-crd.yaml
+++ b/config/pomerium-mcp/pomerium-crd.yaml
@@ -1,0 +1,22 @@
+#
+# Pomerium global config CR for the pomerium-mcp instance.
+# Cluster-scoped and applied separately from the kustomization:
+#
+#   kubectl apply -k config/pomerium-mcp
+#   kubectl apply -f config/pomerium-mcp/pomerium-crd.yaml
+#
+# The StatefulSet's `--pomerium-config=global-mcp` flag binds it to this CR.
+# `storage.file.path` lives on the PVC mounted at /data so the databroker
+# survives pod restarts.
+#
+apiVersion: ingress.pomerium.io/v1
+kind: Pomerium
+metadata:
+  name: global-mcp
+spec:
+  secrets: pomerium-mcp/bootstrap
+  storage:
+    file:
+      path: /data/pomerium.db
+  runtimeFlags:
+    mcp: true


### PR DESCRIPTION

config 
```yaml
apiVersion: ingress.pomerium.io/v1
kind: Pomerium
metadata:
  name: global-mcp
spec:
  secrets: pomerium-mcp/bootstrap
  # persistent data broker is required for MCP
  storage:
    file:
      path: /data/pomerium.db
  runtimeFlags:
    mcp: true
  # specifies the allowed domains for upstream AS/PRM metadata URLs. Supports wildcard patterns like "*.example.com". This restricts which domains Pomerium will contact during upstream OAuth discovery (resource_metadata from WWW-Authenticate, authorization_servers from PRM). 
  mcpAllowedAsMetadataDomains: []
  # specifies the allowed domains for MCP client ID metadata URLs. This is required when MCP is enabled.
  mcpAllowedClientIdDomains: ["vscode.dev", "claude.ai"]
```
