### PR TITLE
ingress-controller: add new certificate name index

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -336,8 +336,6 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-ignore (
-    ./internal/ui
-)
+ignore ./internal/ui
 
 tool github.com/pomerium/pomerium/pkg/envoy/get-envoy

--- a/internal/certificate/nameindex.go
+++ b/internal/certificate/nameindex.go
@@ -12,6 +12,8 @@ type NameIndex[Key comparable] interface {
 	// Add adds all the names to the index for the given key. Multiple
 	// keys can be associated with the same names.
 	Add(key Key, names []string)
+	// Get returns all the names for the given key.
+	Get(key Key) []string
 	// Keys returns all the known keys. Order is non-deterministic.
 	Keys() []Key
 	// Lookup looks up any keys associated with the given name. Wildcard search
@@ -67,6 +69,10 @@ func (idx *nameIndex[Key]) Add(key Key, names []string) {
 
 		keys[key] = struct{}{}
 	}
+}
+
+func (idx *nameIndex[Key]) Get(key Key) []string {
+	return slices.Clone(idx.keys[key])
 }
 
 func (idx *nameIndex[Key]) Keys() []Key {

--- a/internal/certificate/nameindex.go
+++ b/internal/certificate/nameindex.go
@@ -49,7 +49,7 @@ func (idx *nameIndex[Key]) Add(key Key, names []string) {
 	idx.Remove(key)
 
 	// add the key
-	idx.keys[key] = names
+	idx.keys[key] = slices.Clone(names)
 
 	// index each of the names
 	for _, name := range names {

--- a/internal/certificate/nameindex.go
+++ b/internal/certificate/nameindex.go
@@ -1,0 +1,158 @@
+package certificate
+
+import (
+	"maps"
+	"slices"
+	"strings"
+)
+
+// NameIndex is used to index certificate DNS names. It supports exact and
+// wildcard matching and dynamic updates.
+type NameIndex[Key comparable] interface {
+	// Add adds all the names to the index for the given key. Multiple
+	// keys can be associated with the same names.
+	Add(key Key, names []string)
+	// Keys returns all the known keys. Order is non-deterministic.
+	Keys() []Key
+	// Lookup looks up any keys associated with the given name. Wildcard search
+	// is supported (Lookup("*.example.com") -> would match a key for
+	// "www.example.com"). Order is non-deterministic.
+	Lookup(name string) []Key
+	// Names returns all the known names. Order is non-deterministic.
+	Names() []string
+	// Remove removes a key from the index and possibly all of its associated
+	// names if they aren't referenced by any other keys.
+	Remove(key Key)
+}
+
+// NewNameIndex creates a new NameIndex for the given key type. The NameIndex
+// is not safe for concurrent use.
+func NewNameIndex[Key comparable]() NameIndex[Key] {
+	return &nameIndex[Key]{
+		suffixes: make(map[string]map[string]map[Key]struct{}),
+		keys:     make(map[Key][]string),
+	}
+}
+
+type nameIndex[Key comparable] struct {
+	// suffixes is a map of suffix -> prefix -> keys,
+	// where for www.example.com, suffix is example.com
+	// and prefix is www
+	suffixes map[string]map[string]map[Key]struct{}
+	keys     map[Key][]string
+}
+
+func (idx *nameIndex[Key]) Add(key Key, names []string) {
+	// always remove first to keep the index consistent
+	idx.Remove(key)
+
+	// add the key
+	idx.keys[key] = names
+
+	// index each of the names
+	for _, name := range names {
+		prefix, suffix := idx.splitName(name)
+
+		prefixes, ok := idx.suffixes[suffix]
+		if !ok {
+			prefixes = make(map[string]map[Key]struct{})
+			idx.suffixes[suffix] = prefixes
+		}
+
+		keys, ok := prefixes[prefix]
+		if !ok {
+			keys = make(map[Key]struct{})
+			prefixes[prefix] = keys
+		}
+
+		keys[key] = struct{}{}
+	}
+}
+
+func (idx *nameIndex[Key]) Keys() []Key {
+	return slices.Collect(maps.Keys(idx.keys))
+}
+
+func (idx *nameIndex[Key]) Lookup(name string) []Key {
+	prefix, suffix := idx.splitName(name)
+
+	prefixes, ok := idx.suffixes[suffix]
+	if !ok {
+		return nil
+	}
+
+	allKeys := map[Key]struct{}{}
+	// if the prefix is *, we should return all the keys for all the names
+	if prefix == "*" {
+		for _, keys := range prefixes {
+			for key := range keys {
+				allKeys[key] = struct{}{}
+			}
+		}
+	} else {
+		// lookup an exact match
+		if keys, ok := prefixes[prefix]; ok {
+			for key := range keys {
+				allKeys[key] = struct{}{}
+			}
+		}
+		// if we're storing a wildcard return those keys too
+		if keys, ok := prefixes["*"]; ok {
+			for key := range keys {
+				allKeys[key] = struct{}{}
+			}
+		}
+	}
+	return slices.Collect(maps.Keys(allKeys))
+}
+
+func (idx *nameIndex[Key]) Names() []string {
+	m := map[string]struct{}{}
+	for _, names := range idx.keys {
+		for _, name := range names {
+			m[name] = struct{}{}
+		}
+	}
+	return slices.Collect(maps.Keys(m))
+}
+
+func (idx *nameIndex[Key]) Remove(key Key) {
+	names := idx.keys[key]
+	delete(idx.keys, key)
+	for _, name := range names {
+		prefix, suffix := idx.splitName(name)
+
+		prefixes, ok := idx.suffixes[suffix]
+		if !ok {
+			continue
+		}
+
+		keys, ok := prefixes[prefix]
+		if !ok {
+			continue
+		}
+
+		delete(keys, key)
+		// remove empty maps
+		if len(keys) == 0 {
+			delete(prefixes, prefix)
+		}
+		if len(prefixes) == 0 {
+			delete(idx.suffixes, suffix)
+		}
+	}
+}
+
+func (idx *nameIndex[Key]) splitName(name string) (prefix, suffix string) {
+	// remove any trailing .
+	name = strings.TrimSuffix(name, ".")
+	// matching is lowercase
+	name = strings.ToLower(name)
+
+	prefix, suffix, found := strings.Cut(name, ".")
+	if !found {
+		return name, ""
+	}
+
+	return prefix, suffix
+}

--- a/internal/certificate/nameindex_test.go
+++ b/internal/certificate/nameindex_test.go
@@ -1,0 +1,72 @@
+package certificate_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/ingress-controller/internal/certificate"
+)
+
+func TestNameIndex(t *testing.T) {
+	t.Parallel()
+
+	idx := certificate.NewNameIndex[int]()
+
+	idx.Add(1, []string{"*.example.com"})
+	keys := idx.Lookup("www.example.com")
+	slices.Sort(keys)
+	assert.Equal(t, []int{1}, keys)
+
+	keys = idx.Lookup("wWw.ExaMPle.com")
+	slices.Sort(keys)
+	assert.Equal(t, []int{1}, keys, "should be case insensitive")
+
+	keys = idx.Lookup("www.example.com.")
+	slices.Sort(keys)
+	assert.Equal(t, []int{1}, keys, "should strip trailing dots")
+
+	idx.Add(2, []string{"www.example.com"})
+	keys = idx.Lookup("www.example.com")
+	slices.Sort(keys)
+	assert.Equal(t, []int{1, 2}, keys)
+
+	idx.Remove(1)
+	keys = idx.Lookup("www.example.com")
+	slices.Sort(keys)
+	assert.Equal(t, []int{2}, keys)
+
+	idx.Add(3, []string{"a.example.com"})
+	idx.Add(4, []string{"b.example.com"})
+	idx.Add(5, []string{"c.example.com"})
+	keys = idx.Lookup("*.example.com")
+	slices.Sort(keys)
+	assert.Equal(t, []int{2, 3, 4, 5}, keys)
+	keys = idx.Lookup("*.com")
+	slices.Sort(keys)
+	assert.Empty(t, keys, "should only support single-level wildcards")
+
+	keys = idx.Keys()
+	slices.Sort(keys)
+	assert.Equal(t, []int{2, 3, 4, 5}, keys)
+
+	names := idx.Names()
+	slices.Sort(names)
+	assert.Equal(t, []string{"a.example.com", "b.example.com", "c.example.com", "www.example.com"}, names)
+
+	idx.Add(6, []string{"localhost"})
+	keys = idx.Lookup("localhost")
+	assert.Equal(t, []int{6}, keys)
+	keys = idx.Lookup("*")
+	assert.Equal(t, []int{6}, keys)
+
+	idx.Remove(2)
+	idx.Remove(3)
+	idx.Remove(4)
+	idx.Remove(5)
+	idx.Remove(6)
+
+	keys = idx.Lookup("*")
+	assert.Empty(t, keys)
+}

--- a/internal/certificate/nameindex_test.go
+++ b/internal/certificate/nameindex_test.go
@@ -32,6 +32,10 @@ func TestNameIndex(t *testing.T) {
 	slices.Sort(keys)
 	assert.Equal(t, []int{1, 2}, keys)
 
+	names := idx.Get(2)
+	slices.Sort(names)
+	assert.Equal(t, []string{"www.example.com"}, names)
+
 	idx.Remove(1)
 	keys = idx.Lookup("www.example.com")
 	slices.Sort(keys)
@@ -51,7 +55,7 @@ func TestNameIndex(t *testing.T) {
 	slices.Sort(keys)
 	assert.Equal(t, []int{2, 3, 4, 5}, keys)
 
-	names := idx.Names()
+	names = idx.Names()
 	slices.Sort(names)
 	assert.Equal(t, []string{"a.example.com", "b.example.com", "c.example.com", "www.example.com"}, names)
 


### PR DESCRIPTION
## Summary
Add a new certificate name index which will be used for matching certificates to routes.

Although we have a similar index in core, it does not support dynamic updates and would need to be rebuilt every time, but this index would be updated by individual updates via `Sync` calls from the databroker.

## Related issues
- [ENG-4004](https://linear.app/pomerium/issue/ENG-4004/ingress-controller-add-certificate-name-index)


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
