### PR TITLE
ci: fix docs pull request workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,6 +15,10 @@ jobs:
         with:
           go-version-file: .tool-versions
 
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: .tool-versions
+
       - name: generate docs
         run: make docs
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 golangci-lint 2.11.4
 golang 1.26.2
+nodejs 24.15.0

--- a/scripts/open-docs-pull-request.sh
+++ b/scripts/open-docs-pull-request.sh
@@ -18,7 +18,8 @@ git clone --depth 1 \
 echo "Copying contents to git repo"
 cp -R "$source_path" "$clone_dir/$destination_path"
 cd "$clone_dir"
-yarn && yarn prettier --write "$destination_path/$source_path"
+yarn
+yarn prettier --write "$destination_path/$source_path"
 git checkout -b "$destination_head_branch"
 
 if [ -z "$(git status -z)" ]; then


### PR DESCRIPTION
## Summary

Fix the workflow for syncing the generated reference.md file to the documentation repo by adding a step to install a newer nodejs version. Also update the script so that if the 'yarn' step fails, the script will not continue. (Combining 'yarn && yarn prettier ...' in one command meant that even with 'set -e', an error from 'yarn' would not stop the script.)

## Related issues

https://linear.app/pomerium/issue/ENG-3983/docs-spurious-ingress-reference-update-prs


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
