### PR TITLE
Update config initialization to use config.New

### DIFF
--- a/cmd/all_in_one.go
+++ b/cmd/all_in_one.go
@@ -243,7 +243,7 @@ func (s *allCmdParam) run(ctx context.Context) error {
 }
 
 func (s *allCmdParam) makeBootstrapConfig(opt allCmdOptions) error {
-	s.cfg.Options = config.NewDefaultOptions()
+	s.cfg = *config.New(config.NewDefaultOptions())
 
 	s.cfg.Options.Services = strings.Join(opt.services, ",")
 	s.cfg.Options.Addr = opt.serverAddr


### PR DESCRIPTION
## Summary

Initialize the config using `config.New`, which contains setup logic for some fields that do not have a valid zero value.

See also: https://github.com/pomerium/pomerium/pull/6353.

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
