### PR TITLE
add ingress annotation for native ssh

### DIFF
--- a/model/ingress_config.go
+++ b/model/ingress_config.go
@@ -32,9 +32,11 @@ const (
 	PathRegex = "path_regex"
 	// UseServiceProxy will use standard k8s service proxy as upstream, opposed to individual endpoints
 	UseServiceProxy = "service_proxy_upstream"
-	// TCPUpstream indicates this route is a TCP service https://www.pomerium.com/docs/tcp/
+	// SSHUpstream indicates this route is for natively-proxied SSH https://www.pomerium.com/docs/capabilities/native-ssh-access
+	SSHUpstream = "ssh_upstream"
+	// TCPUpstream indicates this route is for TCP tunneled over HTTP https://www.pomerium.com/docs/tcp/
 	TCPUpstream = "tcp_upstream"
-	// UDPUpstream indicates this route is a UDP service https://www.pomerium.com/docs/capabilities/udp/
+	// UDPUpstream indicates this route is for UDP tunneled over HTTP https://www.pomerium.com/docs/capabilities/udp/
 	UDPUpstream = "udp_upstream"
 	// SubtleAllowEmptyHost is a required annotation when creating an ingress containing
 	// rules with an empty (catch-all) host, as it can cause unexpected behavior
@@ -189,12 +191,17 @@ func (ic *IngressConfig) IsSecureUpstream() bool {
 	return ic.IsAnnotationSet(SecureUpstream)
 }
 
-// IsTCPUpstream returns true is this route represents a TCP service https://www.pomerium.com/docs/tcp/
+// IsSSHUpstream returns true if this route is for natively-proxied SSH https://www.pomerium.com/docs/capabilities/native-ssh-access
+func (ic *IngressConfig) IsSSHUpstream() bool {
+	return ic.IsAnnotationSet(SSHUpstream)
+}
+
+// IsTCPUpstream returns true if this route is for TCP tunneled over HTTP https://www.pomerium.com/docs/tcp/
 func (ic *IngressConfig) IsTCPUpstream() bool {
 	return ic.IsAnnotationSet(TCPUpstream)
 }
 
-// IsUDPUpstream returns true is this route represents a UDP service https://www.pomerium.com/docs/capabilities/tcp/
+// IsUDPUpstream returns true if this route is for UDP tunneled over HTTP https://www.pomerium.com/docs/capabilities/tcp/
 func (ic *IngressConfig) IsUDPUpstream() bool {
 	return ic.IsAnnotationSet(UDPUpstream)
 }

--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -94,6 +94,7 @@ var (
 	handledElsewhere = boolMap([]string{
 		model.PathRegex,
 		model.SecureUpstream,
+		model.SSHUpstream,
 		model.TCPUpstream,
 		model.UDPUpstream,
 		model.UseServiceProxy,

--- a/pomerium/ingress_to_route.go
+++ b/pomerium/ingress_to_route.go
@@ -142,6 +142,16 @@ func setRoutePath(r *pb.Route, p networkingv1.HTTPIngressPath, ic *model.Ingress
 		return fmt.Errorf("pathType is required")
 	}
 
+	if ic.IsSSHUpstream() {
+		if *p.PathType != networkingv1.PathTypeImplementationSpecific {
+			return fmt.Errorf("ssh services must have %s path type", networkingv1.PathTypeImplementationSpecific)
+		}
+		if p.Path != "" {
+			return fmt.Errorf("ssh services must not specify path, got %s", r.Path)
+		}
+		return nil
+	}
+
 	if ic.IsTCPUpstream() {
 		if *p.PathType != networkingv1.PathTypeImplementationSpecific {
 			return fmt.Errorf("tcp services must have %s path type", networkingv1.PathTypeImplementationSpecific)
@@ -185,6 +195,10 @@ func setRouteFrom(r *pb.Route, host string, p networkingv1.HTTPIngressPath, ic *
 	u := url.URL{
 		Scheme: "https",
 		Host:   host,
+	}
+
+	if ic.IsSSHUpstream() {
+		u.Scheme = "ssh"
 	}
 
 	if ic.IsTCPUpstream() {
@@ -282,7 +296,9 @@ func getPathServiceHosts(r *pb.Route, p networkingv1.HTTPIngressPath, ic *model.
 }
 
 func getUpstreamScheme(ic *model.IngressConfig) string {
-	if ic.IsTCPUpstream() {
+	if ic.IsSSHUpstream() {
+		return "ssh"
+	} else if ic.IsTCPUpstream() {
 		return "tcp"
 	} else if ic.IsUDPUpstream() {
 		return "udp"

--- a/pomerium/ingress_to_route.go
+++ b/pomerium/ingress_to_route.go
@@ -147,7 +147,7 @@ func setRoutePath(r *pb.Route, p networkingv1.HTTPIngressPath, ic *model.Ingress
 			return fmt.Errorf("ssh services must have %s path type", networkingv1.PathTypeImplementationSpecific)
 		}
 		if p.Path != "" {
-			return fmt.Errorf("ssh services must not specify path, got %s", r.Path)
+			return fmt.Errorf("ssh services must not specify path, got %s", p.Path)
 		}
 		return nil
 	}
@@ -157,7 +157,7 @@ func setRoutePath(r *pb.Route, p networkingv1.HTTPIngressPath, ic *model.Ingress
 			return fmt.Errorf("tcp services must have %s path type", networkingv1.PathTypeImplementationSpecific)
 		}
 		if p.Path != "" {
-			return fmt.Errorf("tcp services must not specify path, got %s", r.Path)
+			return fmt.Errorf("tcp services must not specify path, got %s", p.Path)
 		}
 		return nil
 	}
@@ -167,7 +167,7 @@ func setRoutePath(r *pb.Route, p networkingv1.HTTPIngressPath, ic *model.Ingress
 			return fmt.Errorf("udp services must have %s path type", networkingv1.PathTypeImplementationSpecific)
 		}
 		if p.Path != "" {
-			return fmt.Errorf("udp services must not specify path, got %s", r.Path)
+			return fmt.Errorf("udp services must not specify path, got %s", p.Path)
 		}
 		return nil
 	}

--- a/pomerium/routes_test.go
+++ b/pomerium/routes_test.go
@@ -467,6 +467,70 @@ func TestKubernetesToken(t *testing.T) {
 	require.NoError(t, validate(ctx, cfg, "test"))
 }
 
+func TestSSHUpstream(t *testing.T) {
+	irv := networkingv1.IngressRuleValue{
+		HTTP: &networkingv1.HTTPIngressRuleValue{
+			Paths: []networkingv1.HTTPIngressPath{{
+				PathType: new(networkingv1.PathTypeImplementationSpecific),
+				Backend: networkingv1.IngressBackend{
+					Service: &networkingv1.IngressServiceBackend{
+						Name: "example-svc",
+						Port: networkingv1.ServiceBackendPort{
+							Number: 22,
+						},
+					},
+				},
+			}},
+		},
+	}
+	ic := model.IngressConfig{
+		AnnotationPrefix: "p",
+		Ingress: &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ingress",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"p/ssh_upstream": "true",
+				},
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{{
+					Host:             "my-ssh-route",
+					IngressRuleValue: irv,
+				}},
+			},
+		},
+		Services: map[types.NamespacedName]*corev1.Service{
+			{Name: "example-svc", Namespace: "default"}: {},
+		},
+	}
+
+	t.Run("ok", func(t *testing.T) {
+		routes, err := ingressToRoutes(t.Context(), &ic)
+		require.NoError(t, err)
+
+		require.Len(t, routes, 1)
+		assert.Equal(t, "ssh://my-ssh-route", routes[0].From)
+		assert.Equal(t, []string{"ssh://example-svc.default.svc.cluster.local:22"}, routes[0].To)
+	})
+	t.Run("bad path type", func(t *testing.T) {
+		ic := ic
+		ic.Ingress = ic.Ingress.DeepCopy()
+		ic.Ingress.Spec.Rules[0].HTTP.Paths[0].PathType = new(networkingv1.PathTypeExact)
+
+		_, err := ingressToRoutes(t.Context(), &ic)
+		assert.ErrorContains(t, err, "ssh services must have ImplementationSpecific path type")
+	})
+	t.Run("non-empty path", func(t *testing.T) {
+		ic := ic
+		ic.Ingress = ic.Ingress.DeepCopy()
+		ic.Ingress.Spec.Rules[0].HTTP.Paths[0].Path = "/some/path"
+
+		_, err := ingressToRoutes(t.Context(), &ic)
+		assert.ErrorContains(t, err, "ssh services must not specify path, got /some/path")
+	})
+}
+
 func TestTCPUpstream(t *testing.T) {
 	typePrefix := networkingv1.PathTypePrefix
 	typeImpSpec := networkingv1.PathTypeImplementationSpecific


### PR DESCRIPTION
## Summary

Add a new Ingress annotation `ingress.pomerium.io/ssh_upstream` for native SSH routes, following the example of the similar `tcp_upstream` and `udp_upstream` annotations.

## Related issues

- https://github.com/pomerium/ingress-controller/issues/1410

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
