### PR TITLE
sync: add bootstrap ingress support

### DIFF
--- a/cmd/all_in_one.go
+++ b/cmd/all_in_one.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -13,8 +14,10 @@ import (
 	"github.com/volatiletech/null/v9"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	runtime_ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -23,6 +26,7 @@ import (
 	"github.com/pomerium/ingress-controller/controllers/gateway"
 	"github.com/pomerium/ingress-controller/controllers/ingress"
 	"github.com/pomerium/ingress-controller/controllers/settings"
+	"github.com/pomerium/ingress-controller/model"
 	"github.com/pomerium/ingress-controller/pomerium"
 	pomerium_ctrl "github.com/pomerium/ingress-controller/pomerium/ctrl"
 	"github.com/pomerium/ingress-controller/util"
@@ -52,6 +56,7 @@ type allCmdOptions struct {
 	deriveTLS          string   `validate:"required,hostname"`
 	grpcAddr           string   `validate:"required,hostname_port"`
 	services           []string `validate:"dive,oneof=all authenticate authorize databroker proxy"`
+	syncAPIIngress     string
 
 	CertificateControllerOptions certificateControllerOptions
 	DataBrokerOptions            dataBrokerOptions
@@ -65,6 +70,7 @@ type allCmdParam struct {
 	dumpConfigDiff          bool
 	syncAPIURL              string
 	syncAPIToken            string
+	syncAPIBootstrap        bool
 
 	// bootstrapMetricsAddr for bootstrap configuration controller metrics
 	bootstrapMetricsAddr string
@@ -135,6 +141,7 @@ func (s *allCmd) setupFlags() error {
 	flags.DurationVar(&s.configControllerShutdownTimeout, configControllerShutdown, time.Second*30, "timeout waiting for graceful config controller shutdown")
 	flags.StringVar(&s.grpcAddr, "grpc-addr", ":5443", "the address the gRPC server would bind to")
 	flags.StringSliceVar(&s.services, "services", []string{"all"}, "the pomerium services to run")
+	flags.StringVar(&s.syncAPIIngress, syncAPIIngress, "", "unified API sync ingress")
 
 	for _, flag := range hidden {
 		if err := s.PersistentFlags().MarkHidden(flag); err != nil {
@@ -160,7 +167,7 @@ func (s *allCmd) exec(*cobra.Command, []string) error {
 	setupLogger(s.debug)
 	ctx := runtime_ctrl.SetupSignalHandler()
 
-	param, err := s.getParam()
+	param, err := s.getParam(ctx)
 	if err != nil {
 		return err
 	}
@@ -168,7 +175,7 @@ func (s *allCmd) exec(*cobra.Command, []string) error {
 	return param.run(ctx)
 }
 
-func (s *allCmdOptions) getParam() (*allCmdParam, error) {
+func (s *allCmdOptions) getParam(ctx context.Context) (*allCmdParam, error) {
 	settings, err := util.ParseNamespacedName(s.GlobalSettings, util.WithClusterScope())
 	if err != nil {
 		return nil, fmt.Errorf("--%s: %w", globalSettings, err)
@@ -197,9 +204,10 @@ func (s *allCmdOptions) getParam() (*allCmdParam, error) {
 		configControllerShutdownTimeout: s.configControllerShutdownTimeout,
 		syncAPIURL:                      s.SyncAPIURL,
 		syncAPIToken:                    s.SyncAPIToken,
+		syncAPIBootstrap:                s.syncAPIIngress != "",
 		certificateControllerName:       s.CertificateControllerOptions.Name,
 	}
-	if err := p.makeBootstrapConfig(*s); err != nil {
+	if err := p.makeBootstrapConfig(ctx, *s); err != nil {
 		return nil, fmt.Errorf("bootstrap: %w", err)
 	}
 
@@ -218,7 +226,7 @@ func (s *allCmdParam) run(ctx context.Context) error {
 
 	eg, ctx := errgroup.WithContext(ctx)
 	cfgCtl := util.NewRestartOnChange[*config.Config]()
-	runner, err := pomerium_ctrl.NewPomeriumRunner(s.cfg, cfgCtl.OnConfigUpdated)
+	runner, err := pomerium_ctrl.NewPomeriumRunner(s.cfg, cfgCtl.OnConfigUpdated, s.syncAPIBootstrap)
 	if err != nil {
 		return fmt.Errorf("preparing to run pomerium: %w", err)
 	}
@@ -242,7 +250,7 @@ func (s *allCmdParam) run(ctx context.Context) error {
 	return eg.Wait()
 }
 
-func (s *allCmdParam) makeBootstrapConfig(opt allCmdOptions) error {
+func (s *allCmdParam) makeBootstrapConfig(ctx context.Context, opt allCmdOptions) error {
 	s.cfg = *config.New(config.NewDefaultOptions())
 
 	s.cfg.Options.Services = strings.Join(opt.services, ",")
@@ -312,6 +320,61 @@ func (s *allCmdParam) makeBootstrapConfig(opt allCmdOptions) error {
 
 	opt.DataBrokerOptions.apply(&s.cfg)
 
+	if err := s.applyBootstrapIngress(ctx, opt.syncAPIIngress, opt.AnnotationPrefix); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *allCmdParam) applyBootstrapIngress(
+	ctx context.Context, name string, annotationPrefix string,
+) (err error) {
+	if name == "" {
+		// No bootstrap ingress.
+		return nil
+	}
+
+	// Fetch the bootstrap ingress as a one-off.
+	ns, n, ok := strings.Cut(name, "/")
+	if !ok {
+		return fmt.Errorf("expected ingress name in namespace/name formt")
+	}
+	nn := types.NamespacedName{Namespace: ns, Name: n}
+	scheme, err := getScheme()
+	if err != nil {
+		return fmt.Errorf("get scheme for bootstrap ingress: %w", err)
+	}
+	restCfg, err := runtime_ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("get k8s config for bootstrap ingress: %w", err)
+	}
+	k8sClient, err := client.New(restCfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("create k8s client for bootstrap ingress: %w", err)
+	}
+	var bootstrapIngress networkingv1.Ingress
+	if err := k8sClient.Get(ctx, nn, &bootstrapIngress); err != nil {
+		return fmt.Errorf("get bootstrap ingress: %w", err)
+	}
+	ic, err := ingress.FetchIngress(ctx, k8sClient, &bootstrapIngress, annotationPrefix)
+	if err != nil {
+		return fmt.Errorf("fetch bootstrap ingress data: %w", err)
+	}
+
+	// Force the route 'From' URL to use the service proxy URL (so we don't need
+	// to watch for changes to the service endpoints).
+	ic.Ingress = ic.Ingress.DeepCopy()
+	ic.Ingress.Annotations[annotationPrefix+"/"+model.UseServiceProxy] = "true"
+
+	routes, err := pomerium.IngressToRoutes(ctx, ic)
+	if err != nil {
+		return fmt.Errorf("convert bootstrap ingress to routes: %w", err)
+	}
+	s.cfg.Options.Policies = append(s.cfg.Options.Policies, routes...)
+
+	s.syncAPIURL = routes[0].From
+
 	return nil
 }
 
@@ -339,7 +402,18 @@ func (s *allCmdParam) buildController(ctx context.Context, cfg *config.Config) (
 	client := databroker.NewDataBrokerServiceClient(conn)
 	var reconciler pomerium.Reconciler
 	if s.syncAPIURL != "" {
-		reconciler = pomerium.NewAPIReconciler(s.syncAPIURL, s.syncAPIToken, s.cfg.Options)
+		var dialAddressOverride string
+		if s.syncAPIBootstrap {
+			_, port, err := net.SplitHostPort(s.cfg.Options.Addr)
+			if err != nil {
+				return nil, fmt.Errorf("couldn't get server address port: %w", err)
+			}
+			dialAddressOverride = net.JoinHostPort("localhost", port)
+		}
+		reconciler, err = pomerium.NewAPIReconciler(s.syncAPIURL, s.syncAPIToken, s.cfg.Options, dialAddressOverride)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		reconciler = pomerium.NewDataBrokerReconciler(client, s.dumpConfigDiff)
 	}
@@ -389,7 +463,6 @@ func (s *allCmdParam) runBootstrapConfigController(ctx context.Context, reconcil
 	if host, err := os.Hostname(); err == nil {
 		name = fmt.Sprintf("%s pod/%s", name, host)
 	}
-	// TODO: do we need to disable the bootstrap config controller when syncing via the API?
 	if err := settings.NewSettingsController(mgr, reconciler, s.settings, name, false, health_ctrl.SettingsBootstrapReconciler); err != nil {
 		return fmt.Errorf("settings controller: %w", err)
 	}

--- a/cmd/all_in_one.go
+++ b/cmd/all_in_one.go
@@ -338,7 +338,7 @@ func (s *allCmdParam) applyBootstrapIngress(
 	// Fetch the bootstrap ingress as a one-off.
 	ns, n, ok := strings.Cut(name, "/")
 	if !ok {
-		return fmt.Errorf("expected ingress name in namespace/name formt")
+		return fmt.Errorf("expected ingress name in namespace/name format, got %q", name)
 	}
 	nn := types.NamespacedName{Namespace: ns, Name: n}
 	scheme, err := getScheme()
@@ -362,14 +362,16 @@ func (s *allCmdParam) applyBootstrapIngress(
 		return fmt.Errorf("fetch bootstrap ingress data: %w", err)
 	}
 
-	// Force the route 'From' URL to use the service proxy URL (so we don't need
+	// Force the route 'To' URL to use the service proxy URL (so we don't need
 	// to watch for changes to the service endpoints).
 	ic.Ingress = ic.Ingress.DeepCopy()
-	ic.Ingress.Annotations[annotationPrefix+"/"+model.UseServiceProxy] = "true"
+	util.SetAnnotation(ic.Ingress, annotationPrefix+"/"+model.UseServiceProxy, "true")
 
 	routes, err := pomerium.IngressToRoutes(ctx, ic)
 	if err != nil {
 		return fmt.Errorf("convert bootstrap ingress to routes: %w", err)
+	} else if len(routes) == 0 {
+		return fmt.Errorf("bootstrap ingress %q has no rules", name)
 	}
 	s.cfg.Options.Policies = append(s.cfg.Options.Policies, routes...)
 

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -168,8 +168,11 @@ func (s *controllerCmd) buildController(ctx context.Context) (*controllers.Contr
 	}
 
 	if s.SyncAPIURL != "" {
-		c.Reconciler = pomerium.NewAPIReconciler(
-			s.SyncAPIURL, s.SyncAPIToken, pomerium_config.NewDefaultOptions())
+		c.Reconciler, err = pomerium.NewAPIReconciler(
+			s.SyncAPIURL, s.SyncAPIToken, pomerium_config.NewDefaultOptions(), "")
+		if err != nil {
+			return nil, err
+		}
 		c.MgrOpts.LeaderElection = true
 		c.MgrOpts.LeaderElectionID = s.leaderElectionID
 		c.MgrOpts.LeaderElectionNamespace = s.leaderElectionNamespace

--- a/cmd/ingress_opts.go
+++ b/cmd/ingress_opts.go
@@ -7,8 +7,6 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/pomerium/sdk-go"
-
 	icsv1 "github.com/pomerium/ingress-controller/apis/ingress/v1"
 	"github.com/pomerium/ingress-controller/controllers/gateway"
 	"github.com/pomerium/ingress-controller/controllers/ingress"
@@ -23,7 +21,6 @@ type ingressControllerOpts struct {
 	Namespaces              []string
 	UpdateStatusFromService string ``
 	GlobalSettings          string `validate:"required"`
-	SyncAPIOptions          []sdk.ClientOption
 	SyncAPIURL              string
 	SyncAPIToken            string
 }
@@ -37,6 +34,7 @@ const (
 	sharedSecret               = "shared-secret"
 	updateStatusFromService    = "update-status-from-service"
 	globalSettings             = "pomerium-config"
+	syncAPIIngress             = "sync-api-ingress"
 	syncAPIURL                 = "sync-api-url"
 	syncAPIToken               = "sync-api-token" //nolint:gosec
 )

--- a/controllers/ingress/fetch.go
+++ b/controllers/ingress/fetch.go
@@ -28,10 +28,11 @@ func (r *ingressController) fetchIngress(ctx context.Context, ingress *networkin
 		_ = client.Get(ctx, *r.updateStatusFromService, new(corev1.Service))
 	}
 
-	return fetchIngress(ctx, client, ingress, r.annotationPrefix)
+	return FetchIngress(ctx, client, ingress, r.annotationPrefix)
 }
 
-func fetchIngress(
+// FetchIngress populates a model.IngressConfig for ingress.
+func FetchIngress(
 	ctx context.Context,
 	client client.Client,
 	ingress *networkingv1.Ingress,

--- a/pomerium/ctrl/bootstrap.go
+++ b/pomerium/ctrl/bootstrap.go
@@ -15,9 +15,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/pomerium/pomerium/config"
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+
 	"github.com/pomerium/ingress-controller/internal/filemgr"
 	"github.com/pomerium/ingress-controller/model"
-	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/ingress-controller/pomerium"
 )
 
 // Apply prepares a minimal bootstrap configuration for Pomerium
@@ -209,5 +212,16 @@ func applySecrets(_ context.Context, dst *config.Options, src *model.Config) err
 		*secret.sp = txt
 	}
 
+	return nil
+}
+
+// ApplyAdditional propagates additional core bootstrap settings, needed when
+// running all-in-one mode together with Enterprise API sync.
+func ApplyAdditional(ctx context.Context, dst *config.Options, src *model.Config) error {
+	var pbConfig configpb.Config
+	if err := pomerium.ApplyConfig(ctx, &pbConfig, src); err != nil {
+		return err
+	}
+	dst.ApplySettings(ctx, nil, pbConfig.Settings)
 	return nil
 }

--- a/pomerium/ctrl/bootstrap_test.go
+++ b/pomerium/ctrl/bootstrap_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 
+	icsv1 "github.com/pomerium/ingress-controller/apis/ingress/v1"
 	"github.com/pomerium/ingress-controller/model"
 	"github.com/pomerium/ingress-controller/util"
 )
@@ -66,4 +67,63 @@ func TestSecretsDecodeRules(t *testing.T) {
 			},
 		},
 	}))
+}
+
+const exampleCert = `-----BEGIN CERTIFICATE-----
+MIIBXzCCAQagAwIBAgICEAAwCgYIKoZIzj0EAwIwFzEVMBMGA1UEAxMMVGVzdCBS
+b290IENBMB4XDTI1MDkxMjE1NTk1M1oXDTM1MDkxMDE1NTk1M1owFzEVMBMGA1UE
+AxMMVGVzdCBSb290IENBMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnomv0HAN
+5+BEp3H5LZPl7WE3KWa6VPAxBpCf8BXYpyaJH2PG7VJ1Ateu/I2Y/+AH4f8m6DHV
+iHhi3ll2Qu1oLqNCMEAwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8w
+HQYDVR0OBBYEFEibW9kXYo7F3BR++6c8lMlU5GAYMAoGCCqGSM49BAMCA0cAMEQC
+IDopBqx9I9AxBtHFzAESP7uoReoRdwwoqdUDY+I+/kW0AiAY1wV3V3A4fSdjV6x9
+fk5EbQ+E27ez9yyDZ6XtQKlJLQ==
+-----END CERTIFICATE-----`
+
+func TestApplyAdditional(t *testing.T) {
+	// ApplyAdditional propagates additional core bootstrap settings from the
+	// Pomerium CRD spec to the config.Options struct.
+	idpURL := "https://idp.example.com"
+	cfg := &model.Config{
+		Pomerium: icsv1.Pomerium{
+			Spec: icsv1.PomeriumSpec{
+				Authenticate: &icsv1.Authenticate{
+					URL: "https://authenticate.example.com",
+				},
+				IdentityProvider: &icsv1.IdentityProvider{
+					Provider: "oidc",
+					URL:      &idpURL,
+					Secret:   "test/idp-client-secret",
+				},
+			},
+		},
+		IdpSecret: &v1.Secret{
+			Data: map[string][]byte{
+				"client_id":     []byte("test-client-id"),
+				"client_secret": []byte("test-client-secret"),
+			},
+		},
+		Certs: map[types.NamespacedName]*v1.Secret{
+			{Namespace: "test", Name: "my-cert"}: {
+				Type: v1.SecretTypeTLS,
+				Data: map[string][]byte{
+					"tls.crt": []byte(exampleCert),
+					"tls.key": []byte("not-a-real-key"),
+				},
+			},
+		},
+	}
+
+	var opts config.Options
+	err := ApplyAdditional(t.Context(), &opts, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "https://authenticate.example.com", opts.AuthenticateURLString)
+	assert.Equal(t, "oidc", opts.Provider)
+	assert.Equal(t, "https://idp.example.com", opts.ProviderURL)
+	assert.Equal(t, "test-client-id", opts.ClientID)
+	assert.Equal(t, "test-client-secret", opts.ClientSecret)
+	if assert.Len(t, opts.CertificateData, 1) {
+		assert.Equal(t, []byte(exampleCert), opts.CertificateData[0].CertBytes)
+		assert.Equal(t, []byte("not-a-real-key"), opts.CertificateData[0].KeyBytes)
+	}
 }

--- a/pomerium/ctrl/config.go
+++ b/pomerium/ctrl/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/pomerium/pomerium/config"
 )
@@ -23,7 +24,9 @@ var (
 
 var (
 	cmpOpts = []cmp.Option{
+		protocmp.Transform(),
 		cmpopts.IgnoreUnexported(config.Options{}),
+		cmpopts.IgnoreUnexported(config.Policy{}),
 		cmpopts.EquateEmpty(),
 	}
 )

--- a/pomerium/ctrl/run.go
+++ b/pomerium/ctrl/run.go
@@ -18,8 +18,9 @@ var _ = pomerium.ConfigReconciler(new(Runner))
 
 // Runner implements pomerium control loop
 type Runner struct {
-	src  *InMemoryConfigSource
-	base config.Config
+	src              *InMemoryConfigSource
+	base             config.Config
+	syncAPIBootstrap bool
 	sync.Once
 	ready chan struct{}
 }
@@ -50,6 +51,11 @@ func (r *Runner) SetConfig(ctx context.Context, src *model.Config) (changes bool
 	if err := Apply(ctx, dst.Options, src); err != nil {
 		return false, fmt.Errorf("transform config: %w", err)
 	}
+	if r.syncAPIBootstrap {
+		if err := ApplyAdditional(ctx, dst.Options, src); err != nil {
+			return false, fmt.Errorf("apply additional config: %w", err)
+		}
+	}
 
 	changed := r.src.SetConfig(ctx, dst)
 	r.Once.Do(r.readyToRun)
@@ -58,13 +64,14 @@ func (r *Runner) SetConfig(ctx context.Context, src *model.Config) (changes bool
 }
 
 // NewPomeriumRunner creates new pomerium command and control
-func NewPomeriumRunner(base config.Config, listener config.ChangeListener) (*Runner, error) {
+func NewPomeriumRunner(base config.Config, listener config.ChangeListener, syncAPIBootstrap bool) (*Runner, error) {
 	return &Runner{
 		base: base,
 		src: &InMemoryConfigSource{
 			listeners: []config.ChangeListener{listener},
 		},
-		ready: make(chan struct{}),
+		syncAPIBootstrap: syncAPIBootstrap,
+		ready:            make(chan struct{}),
 	}, nil
 }
 

--- a/pomerium/ingress_to_route.go
+++ b/pomerium/ingress_to_route.go
@@ -15,10 +15,29 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/pomerium/pomerium/config"
 	pb "github.com/pomerium/pomerium/pkg/grpc/config"
 
 	"github.com/pomerium/ingress-controller/model"
 )
+
+// IngressToRoutes converts Ingress objects into Pomerium routes (the config
+// struct type, not the protobuf type).
+func IngressToRoutes(ctx context.Context, ic *model.IngressConfig) ([]config.Policy, error) {
+	pbRoutes, err := ingressToRoutes(ctx, ic)
+	if err != nil {
+		return nil, err
+	}
+	routes := make([]config.Policy, len(pbRoutes))
+	for i := range pbRoutes {
+		r, err := config.NewPolicyFromProto(pbRoutes[i])
+		if err != nil {
+			return nil, err
+		}
+		routes[i] = *r
+	}
+	return routes, nil
+}
 
 // ingressToRoutes converts Ingress object into Pomerium Route
 func ingressToRoutes(ctx context.Context, ic *model.IngressConfig) (routeList, error) {

--- a/pomerium/routes_test.go
+++ b/pomerium/routes_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"net/url"
 	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/volatiletech/null/v9"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -19,7 +21,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/pomerium/pomerium/config"
 	pb "github.com/pomerium/pomerium/pkg/grpc/config"
+	"github.com/pomerium/pomerium/pkg/identity"
 
 	_ "github.com/pomerium/ingress-controller/internal"
 	"github.com/pomerium/ingress-controller/model"
@@ -80,6 +84,59 @@ func TestHttp01Solver(t *testing.T) {
 	require.Len(t, routes, 1)
 	require.True(t, routes[0].AllowPublicUnauthenticatedAccess)
 	require.True(t, routes[0].PreserveHostHeader)
+}
+
+func TestIngressToRoutes(t *testing.T) {
+	typePrefix := networkingv1.PathTypePrefix
+	ic := &model.IngressConfig{
+		Ingress: &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-ingress", Namespace: "test"},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{{
+					Host: "a.localhost.pomerium.io",
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{{
+								Path:     "/",
+								PathType: &typePrefix,
+								Backend: networkingv1.IngressBackend{
+									Service: &networkingv1.IngressServiceBackend{
+										Name: "example-svc",
+										Port: networkingv1.ServiceBackendPort{Number: 8080},
+									},
+								},
+							}},
+						},
+					},
+				}},
+			},
+		},
+		Services: map[types.NamespacedName]*corev1.Service{
+			{Name: "example-svc", Namespace: "test"}: {},
+		},
+	}
+
+	routes, err := IngressToRoutes(context.Background(), ic)
+	require.NoError(t, err)
+	assert.Equal(t, []config.Policy{{
+		ID:   `{"n":"my-ingress","ns":"test","h":"a.localhost.pomerium.io","p":"/"}`,
+		Name: "test-my-ingress-a-localhost-pomerium-io",
+		From: "https://a.localhost.pomerium.io",
+		To: config.WeightedURLs{{
+			URL: url.URL{
+				Scheme: "http",
+				Host:   "example-svc.test.svc.cluster.local:8080",
+			},
+			LbWeight: 0,
+		}},
+		Prefix:           "/",
+		StatName:         null.StringFrom("test-my-ingress-a-localhost-pomerium-io"),
+		AllowedIDPClaims: identity.FlattenedClaims{},
+		SubPolicies: []config.SubPolicy{{
+			AllowedIDPClaims: identity.FlattenedClaims{},
+		}},
+		HealthyPanicThreshold: null.NewInt32(0, false),
+	}}, routes)
 }
 
 func TestUpsertIngress(t *testing.T) {

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -260,7 +260,7 @@ func (r *APIReconciler) upsertOneIngress(
 			return changed, err
 		}
 		if ic.Annotations[k] != *route.Id {
-			setAnnotation(ic, k, *route.Id)
+			util.SetAnnotation(ic, k, *route.Id)
 		}
 		changed = changed || changedRoute
 	}
@@ -332,7 +332,7 @@ func (r *APIReconciler) syncOneSecret(
 	if err != nil {
 		return false, err
 	} else if changed {
-		setAnnotation(secret, apiKeyPairIDAnnotation, keyPair.GetId())
+		util.SetAnnotation(secret, apiKeyPairIDAnnotation, keyPair.GetId())
 		controllerutil.AddFinalizer(secret, apiFinalizer)
 		err = r.k8sClient.Patch(ctx, secret, client.MergeFrom(originalSecret))
 	}
@@ -502,7 +502,7 @@ func (r *APIReconciler) SetGatewayConfig(
 				}
 				changes = changes || routeChanged
 				if gr.Annotations[k] != *route.Id {
-					setAnnotation(gr, k, *route.Id)
+					util.SetAnnotation(gr, k, *route.Id)
 				}
 			}
 			controllerutil.AddFinalizer(gr, apiFinalizer)
@@ -570,7 +570,7 @@ func (r *APIReconciler) syncGatewayPolicies(
 			return changes, nil, err
 		} else if changedPolicy {
 			changes = true
-			setAnnotation(obj, apiPolicyIDAnnotation, policy.GetId())
+			util.SetAnnotation(obj, apiPolicyIDAnnotation, policy.GetId())
 			controllerutil.AddFinalizer(obj, apiFinalizer)
 		}
 
@@ -770,7 +770,7 @@ func (r *APIReconciler) syncIngressPolicy(
 		return false, "", fmt.Errorf("couldn't update ingress policy: %w", err)
 	}
 	updatedPolicyID = apiPolicy.GetId()
-	setAnnotation(ingress, apiPolicyIDAnnotation, updatedPolicyID)
+	util.SetAnnotation(ingress, apiPolicyIDAnnotation, updatedPolicyID)
 	return changed, updatedPolicyID, nil
 }
 
@@ -1038,15 +1038,6 @@ func convertProto[Dst, Src proto.Message](msg Src) (Dst, error) {
 	newMsg = newMsg.ProtoReflect().Type().New().Interface().(Dst)
 	err = proto.Unmarshal(b, newMsg)
 	return newMsg, err
-}
-
-func setAnnotation(object client.Object, key, value string) {
-	m := object.GetAnnotations()
-	if m == nil {
-		m = make(map[string]string)
-	}
-	m[key] = value
-	object.SetAnnotations(m)
 }
 
 func falseToNil(x *bool) *bool {

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -661,19 +661,12 @@ func (r *APIReconciler) upsertOneRoute(ctx context.Context, route *configpb.Rout
 		if err == nil {
 			route.Id = resp.Msg.Route.Id
 			return true, nil
-		}
-
-		// If we already created a route, but failed to save the ID annotation,
-		// we may get either an already_exists error (there is a name uniqueness
-		// constraint in Pomerium Zero), or a failed_precondition error (there is
-		// a route 'From' overlap check in Pomerium Enterprise). Any other error
-		// should be returned as is.
-		errCode := connect.CodeOf(err)
-		if errCode != connect.CodeAlreadyExists && errCode != connect.CodeFailedPrecondition {
+		} else if connect.CodeOf(err) != connect.CodeAlreadyExists {
 			return false, err
 		}
 
-		// Attempt to look up the route by name.
+		// If we already created a route, but failed to save the ID annotation,
+		// attempt to look up the route by name.
 		existing, err = r.findRouteByName(ctx, route.GetName())
 		if err != nil {
 			return false, err

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -2,9 +2,13 @@ package pomerium
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"maps"
+	"net"
+	"net/http"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -35,16 +39,36 @@ import (
 // NewAPIReconciler initializes a reconciler that syncs using the unified API,
 // for the given API url and API token.
 func NewAPIReconciler(
-	url, token string, baseOptions *config.Options,
-) Reconciler {
-	client := sdk.NewClient(
-		sdk.WithURL(url),
-		sdk.WithAPIToken(token))
+	apiURL, apiToken string, baseOptions *config.Options, dialAddressOverride string,
+) (Reconciler, error) {
+	opts := []sdk.ClientOption{
+		sdk.WithURL(apiURL),
+		sdk.WithAPIToken(apiToken),
+	}
+
+	if dialAddressOverride != "" {
+		u, err := url.Parse(apiURL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid API URL: %w", err)
+		}
+		dialer := &tls.Dialer{
+			Config: &tls.Config{
+				ServerName: u.Hostname(),
+			},
+		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.DialTLSContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, dialAddressOverride)
+		}
+		opts = append(opts, sdk.WithHTTPClient(&http.Client{
+			Transport: transport,
+		}))
+	}
 	return &APIReconciler{
-		apiClient:   client,
+		apiClient:   sdk.NewClient(opts...),
 		baseOptions: baseOptions,
 		secretsMap:  model.NewTLSSecretsMap(),
-	}
+	}, nil
 }
 
 var (
@@ -637,12 +661,19 @@ func (r *APIReconciler) upsertOneRoute(ctx context.Context, route *configpb.Rout
 		if err == nil {
 			route.Id = resp.Msg.Route.Id
 			return true, nil
-		} else if connect.CodeOf(err) != connect.CodeAlreadyExists {
-			return false, err
 		}
 
 		// If we already created a route, but failed to save the ID annotation,
-		// attempt to look up the route by name.
+		// we may get either an already_exists error (there is a name uniqueness
+		// constraint in Pomerium Zero), or a failed_precondition error (there is
+		// a route 'From' overlap check in Pomerium Enterprise). Any other error
+		// should be returned as is.
+		errCode := connect.CodeOf(err)
+		if errCode != connect.CodeAlreadyExists && errCode != connect.CodeFailedPrecondition {
+			return false, err
+		}
+
+		// Attempt to look up the route by name.
 		existing, err = r.findRouteByName(ctx, route.GetName())
 		if err != nil {
 			return false, err

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -617,6 +617,51 @@ func TestAPIReconciler_upsertOneIngress(t *testing.T) {
 		assert.Equal(t, "missing-route-id", ic.Annotations["api.pomerium.io/route-id-0"])
 	})
 
+	t.Run("failed precondition", func(t *testing.T) {
+		// Pomerium Enterprise returns FailedPrecondition when route 'From' overlaps
+		// with an existing route.
+		ingress := ingressTemplate.DeepCopy()
+		ic := &model.IngressConfig{
+			AnnotationPrefix: "a", Ingress: ingress,
+			Services: map[types.NamespacedName]*corev1.Service{
+				{Name: "example-svc", Namespace: "test"}: {},
+			},
+		}
+
+		apiClient, k8sClient, r := setupReconciler(t)
+		ctx := t.Context()
+
+		apiClient.EXPECT().CreateRoute(ctx, RequestEq(&configpb.CreateRouteRequest{
+			Route: &configpb.Route{
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-my-ingress-a-localhost-pomerium-io"),
+				From:         "https://a.localhost.pomerium.io",
+				To:           []string{"http://example-svc.test.svc.cluster.local:8080"},
+				Prefix:       "/",
+			},
+		})).Return(nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("route overlap")))
+
+		apiClient.EXPECT().ListRoutes(ctx, RequestEq(&configpb.ListRoutesRequest{
+			Filter: filterByName(t, "test-my-ingress-a-localhost-pomerium-io"),
+		})).Return(connect.NewResponse(&configpb.ListRoutesResponse{
+			Routes: []*configpb.Route{{
+				Id:           new("overlapping-route-id"),
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-my-ingress-a-localhost-pomerium-io"),
+				From:         "https://a.localhost.pomerium.io",
+				To:           []string{"http://example-svc.test.svc.cluster.local:8080"},
+				Prefix:       "/",
+			}},
+		}), nil)
+
+		k8sClient.EXPECT().Patch(ctx, ingress, gomock.Any()).Return(nil)
+
+		changed, err := r.upsertOneIngress(ctx, ic)
+		assert.True(t, changed)
+		assert.NoError(t, err)
+		assert.Equal(t, "overlapping-route-id", ic.Annotations["api.pomerium.io/route-id-0"])
+	})
+
 	t.Run("patch error", func(t *testing.T) {
 		ingress := ingressTemplate.DeepCopy()
 		ic := &model.IngressConfig{
@@ -1645,6 +1690,14 @@ func TestAPIReconciler_deletePolicy(t *testing.T) {
 		assert.Equal(t, apiError, err)
 		assert.Equal(t, "existing-policy-id", ingress.Annotations["api.pomerium.io/policy-id"])
 	})
+}
+
+func TestNewAPIReconciler_InvalidURL(t *testing.T) {
+	// NewAPIReconciler should return an error if the API URL is invalid
+	// when a dial address override is specified.
+	_, err := NewAPIReconciler("://invalid", "token", config.NewDefaultOptions(), "localhost:8443")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid API URL")
 }
 
 func createKeyPairResponseWithID(id string) *connect.Response[configpb.CreateKeyPairResponse] {

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -617,51 +617,6 @@ func TestAPIReconciler_upsertOneIngress(t *testing.T) {
 		assert.Equal(t, "missing-route-id", ic.Annotations["api.pomerium.io/route-id-0"])
 	})
 
-	t.Run("failed precondition", func(t *testing.T) {
-		// Pomerium Enterprise returns FailedPrecondition when route 'From' overlaps
-		// with an existing route.
-		ingress := ingressTemplate.DeepCopy()
-		ic := &model.IngressConfig{
-			AnnotationPrefix: "a", Ingress: ingress,
-			Services: map[types.NamespacedName]*corev1.Service{
-				{Name: "example-svc", Namespace: "test"}: {},
-			},
-		}
-
-		apiClient, k8sClient, r := setupReconciler(t)
-		ctx := t.Context()
-
-		apiClient.EXPECT().CreateRoute(ctx, RequestEq(&configpb.CreateRouteRequest{
-			Route: &configpb.Route{
-				OriginatorId: new("ingress-controller"),
-				Name:         new("test-my-ingress-a-localhost-pomerium-io"),
-				From:         "https://a.localhost.pomerium.io",
-				To:           []string{"http://example-svc.test.svc.cluster.local:8080"},
-				Prefix:       "/",
-			},
-		})).Return(nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("route overlap")))
-
-		apiClient.EXPECT().ListRoutes(ctx, RequestEq(&configpb.ListRoutesRequest{
-			Filter: filterByName(t, "test-my-ingress-a-localhost-pomerium-io"),
-		})).Return(connect.NewResponse(&configpb.ListRoutesResponse{
-			Routes: []*configpb.Route{{
-				Id:           new("overlapping-route-id"),
-				OriginatorId: new("ingress-controller"),
-				Name:         new("test-my-ingress-a-localhost-pomerium-io"),
-				From:         "https://a.localhost.pomerium.io",
-				To:           []string{"http://example-svc.test.svc.cluster.local:8080"},
-				Prefix:       "/",
-			}},
-		}), nil)
-
-		k8sClient.EXPECT().Patch(ctx, ingress, gomock.Any()).Return(nil)
-
-		changed, err := r.upsertOneIngress(ctx, ic)
-		assert.True(t, changed)
-		assert.NoError(t, err)
-		assert.Equal(t, "overlapping-route-id", ic.Annotations["api.pomerium.io/route-id-0"])
-	})
-
 	t.Run("patch error", func(t *testing.T) {
 		ingress := ingressTemplate.DeepCopy()
 		ic := &model.IngressConfig{

--- a/util/object.go
+++ b/util/object.go
@@ -1,0 +1,14 @@
+package util
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+// SetAnnotation sets the given annotation key/value, making a new Annotations
+// map if one does not already exist.
+func SetAnnotation(object client.Object, key, value string) {
+	m := object.GetAnnotations()
+	if m == nil {
+		m = make(map[string]string)
+	}
+	m[key] = value
+	object.SetAnnotations(m)
+}


### PR DESCRIPTION
## Summary

When syncing to Pomerium Enterprise, there is a chicken-and-egg problem: Enterprise relies on Pomerium Core to authenticate all incoming API requests. But the Pomerium route to Enterprise is itself defined using an Ingress, so we can't communicate with the API at all before this route exists. We can't use the API to create the route to the API.

Instead, add a `--sync-api-ingress` option to the `all-in-one` command that takes the name of an Ingress object corresponding to the API provider. When this option is set, the bootstrap settings sync will be expanded to include Pomerium route(s) built from this Ingress. The API client will also be configured to dial the Core listener directly, so even if the Ingress host domain does not resolve from inside the pod network, the API sync should still work.

To avoid the overhead of an extra controller, the Ingress data is fetched just once at startup.

## Related issues

https://linear.app/pomerium/issue/ENG-3854/bootstrap-deadlock-api-reconciler-mode-cannot-reach-console-when

## AI disclosure

Claude Code made some suggestions on where to insert the new logic for fetching the bootstrap ingress data and drafted unit tests.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
