### PR TITLE
clustered-databroker: production-hardening defaults

### DIFF
--- a/config/clustered-databroker/kustomization.yaml
+++ b/config/clustered-databroker/kustomization.yaml
@@ -2,6 +2,7 @@ namespace: pomerium
 resources:
   - ../default
   - ./service
+  - ./pdb.yaml
 patches:
   - patch: |-
       - op: replace
@@ -81,6 +82,24 @@ patches:
               resources:
                 requests:
                   storage: 1Gi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 500m
+      - op: add
+        path: /spec/template/spec/securityContext/fsGroup
+        value: 65532
+      - op: add
+        path: /spec/template/spec/securityContext/fsGroupChangePolicy
+        value: OnRootMismatch
+      - op: add
+        path: /spec/template/spec/affinity
+        value:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: pomerium
     target:
       group: apps
       version: v1

--- a/config/clustered-databroker/pdb.yaml
+++ b/config/clustered-databroker/pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pomerium
+  labels:
+    app.kubernetes.io/name: pomerium
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pomerium


### PR DESCRIPTION
## Summary
Production-hardening defaults for the `config/clustered-databroker` overlay:

- `fsGroup: 65532` and `fsGroupChangePolicy: OnRootMismatch` so the non-root pomerium container can write to the databroker PVC on first provisioning.
- Pod anti-affinity by `kubernetes.io/hostname` so RAFT members spread across nodes.
- `PodDisruptionBudget` with `minAvailable: 2` to preserve RAFT quorum through voluntary disruptions.
- CPU request `500m` (up from 300m), needed for anti-affinity to schedule on environments that gate scheduling on requests.