### PR TITLE
sync: fix missing policy annotations

### DIFF
--- a/pomerium/ingress_to_policy.go
+++ b/pomerium/ingress_to_policy.go
@@ -14,6 +14,13 @@ import (
 // keysToPolicy translates Ingress annotations to a Policy proto compatible
 // with the unified API.
 func keysToPolicy(kv *keys, name string) (*configpb.Policy, error) {
+	// Some policy-related annotations are part of the "base" annotations while
+	// most are part of the "policy" annotations. Reassemble the complete policy
+	// by combining both of these.
+	r := new(configpb.Route)
+	if err := unmarshalAnnotations(r, kv.Base); err != nil {
+		return nil, fmt.Errorf("couldn't unmarshal base annotations: %w", err)
+	}
 	p := new(configpb.Policy)
 	if err := unmarshalPolicyAnnotations(p, kv.Policy); err != nil {
 		return nil, fmt.Errorf("couldn't unmarshal policy annotations: %w", err)
@@ -22,9 +29,11 @@ func keysToPolicy(kv *keys, name string) (*configpb.Policy, error) {
 	// Use the same conversion logic from Core to translate the legacy
 	// allowlist fields.
 	configPolicy := config.Policy{
-		AllowedDomains:   p.AllowedDomains,
-		AllowedUsers:     p.AllowedUsers,
-		AllowedIDPClaims: identity.NewFlattenedClaimsFromPB(p.AllowedIdpClaims),
+		AllowAnyAuthenticatedUser:        r.AllowAnyAuthenticatedUser,
+		AllowPublicUnauthenticatedAccess: r.AllowPublicUnauthenticatedAccess,
+		AllowedDomains:                   p.AllowedDomains,
+		AllowedUsers:                     p.AllowedUsers,
+		AllowedIDPClaims:                 identity.NewFlattenedClaimsFromPB(p.AllowedIdpClaims),
 	}
 	// Include any user-defined PPL.
 	if p.SourcePpl != nil {

--- a/pomerium/ingress_to_policy_test.go
+++ b/pomerium/ingress_to_policy_test.go
@@ -78,6 +78,54 @@ func TestKeysToPolicy(t *testing.T) {
 ]`, *p.SourcePpl)
 }
 
+func TestKeysToPolicy_AnyAuthenticatedUser(t *testing.T) {
+	kv, err := removeKeyPrefix(map[string]string{
+		"a/allow_any_authenticated_user": "true",
+	}, "a")
+	require.NoError(t, err)
+
+	p, err := keysToPolicy(kv, "POLICY-NAME")
+	require.NoError(t, err)
+	require.NotNil(t, p.Name)
+	assert.Equal(t, "POLICY-NAME", *p.Name)
+	require.NotNil(t, p.SourcePpl)
+	assert.JSONEq(t, `[
+  {
+    "allow": {
+      "or": [
+        {
+          "authenticated_user": true
+        }
+      ]
+    }
+  }
+]`, *p.SourcePpl)
+}
+
+func TestKeysToPolicy_Public(t *testing.T) {
+	kv, err := removeKeyPrefix(map[string]string{
+		"a/allow_public_unauthenticated_access": "true",
+	}, "a")
+	require.NoError(t, err)
+
+	p, err := keysToPolicy(kv, "POLICY-NAME")
+	require.NoError(t, err)
+	require.NotNil(t, p.Name)
+	assert.Equal(t, "POLICY-NAME", *p.Name)
+	require.NotNil(t, p.SourcePpl)
+	assert.JSONEq(t, `[
+  {
+    "allow": {
+      "or": [
+        {
+          "accept": true
+        }
+      ]
+    }
+  }
+]`, *p.SourcePpl)
+}
+
 func TestKeysToPolicy_Empty(t *testing.T) {
 	// keysToPolicy should return nil when there are no policy-related annotations.
 	kv, err := removeKeyPrefix(map[string]string{


### PR DESCRIPTION
## Summary

The `allow_public_unauthenticated_access` and `allow_any_authenticated_user` annotations are not honored by the current unified API sync logic. These are part of the "Base" annotations rather than the "Policy" annotations, but they should still affect the derived policy. Make sure the conversion logic accounts for these annotations.

## Related issues

https://linear.app/pomerium/issue/ENG-4147/ingress-controller-api-sync-ignores-allow-public-unauthenticated

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
