### PR TITLE
sync: handle route failed_precondition error

### DIFF
--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -637,12 +637,19 @@ func (r *APIReconciler) upsertOneRoute(ctx context.Context, route *configpb.Rout
 		if err == nil {
 			route.Id = resp.Msg.Route.Id
 			return true, nil
-		} else if connect.CodeOf(err) != connect.CodeAlreadyExists {
-			return false, err
 		}
 
 		// If we already created a route, but failed to save the ID annotation,
-		// attempt to look up the route by name.
+		// we may get either an already_exists error (there is a name uniqueness
+		// constraint in Pomerium Zero), or a failed_precondition error (there is
+		// a route 'From' overlap check in Pomerium Enterprise). Any other error
+		// should be returned as is.
+		errCode := connect.CodeOf(err)
+		if errCode != connect.CodeAlreadyExists && errCode != connect.CodeFailedPrecondition {
+			return false, err
+		}
+
+		// Attempt to look up the route by name.
 		existing, err = r.findRouteByName(ctx, route.GetName())
 		if err != nil {
 			return false, err

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -617,6 +617,51 @@ func TestAPIReconciler_upsertOneIngress(t *testing.T) {
 		assert.Equal(t, "missing-route-id", ic.Annotations["api.pomerium.io/route-id-0"])
 	})
 
+	t.Run("failed precondition", func(t *testing.T) {
+		// Pomerium Enterprise returns failed_precondition when there is an
+		// existing route already.
+		ingress := ingressTemplate.DeepCopy()
+		ic := &model.IngressConfig{
+			AnnotationPrefix: "a", Ingress: ingress,
+			Services: map[types.NamespacedName]*corev1.Service{
+				{Name: "example-svc", Namespace: "test"}: {},
+			},
+		}
+
+		apiClient, k8sClient, r := setupReconciler(t)
+		ctx := t.Context()
+
+		apiClient.EXPECT().CreateRoute(ctx, RequestEq(&configpb.CreateRouteRequest{
+			Route: &configpb.Route{
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-my-ingress-a-localhost-pomerium-io"),
+				From:         "https://a.localhost.pomerium.io",
+				To:           []string{"http://example-svc.test.svc.cluster.local:8080"},
+				Prefix:       "/",
+			},
+		})).Return(nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("route overlap")))
+
+		apiClient.EXPECT().ListRoutes(ctx, RequestEq(&configpb.ListRoutesRequest{
+			Filter: filterByName(t, "test-my-ingress-a-localhost-pomerium-io"),
+		})).Return(connect.NewResponse(&configpb.ListRoutesResponse{
+			Routes: []*configpb.Route{{
+				Id:           new("overlapping-route-id"),
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-my-ingress-a-localhost-pomerium-io"),
+				From:         "https://a.localhost.pomerium.io",
+				To:           []string{"http://example-svc.test.svc.cluster.local:8080"},
+				Prefix:       "/",
+			}},
+		}), nil)
+
+		k8sClient.EXPECT().Patch(ctx, ingress, gomock.Any()).Return(nil)
+
+		changed, err := r.upsertOneIngress(ctx, ic)
+		assert.True(t, changed)
+		assert.NoError(t, err)
+		assert.Equal(t, "overlapping-route-id", ic.Annotations["api.pomerium.io/route-id-0"])
+	})
+
 	t.Run("patch error", func(t *testing.T) {
 		ingress := ingressTemplate.DeepCopy()
 		ic := &model.IngressConfig{


### PR DESCRIPTION
## Summary

Routes in Pomerium Enterprise do not appear to have a name uniqueness constraint, so the logic to detect an existing route by checking for a name collision doesn't work. Check for the `failed_precondition` error code in addition to the `already_exists` error code.

## Related issues

https://linear.app/pomerium/issue/ENG-3855/ingress-controller-apireconciler-needs-idempotent-entity-creation-and

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
