### PR TITLE
upgrade core to v0.32.7

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 golangci-lint 2.8.0
-golang 1.25.6
+golang 1.25.10

--- a/config/clustered-databroker/statefulset/image.yaml
+++ b/config/clustered-databroker/statefulset/image.yaml
@@ -7,5 +7,5 @@ spec:
     spec:
       containers:
         - name: pomerium
-          image: pomerium/ingress-controller:v0.32.7
+          image: pomerium/ingress-controller:v0.32.8
           imagePullPolicy: IfNotPresent

--- a/config/pomerium/deployment/image.yaml
+++ b/config/pomerium/deployment/image.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
         - name: pomerium
-          image: pomerium/ingress-controller:v0.32.7
+          image: pomerium/ingress-controller:v0.32.8
           imagePullPolicy: IfNotPresent

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1004,7 +1004,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: pomerium/ingress-controller:v0.32.7
+        image: pomerium/ingress-controller:v0.32.8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v1.12.1
-	github.com/pomerium/pomerium v0.32.6
+	github.com/pomerium/pomerium v0.32.7
 	github.com/rs/zerolog v1.34.0
 	github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cobra v1.10.2
@@ -176,7 +176,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.8.0 // indirect
+	github.com/jackc/pgx/v5 v5.9.2 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -530,8 +530,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.8.0 h1:TYPDoleBBme0xGSAX3/+NujXXtpZn9HBONkQC7IEZSo=
-github.com/jackc/pgx/v5 v5.8.0/go.mod h1:QVeDInX2m9VyzvNeiCJVjCkNFqzsNb43204HshNSZKw=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/johannesboyne/gofakes3 v0.0.0-20250916175020-ebf3e50324d3 h1:2713fQZ560HxoNVgfJH41GKzjMjIG+DW4hH6nYXfXW8=
@@ -702,8 +702,8 @@ github.com/pomerium/datasource v0.18.2-0.20260116153236-1f58110d0e17 h1:0xmmqjD1
 github.com/pomerium/datasource v0.18.2-0.20260116153236-1f58110d0e17/go.mod h1:E+aEx9rVJm+lNWcKUzMHY6MobZC0HchBCn9zdP2EfHE=
 github.com/pomerium/envoy-custom v1.36.5-p1 h1:Cs/KLpVAlI1gFflRh0EGaeh5VlAHW+IltAflV+HB1No=
 github.com/pomerium/envoy-custom v1.36.5-p1/go.mod h1:+wpbZvum83bq/OD4cp9/8IZiMV6boBkwDhlFPLOoWoI=
-github.com/pomerium/pomerium v0.32.6 h1:t4TDZfVKWDlNumKyNwQwS8FEYzMw9a5mRiDsh2/s/6Q=
-github.com/pomerium/pomerium v0.32.6/go.mod h1:unz14X6lG8ezqbnG+oYxxRMaHjp5tRqAliF3r2Flja0=
+github.com/pomerium/pomerium v0.32.7 h1:ejWeLnOleAYXkT1u9y+UGON5yRKUpAg4rpSvEhZ//SE=
+github.com/pomerium/pomerium v0.32.7/go.mod h1:/0vCiayfybuKNMvze+1u131qlV87PiGOLSFMITSHA7E=
 github.com/pomerium/protoutil v0.0.0-20260116153545-19d2ae5b7518 h1:xIW5acZOr+EBXMapcOYsBCY/o7uh5GpKVVkk8iaTRFU=
 github.com/pomerium/protoutil v0.0.0-20260116153545-19d2ae5b7518/go.mod h1:vPV2+oC0DppJcM14IwN5nCJXW0Bh6J6r5Kg/vjEb0kQ=
 github.com/pomerium/webauthn v0.0.0-20260116153041-d32e028c3f7e h1:ACaHHitpK9WxN8Rd+hXPktyE3dWvfsfq9Hq86Kb8yU4=


### PR DESCRIPTION
Prepare for a v0.32.8 release by updating core to the latest v0.32.7. Also bump the Go version to 1.25.10 to match.