### PR TITLE
rework settings sync to apply Core defaults

### DIFF
--- a/pomerium/config.go
+++ b/pomerium/config.go
@@ -273,7 +273,6 @@ func applyCerts(_ context.Context, p *pb.Config, c *model.Config) error {
 
 func applyAuthenticate(_ context.Context, p *pb.Config, c *model.Config) error {
 	if c.Spec.Authenticate == nil {
-		p.Settings.AuthenticateServiceUrl = proto.String("https://authenticate.pomerium.app")
 		return nil
 	}
 

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -360,6 +360,8 @@ func (r *APIReconciler) SetConfig(ctx context.Context, cfg *model.Config) (chang
 	// Preserve any settings that cannot be set via the Pomerium CRD.
 	settings.Id = existing.Id
 	settings.AutoApplyChangesets = existing.AutoApplyChangesets
+	settings.AutocertDir = existing.AutocertDir
+	settings.RuntimeFlags = existing.RuntimeFlags
 
 	// Mask timestamp metadata.
 	existing.CreatedAt = nil

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/pomerium/pomerium/config"
-	"github.com/pomerium/pomerium/pkg/cryptutil"
 	pb "github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/pomerium/sdk-go"
 	"github.com/pomerium/sdk-go/proto/pomerium"
@@ -345,7 +344,7 @@ func (r *APIReconciler) SetConfig(ctx context.Context, cfg *model.Config) (chang
 
 	// Apply all Core defaults.
 	mergedSettings := config.NewDefaultOptions()
-	mergedSettings.ApplySettings(ctx, cryptutil.NewCertificatesIndex(), pbConfig.Settings)
+	mergedSettings.ApplySettings(ctx, nil, pbConfig.Settings)
 
 	settings, err := convertProto[*pomerium.Settings](mergedSettings.ToProto().GetSettings())
 	if err != nil {
@@ -359,6 +358,7 @@ func (r *APIReconciler) SetConfig(ctx context.Context, cfg *model.Config) (chang
 	existing := resp.Msg.Settings
 
 	// Preserve any settings that cannot be set via the Pomerium CRD.
+	settings.Id = existing.Id
 	settings.AutoApplyChangesets = existing.AutoApplyChangesets
 
 	// Mask timestamp metadata.

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -23,6 +23,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 	pb "github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/pomerium/sdk-go"
 	"github.com/pomerium/sdk-go/proto/pomerium"
@@ -341,7 +343,11 @@ func (r *APIReconciler) SetConfig(ctx context.Context, cfg *model.Config) (chang
 	pbConfig.Settings.Certificates = nil
 	pbConfig.Settings.CertificateAuthority = nil
 
-	settings, err := convertProto[*pomerium.Settings](pbConfig.Settings)
+	// Apply all Core defaults.
+	mergedSettings := config.NewDefaultOptions()
+	mergedSettings.ApplySettings(ctx, cryptutil.NewCertificatesIndex(), pbConfig.Settings)
+
+	settings, err := convertProto[*pomerium.Settings](mergedSettings.ToProto().GetSettings())
 	if err != nil {
 		return false, err
 	}
@@ -350,18 +356,10 @@ func (r *APIReconciler) SetConfig(ctx context.Context, cfg *model.Config) (chang
 	if err != nil {
 		return false, err
 	}
-
-	// Mask any settings that cannot be set via the Pomerium CRD
 	existing := resp.Msg.Settings
-	existing.Address = nil
-	existing.Autocert = nil
-	existing.ClusterId = nil
-	existing.GrpcAddress = nil
-	existing.GrpcInsecure = nil
-	existing.Id = nil
-	existing.InsecureServer = nil
-	existing.NamespaceId = nil
-	existing.SharedSecret = nil
+
+	// Preserve any settings that cannot be set via the Pomerium CRD.
+	settings.AutoApplyChangesets = existing.AutoApplyChangesets
 
 	// Mask timestamp metadata.
 	existing.CreatedAt = nil

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gateway_v1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/sdk-go/proto/pomerium"
 
 	icgv1alpha1 "github.com/pomerium/ingress-controller/apis/gateway/v1alpha1"
@@ -1028,6 +1029,9 @@ func TestAPIReconciler_SetConfig(t *testing.T) {
 		},
 	}
 
+	defaultSettings, err := convertProto[*pomerium.Settings](config.NewDefaultOptions().ToProto().GetSettings())
+	require.NoError(t, err)
+
 	t.Run("settings changed", func(t *testing.T) {
 		apiClient, _, r := setupReconciler(t)
 		ctx := t.Context()
@@ -1042,16 +1046,20 @@ func TestAPIReconciler_SetConfig(t *testing.T) {
 				},
 			}, nil)
 
+		expectedSettings := proto.CloneOf(defaultSettings)
+		proto.Merge(expectedSettings, &pomerium.Settings{
+			Id:                     new("settings-id-123"),
+			AuthenticateServiceUrl: new("https://authenticate.localhost.pomerium.io"),
+			IdpClientId:            new("CLIENT_ID"),
+			IdpClientSecret:        new("CLIENT_SECRET"),
+			IdpProvider:            new("oidc"),
+			IdpProviderUrl:         new("https://idp.example.com"),
+			PassIdentityHeaders:    new(true),
+		})
+
 		// ...and then call UpdateSettings() once it knows there are changes to sync.
 		apiClient.EXPECT().UpdateSettings(ctx, RequestEq(&pomerium.UpdateSettingsRequest{
-			Settings: &pomerium.Settings{
-				AuthenticateServiceUrl: new("https://authenticate.localhost.pomerium.io"),
-				IdpClientId:            new("CLIENT_ID"),
-				IdpClientSecret:        new("CLIENT_SECRET"),
-				IdpProvider:            new("oidc"),
-				IdpProviderUrl:         new("https://idp.example.com"),
-				PassIdentityHeaders:    new(true),
-			},
+			Settings: expectedSettings,
 		})).Return(&connect.Response[pomerium.UpdateSettingsResponse]{
 			Msg: &pomerium.UpdateSettingsResponse{},
 		}, nil)
@@ -1065,19 +1073,25 @@ func TestAPIReconciler_SetConfig(t *testing.T) {
 		apiClient, _, r := setupReconciler(t)
 		ctx := t.Context()
 
+		existingSettings := proto.CloneOf(defaultSettings)
+		proto.Merge(existingSettings, &pomerium.Settings{
+			Id: new("settings-id-123"),
+
+			AuthenticateServiceUrl: new("https://authenticate.localhost.pomerium.io"),
+			IdpClientId:            new("CLIENT_ID"),
+			IdpClientSecret:        new("CLIENT_SECRET"),
+			IdpProvider:            new("oidc"),
+			IdpProviderUrl:         new("https://idp.example.com"),
+			PassIdentityHeaders:    new(true),
+
+			AutoApplyChangesets: new(true), // this setting should be ignored
+		})
+
 		// If the settings already match, there should be no UpdateSettings() call.
 		apiClient.EXPECT().GetSettings(ctx, connect.NewRequest(&pomerium.GetSettingsRequest{})).
 			Return(&connect.Response[pomerium.GetSettingsResponse]{
 				Msg: &pomerium.GetSettingsResponse{
-					Settings: &pomerium.Settings{
-						Id: new("settings-id-123"),
-
-						AuthenticateServiceUrl: new("https://authenticate.localhost.pomerium.io"),
-						IdpClientId:            new("CLIENT_ID"),
-						IdpClientSecret:        new("CLIENT_SECRET"),
-						IdpProvider:            new("oidc"),
-						IdpProviderUrl:         new("https://idp.example.com"),
-						PassIdentityHeaders:    new(true)},
+					Settings: existingSettings,
 				},
 			}, nil)
 

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -1047,15 +1047,15 @@ func TestAPIReconciler_SetConfig(t *testing.T) {
 			}, nil)
 
 		expectedSettings := proto.CloneOf(defaultSettings)
-		proto.Merge(expectedSettings, &pomerium.Settings{
-			Id:                     new("settings-id-123"),
-			AuthenticateServiceUrl: new("https://authenticate.localhost.pomerium.io"),
-			IdpClientId:            new("CLIENT_ID"),
-			IdpClientSecret:        new("CLIENT_SECRET"),
-			IdpProvider:            new("oidc"),
-			IdpProviderUrl:         new("https://idp.example.com"),
-			PassIdentityHeaders:    new(true),
-		})
+		expectedSettings.Id = new("settings-id-123")
+		expectedSettings.AuthenticateServiceUrl = new("https://authenticate.localhost.pomerium.io")
+		expectedSettings.AutocertDir = nil
+		expectedSettings.IdpClientId = new("CLIENT_ID")
+		expectedSettings.IdpClientSecret = new("CLIENT_SECRET")
+		expectedSettings.IdpProvider = new("oidc")
+		expectedSettings.IdpProviderUrl = new("https://idp.example.com")
+		expectedSettings.PassIdentityHeaders = new(true)
+		expectedSettings.RuntimeFlags = nil
 
 		// ...and then call UpdateSettings() once it knows there are changes to sync.
 		apiClient.EXPECT().UpdateSettings(ctx, RequestEq(&pomerium.UpdateSettingsRequest{


### PR DESCRIPTION
## Summary

When syncing settings via the new API we should apply any defaults values explicitly, as they may not be inferred by the API implementation.

Also remove the hard-coded default authenticate service URL, as this should no longer be necessary.

## Related issues

https://linear.app/pomerium/issue/ENG-3960/ingress-controller-settings-sync-should-apply-core-defaults
https://linear.app/pomerium/issue/ENG-3957/ingress-controller-settings-sync-should-not-overwrite-zero-only

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
