### PR TITLE
ingress-controller: delay starting the certificate controller until all required CRDs exist

### DIFF
--- a/controllers/certificate/controller.go
+++ b/controllers/certificate/controller.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"time"
 
 	certmanager_v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanager_meta_v1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -20,6 +21,7 @@ import (
 	core_v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/rand"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,25 +54,14 @@ func NewCertificateController(
 	mgr controllerruntime.Manager,
 	dataBrokerClient databrokerpb.DataBrokerServiceClient,
 	options ...Option,
-) error {
+) {
 	c := &certificateController{
 		cfg:              getControllerConfig(options...),
 		kubernetesClient: mgr.GetClient(),
 		dataBrokerClient: dataBrokerClient,
 	}
 	c.dataBrokerCollector = newDataBrokerCollector(c)
-
-	err := controllerruntime.NewControllerManagedBy(mgr).
-		Named(c.cfg.controllerName).
-		Watches(new(core_v1.Secret), &handler.EnqueueRequestForObject{}).
-		Watches(new(pomerium_ingress_v1.Pomerium), &handler.EnqueueRequestForObject{}).
-		Watches(new(certmanager_v1.Certificate), &handler.EnqueueRequestForObject{}).
-		Complete(c)
-	if err != nil {
-		return fmt.Errorf("error building certificate controller: %w", err)
-	}
-
-	return nil
+	go c.run(mgr)
 }
 
 func (c *certificateController) Reconcile(ctx context.Context, _ controllerruntime.Request) (res controllerruntime.Result, err error) {
@@ -224,6 +215,43 @@ func (c *certificateController) reconcileSecrets(
 	}
 
 	return c.upsertConfig(ctx, cfg)
+}
+
+func (c *certificateController) run(mgr controllerruntime.Manager) {
+	ctx := context.Background()
+
+	// wait for all the CRDs to be available
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for _, gvk := range []schema.GroupVersionKind{
+		schema.FromAPIVersionAndKind("cert-manager.io/v1", "Certificate"),
+		schema.FromAPIVersionAndKind("ingress.pomerium.io/v1", "Pomerium"),
+	} {
+		for i := 0; ; i++ {
+			_, err := mgr.GetCache().GetInformerForKind(ctx, gvk)
+			if err == nil {
+				break
+			}
+			if i == 0 {
+				log.FromContext(ctx).
+					Info("certificate-controller: required CRD does not exist, the certificate controller will not run until it is created",
+						"controller", c.cfg.controllerName,
+						"group-version-kind", gvk.String())
+			}
+			<-ticker.C
+		}
+	}
+
+	err := controllerruntime.NewControllerManagedBy(mgr).
+		Named(c.cfg.controllerName).
+		Watches(new(core_v1.Secret), &handler.EnqueueRequestForObject{}).
+		Watches(new(pomerium_ingress_v1.Pomerium), &handler.EnqueueRequestForObject{}).
+		Watches(new(certmanager_v1.Certificate), &handler.EnqueueRequestForObject{}).
+		Complete(c)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "error building certificate controller")
+	}
 }
 
 func (c *certificateController) createCertificate(

--- a/controllers/certificate/integration_test.go
+++ b/controllers/certificate/integration_test.go
@@ -128,12 +128,12 @@ func (s *ControllerTestSuite) startController(ctx context.Context, client databr
 		},
 	})
 	s.NoError(err)
-	s.NoError(certificate.NewCertificateController(
+	certificate.NewCertificateController(
 		mgr,
 		client,
 		certificate.WithGlobalSettingsName(types.NamespacedName{Name: testGlobalSettingsName}),
 		certificate.WithNamespace(testNamespace),
-	))
+	)
 
 	go func() {
 		if err := mgr.Start(ctx); err != nil && ctx.Err() == nil {

--- a/controllers/config_controller.go
+++ b/controllers/config_controller.go
@@ -93,11 +93,9 @@ func (c *Controller) RunLeased(ctx context.Context) (err error) {
 		if err = settings.NewSettingsController(mgr, c.Reconciler, *c.GlobalSettings, "pomerium-crd", true, health_ctrl.SettingsReconciler); err != nil {
 			return fmt.Errorf("create settings controller: %w", err)
 		}
-		if err = certificate.NewCertificateController(mgr, c.DataBrokerServiceClient,
+		certificate.NewCertificateController(mgr, c.DataBrokerServiceClient,
 			certificate.WithControllerName(c.CertificateControllerName),
-			certificate.WithGlobalSettingsName(*c.GlobalSettings)); err != nil {
-			return fmt.Errorf("error creating certificate controller: %w", err)
-		}
+			certificate.WithGlobalSettingsName(*c.GlobalSettings))
 	} else {
 		log.FromContext(ctx).V(1).Info("no Pomerium CRD")
 	}


### PR DESCRIPTION
## Summary
Delay starting the certificate controller until all the required CRDs exist. 

Currently if the cert-manager CRDs don't exist, an error will be logged every 10 seconds:

```json
{
  "level":"error",
  "ts":"2026-05-26T15:08:46Z",
  "logger":"controller-runtime.source.Kind",
  "msg":"if kind is a CRD, it should be installed before calling Start",
  "kind":"Certificate.cert-manager.io",
  "error":"no matches for kind \"Certificate\" in version \"cert-manager.io/v1\""
}
```

It would actually recover from this automatically, but the log message was noisy and potentially confusing, so this PR makes it a little more clear what the issue is and only logs the first time.

## Related issues
- [ENG-4065](https://linear.app/pomerium/issue/ENG-4065/ingress-controller-certificate-controller-should-handling-missing-cert)


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
