### PR TITLE
crd: identityProvider <-> authenticate constraints

### DIFF
--- a/apis/ingress/v1/pomerium_types.go
+++ b/apis/ingress/v1/pomerium_types.go
@@ -221,6 +221,8 @@ type DownstreamMTLS struct {
 }
 
 // PomeriumSpec defines Pomerium-specific configuration parameters.
+// +kubebuilder:validation:XValidation:rule="!has(self.identityProvider) || has(self.authenticate)",message="authenticate is required if identityProvider is set",reason="FieldValueRequired",fieldPath=".authenticate"
+// +kubebuilder:validation:XValidation:rule="!has(self.authenticate) || has(self.identityProvider)",message="identityProvider is required if authenticate is set",reason="FieldValueRequired",fieldPath=".identityProvider"
 type PomeriumSpec struct {
 	// AccessLogFields sets the <a href="https://www.pomerium.com/docs/reference/access-log-fields">access fields</a> to log.
 	AccessLogFields *[]string `json:"accessLogFields,omitempty"`

--- a/config/crd/bases/ingress.pomerium.io_pomerium.yaml
+++ b/config/crd/bases/ingress.pomerium.io_pomerium.yaml
@@ -613,6 +613,15 @@ spec:
             required:
             - secrets
             type: object
+            x-kubernetes-validations:
+            - fieldPath: .authenticate
+              message: authenticate is required if identityProvider is set
+              reason: FieldValueRequired
+              rule: '!has(self.identityProvider) || has(self.authenticate)'
+            - fieldPath: .identityProvider
+              message: identityProvider is required if authenticate is set
+              reason: FieldValueRequired
+              rule: '!has(self.authenticate) || has(self.identityProvider)'
           status:
             description: PomeriumStatus represents configuration and Ingress status.
             properties:

--- a/controllers/settings/integration_test.go
+++ b/controllers/settings/integration_test.go
@@ -120,31 +120,34 @@ func (s *ControllerTestSuite) TestValidation() {
 	for i, tc := range []struct {
 		name        string
 		spec        icsv1.PomeriumSpec
-		expectError bool
+		expectError string
 	}{
-		{"empty spec", icsv1.PomeriumSpec{}, true},
+		{"empty spec", icsv1.PomeriumSpec{}, "spec.secrets in body should be at least 1 chars long"},
 		{"ok spec", icsv1.PomeriumSpec{
 			Authenticate:     auth,
 			IdentityProvider: idp,
 			Secrets:          "pomerium/default-secrets",
-		}, false},
+		}, ""},
 		{"secrets required", icsv1.PomeriumSpec{
 			Authenticate:     auth,
 			IdentityProvider: idp,
-		}, true},
+		}, "spec.secrets in body should be at least 1 chars long"},
 		{"invalid auth url", icsv1.PomeriumSpec{
 			Authenticate:     &icsv1.Authenticate{URL: "hostname"},
 			IdentityProvider: idp,
 			Secrets:          "pomerium/default-secrets",
-		}, true},
-		{"auth may be omitted", icsv1.PomeriumSpec{
+		}, "spec.authenticate.url in body must be of type uri"},
+		{"auth and idp may be omitted", icsv1.PomeriumSpec{
+			Secrets: "pomerium/default-secrets",
+		}, ""},
+		{"auth required if idp present", icsv1.PomeriumSpec{
 			IdentityProvider: idp,
 			Secrets:          "pomerium/default-secrets",
-		}, false},
-		{"idp may be optional", icsv1.PomeriumSpec{
+		}, "authenticate is required if identityProvider is set"},
+		{"idp required if auth present", icsv1.PomeriumSpec{
 			Authenticate: auth,
 			Secrets:      "pomerium/default-secrets",
-		}, false},
+		}, "identityProvider is required if authenticate is set"},
 		{"idp secret required", icsv1.PomeriumSpec{
 			Authenticate: auth,
 			Secrets:      "pomerium/default-secrets",
@@ -152,7 +155,7 @@ func (s *ControllerTestSuite) TestValidation() {
 				Secret:   "",
 				Provider: "oidc",
 			},
-		}, true},
+		}, "spec.identityProvider.secret in body should be at least 1 chars long"},
 		{"idp provider required", icsv1.PomeriumSpec{
 			Authenticate: auth,
 			IdentityProvider: &icsv1.IdentityProvider{
@@ -160,7 +163,7 @@ func (s *ControllerTestSuite) TestValidation() {
 				Provider: "",
 			},
 			Secrets: "pomerium/default-secrets",
-		}, true},
+		}, `spec.identityProvider.provider: Unsupported value: ""`},
 		{"idp provider enum", icsv1.PomeriumSpec{
 			Authenticate: auth,
 			IdentityProvider: &icsv1.IdentityProvider{
@@ -168,15 +171,15 @@ func (s *ControllerTestSuite) TestValidation() {
 				Provider: "invalid",
 			},
 			Secrets: "pomerium/default-secrets",
-		}, true},
+		}, `spec.identityProvider.provider: Unsupported value: "invalid"`},
 	} {
 		s.T().Run(tc.name, func(t *testing.T) {
 			err := s.Client.Create(ctx, &icsv1.Pomerium{
 				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("settings-%d", i), Namespace: "default"},
 				Spec:       tc.spec,
 			})
-			if tc.expectError {
-				assert.Error(t, err)
+			if tc.expectError != "" {
+				assert.ErrorContains(t, err, tc.expectError)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -755,6 +755,15 @@ spec:
             required:
             - secrets
             type: object
+            x-kubernetes-validations:
+            - fieldPath: .authenticate
+              message: authenticate is required if identityProvider is set
+              reason: FieldValueRequired
+              rule: '!has(self.identityProvider) || has(self.authenticate)'
+            - fieldPath: .identityProvider
+              message: identityProvider is required if authenticate is set
+              reason: FieldValueRequired
+              rule: '!has(self.authenticate) || has(self.identityProvider)'
           status:
             description: PomeriumStatus represents configuration and Ingress status.
             properties:


### PR DESCRIPTION
## Summary

Add two CEL constraints on the Pomerium CRD to enforce that if the `identityProvider` field is set, the `authenticate` field must be set as well (and vice versa).

Logically, this could be expressed as the single constraint `has(self.identityProvider) == has(self.authenticate)`, but if we split it into two we can customize the error message depending on the case.

Update the existing integration test to verify specific validation error message text.

## Related issues

https://linear.app/pomerium/issue/ENG-4061/ingress-controller-providerhosted-accepted-but-produces-unusable

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
