### PR TITLE
ingress-controller/config: remove quic port, add configs for eks and gke

### DIFF
--- a/config/http3-eks/README.md
+++ b/config/http3-eks/README.md
@@ -1,0 +1,5 @@
+# HTTP/3 Support for EKS
+
+By default EKS will complain about a multi-protocol (TCP+UDP) load balancer. This kustomization will make the necessary changes to the pomerium proxy service to support HTTP/3.
+
+These changes were taken from Amazon's [documentation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/use_cases/quic/).

--- a/config/http3-eks/kustomization.yaml
+++ b/config/http3-eks/kustomization.yaml
@@ -1,0 +1,50 @@
+namespace: pomerium
+resources:
+  - ../default
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/ports/-
+        value:
+          name: quic
+          port: 443
+          targetPort: quic
+          protocol: UDP
+      - op: replace
+        path: /spec/loadBalancerClass
+        value: "service.k8s.aws/nlb"
+      - op: add
+        path: /metadata/annotations/service.beta.kubernetes.io~1aws-load-balancer-disable-nlb-sg
+        value: "true"
+      - op: add
+        path: /metadata/annotations/service.beta.kubernetes.io~1aws-load-balancer-enable-tcp-udp-listener
+        value: "true"
+      - op: add
+        path: /metadata/annotations/service.beta.kubernetes.io~1aws-load-balancer-nlb-target-type
+        value: "ip"
+      - op: add
+        path: /metadata/annotations/service.beta.kubernetes.io~1aws-load-balancer-quic-enabled-ports
+        value: "443"
+      - op: add
+        path: /metadata/annotations/service.beta.kubernetes.io~1aws-load-balancer-scheme
+        value: "internet-facing"
+    target:
+      version: v1
+      kind: Service
+      name: pomerium-proxy
+  - patch: |-
+      - op: add
+        path: /metadata/labels/elbv2.k8s.aws~1quic-server-id-inject
+        value: "enabled"
+    target:
+      version: v1
+      kind: Namespace
+      name: pomerium
+  - patch: |-
+      - op: add
+        path: /spec/template/metadata/annotations/service.beta.kubernetes.io~1aws-load-balancer-quic-enabled-containers
+        value: pomerium
+    target:
+      version: apps/v1
+      kind: Deployment
+      name: pomerium

--- a/config/http3-gke/README.md
+++ b/config/http3-gke/README.md
@@ -1,0 +1,5 @@
+# HTTP/3 Support for GKE
+
+By default GKE will complain about a multi-protocol (TCP+UDP) load balancer. This kustomization will make the necessary changes to the pomerium proxy service to support HTTP/3.
+
+These changes were taken from Google's [documentation](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/mixed-protocol-lb).

--- a/config/http3-gke/kustomization.yaml
+++ b/config/http3-gke/kustomization.yaml
@@ -1,0 +1,19 @@
+namespace: pomerium
+resources:
+  - ../default
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/ports/-
+        value:
+          name: quic
+          port: 443
+          targetPort: quic
+          protocol: UDP
+      - op: replace
+        path: /spec/loadBalancerClass
+        value: "networking.gke.io/l4-regional-external"
+    target:
+      version: v1
+      kind: Service
+      name: pomerium-proxy

--- a/config/pomerium/service/proxy.yaml
+++ b/config/pomerium/service/proxy.yaml
@@ -15,10 +15,6 @@ spec:
       port: 443
       targetPort: https
       protocol: TCP
-    - name: quic
-      port: 443
-      targetPort: quic
-      protocol: UDP
     - name: http
       port: 80
       targetPort: http

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1011,10 +1011,6 @@ spec:
     port: 443
     protocol: TCP
     targetPort: https
-  - name: quic
-    port: 443
-    protocol: UDP
-    targetPort: quic
   - name: http
     port: 80
     protocol: TCP


### PR DESCRIPTION
## Summary
Remove the `quic` port from the base config and add two new configs for EKS and GKE that should configure services in such a way that they can be used with HTTP/3.

## Related issues
- [ENG-3962](https://linear.app/pomerium/issue/ENG-3962/pomerium-ingress-controller-loadbalancer-service-uses-mixed-tcpudp)


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
