### PR TITLE
deps: upgrade pomerium core to pick up MCP PRM port-normalization fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v1.15.1
-	github.com/pomerium/pomerium v0.32.5-rc.1.0.20260427235339-cec43558f9c6
+	github.com/pomerium/pomerium v0.32.5-rc.1.0.20260430023512-b6db439128bf
 	github.com/pomerium/sdk-go v0.0.10-0.20260407162330-4596c91f544d
 	github.com/rs/zerolog v1.35.0
 	github.com/sergi/go-diff v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -774,8 +774,8 @@ github.com/pomerium/datasource v0.18.2-0.20260409015902-b23fbd70ad17 h1:jX6pVfxg
 github.com/pomerium/datasource v0.18.2-0.20260409015902-b23fbd70ad17/go.mod h1:++WoZ7YvI091gdkme1YoCfzCTyE/pKiJBwwFE1QNR5I=
 github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260331001551-046de5d7c5da h1:aS+bHfLE8IuLblPpXQVzKChYQQTlfEHkK6h3bmigcVM=
 github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260331001551-046de5d7c5da/go.mod h1:7Svo/CaRt9vfJ22sEC+T/q/y2WNi/cZTlugNYUS7xwI=
-github.com/pomerium/pomerium v0.32.5-rc.1.0.20260427235339-cec43558f9c6 h1:+Y1RoHrTv+RMqkjB22aIbhQsdIZelSzWfA0Ao4dcbkw=
-github.com/pomerium/pomerium v0.32.5-rc.1.0.20260427235339-cec43558f9c6/go.mod h1:PeqK5TjIFejKNeov2974D2/MDK2R/JzVkXGltxV1ZD8=
+github.com/pomerium/pomerium v0.32.5-rc.1.0.20260430023512-b6db439128bf h1:hPk3U6HzZE7PRSz/nJjn5oDgKisdnkNyXx6CCEI2uzs=
+github.com/pomerium/pomerium v0.32.5-rc.1.0.20260430023512-b6db439128bf/go.mod h1:3NdG7cTusJeMcmlMUzSTvaLcF+adTIYPbxwBxC7YHNc=
 github.com/pomerium/protoutil v0.0.0-20260409020752-3f215632cd09 h1:m2hAj5/Csh/SR2R8Y1DwDO3cz6WWpPqKHwxF55NS9h8=
 github.com/pomerium/protoutil v0.0.0-20260409020752-3f215632cd09/go.mod h1:Z2DdXU7Y2Vqj45ynjJMJGRYxs5sb17f7I1dFVA+sKQs=
 github.com/pomerium/sdk-go v0.0.10-0.20260407162330-4596c91f544d h1:DdHPrdQNSjU3J1DsqWKcxh/pHlNkAgjtj32vzbcEXPo=


### PR DESCRIPTION
## Summary

Bumps `github.com/pomerium/pomerium` to `b6db439128bf`, which brings in [pomerium/pomerium#6309](https://github.com/pomerium/pomerium/pull/6309) (mcp: strip default ports when comparing PRM resource to upstream URL).

Without this, every MCP route through the ingress controller against an HTTPS upstream defined via an `ExternalName` Service fails upstream OAuth discovery: the controller emits an explicit `:443` (the standard form for ExternalName services) while canonical PRM `resource` strings omit it, and the equality check rejected the match.

## Related issues

- [ENG-3963](https://linear.app/pomerium/issue/ENG-3963/pomerium-mcp-prm-resource-check-fails-on-default-ports-every-https)
- pomerium/pomerium#6309

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests (in core)
- [ ] updated UPGRADING.md
- [x] add appropriate tag (\`bug\`)
- [ ] ready for review