### PR TITLE
sync: query filter should use snake_case

### DIFF
--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -676,8 +676,8 @@ func (r *APIReconciler) findRouteByName(
 	ctx context.Context, name string,
 ) (existing *configpb.Route, err error) {
 	filter, err := structpb.NewStruct(map[string]any{
-		"originatorId": originatorID,
-		"name":         name,
+		"originator_id": originatorID,
+		"name":          name,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("internal error - couldn't create ListRoutes filter: %w", err)
@@ -813,8 +813,8 @@ func (r *APIReconciler) findPolicyByName(
 	ctx context.Context, name string,
 ) (existing *configpb.Policy, err error) {
 	filter, err := structpb.NewStruct(map[string]any{
-		"originatorId": originatorID,
-		"name":         name,
+		"originator_id": originatorID,
+		"name":          name,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("internal error - couldn't create ListPolicies filter: %w", err)
@@ -917,8 +917,8 @@ func (r *APIReconciler) findKeyPairByName(
 	ctx context.Context, name string,
 ) (existing *configpb.KeyPair, err error) {
 	filter, err := structpb.NewStruct(map[string]any{
-		"originatorId": originatorID,
-		"name":         name,
+		"originator_id": originatorID,
+		"name":          name,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("internal error - couldn't create ListKeyPairs filter: %w", err)

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -1675,8 +1675,8 @@ func (noopBackendRefChecker) Valid(_ client.Object, _ *gateway_v1.BackendRef) bo
 
 func filterByName(t *testing.T, name string) *structpb.Struct {
 	f, err := structpb.NewStruct(map[string]any{
-		"originatorId": "ingress-controller",
-		"name":         name,
+		"originator_id": "ingress-controller",
+		"name":          name,
 	})
 	require.NoError(t, err)
 	return f


### PR DESCRIPTION
## Summary

Pomerium Enterprise expects the filter key "originator_id" rather than "originatorId", while Pomerium Zero accepts either.

## Related issues

https://linear.app/pomerium/issue/ENG-3855/ingress-controller-apireconciler-needs-idempotent-entity-creation-and

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
