### PR TITLE
update sdk-go along with pomerium core

### DIFF
--- a/scripts/update-dependencies
+++ b/scripts/update-dependencies
@@ -18,6 +18,7 @@ update-pomerium() {
 	require-command go
 
 	go get -u github.com/pomerium/pomerium@main
+	go get -u github.com/pomerium/sdk-go@main
 	go mod tidy
 
 	popd


### PR DESCRIPTION
## Summary

We currently have two copies of the core config protos in the dependency tree: one from pomerium/pomerium, and one from pomerium/sdk-go (for the unified API / connect-rpc support). If these two get out of sync, settings may not serialize correctly. For now, let's mitigate this issue by syncing both of these modules in the update-dependencies script.

## Related issues

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
