### PR TITLE
Makefile: rerun npm ci when node_modules is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,13 +119,14 @@ internal/ui:
 	@cp -rf $(UI_DIR) ./internal
 	@chmod u+w internal/ui internal/ui/dist
 
-internal/ui/package.json: internal/ui
+internal/ui/node_modules: internal/ui
 	@echo "==> $@"
 	@cd internal/ui && npm ci
+	@touch internal/ui/node_modules
 
 .PHONY: pomerium-ui
 pomerium-ui: internal/ui/dist/index.js
-internal/ui/dist/index.js: internal/ui/package.json
+internal/ui/dist/index.js: internal/ui/node_modules
 	@echo "==> $@"
 	@cd internal/ui && npm run build
 


### PR DESCRIPTION
## Summary
`make build` failed on clean checkout with `sh: ts-node: command not found` when `internal/ui/node_modules` was missing, because the UI build target was keyed off `internal/ui/package.json` (whose recipe is actually `npm ci`). Once `package.json` existed, make considered the target up-to-date and skipped `npm ci`, even though `node_modules` did not exist. 