### PR TITLE
sync: add --sync-api-namespace-id option

### DIFF
--- a/cmd/all_in_one.go
+++ b/cmd/all_in_one.go
@@ -69,6 +69,7 @@ type allCmdParam struct {
 	updateStatusFromService string
 	dumpConfigDiff          bool
 	syncAPIURL              string
+	syncAPINamespaceID      string
 	syncAPIToken            string
 	syncAPIBootstrap        bool
 
@@ -203,6 +204,7 @@ func (s *allCmdOptions) getParam(ctx context.Context) (*allCmdParam, error) {
 		dumpConfigDiff:                  s.debugDumpConfigDiff,
 		configControllerShutdownTimeout: s.configControllerShutdownTimeout,
 		syncAPIURL:                      s.SyncAPIURL,
+		syncAPINamespaceID:              s.SyncAPINamespaceID,
 		syncAPIToken:                    s.SyncAPIToken,
 		syncAPIBootstrap:                s.syncAPIIngress != "",
 		certificateControllerName:       s.CertificateControllerOptions.Name,
@@ -412,7 +414,7 @@ func (s *allCmdParam) buildController(ctx context.Context, cfg *config.Config) (
 			}
 			dialAddressOverride = net.JoinHostPort("localhost", port)
 		}
-		reconciler, err = pomerium.NewAPIReconciler(s.syncAPIURL, s.syncAPIToken, s.cfg.Options, dialAddressOverride)
+		reconciler, err = pomerium.NewAPIReconciler(s.syncAPIURL, s.syncAPINamespaceID, s.syncAPIToken, s.cfg.Options, dialAddressOverride)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -169,7 +169,7 @@ func (s *controllerCmd) buildController(ctx context.Context) (*controllers.Contr
 
 	if s.SyncAPIURL != "" {
 		c.Reconciler, err = pomerium.NewAPIReconciler(
-			s.SyncAPIURL, s.SyncAPIToken, pomerium_config.NewDefaultOptions(), "")
+			s.SyncAPIURL, s.SyncAPINamespaceID, s.SyncAPIToken, pomerium_config.NewDefaultOptions(), "")
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/ingress_opts.go
+++ b/cmd/ingress_opts.go
@@ -22,6 +22,7 @@ type ingressControllerOpts struct {
 	UpdateStatusFromService string ``
 	GlobalSettings          string `validate:"required"`
 	SyncAPIURL              string
+	SyncAPINamespaceID      string
 	SyncAPIToken            string
 }
 
@@ -36,6 +37,7 @@ const (
 	globalSettings             = "pomerium-config"
 	syncAPIIngress             = "sync-api-ingress"
 	syncAPIURL                 = "sync-api-url"
+	syncAPINamespaceID         = "sync-api-namespace-id"
 	syncAPIToken               = "sync-api-token" //nolint:gosec
 )
 
@@ -49,6 +51,7 @@ func (s *ingressControllerOpts) setupFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&s.GlobalSettings, globalSettings, "",
 		fmt.Sprintf("namespace/name to a resource of type %s/Settings", icsv1.GroupVersion.Group))
 	flags.StringVar(&s.SyncAPIURL, syncAPIURL, "", "unified API sync URL")
+	flags.StringVar(&s.SyncAPINamespaceID, syncAPINamespaceID, "", "unified API sync namespace ID")
 	flags.StringVar(&s.SyncAPIToken, syncAPIToken, "", "unified API sync token")
 }
 

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -130,7 +130,7 @@ func (r *APIReconciler) Upsert(ctx context.Context, ic *model.IngressConfig) (bo
 
 	// Remove keypairs corresponding to any newly-unreferenced TLS secrets.
 	unreferencedSecrets := r.secretsMap.UpdateIngress(ic)
-	anyDeletes, err := r.deleteKeyPairs(ctx, unreferencedSecrets...)
+	anyDeletes, err := r.deleteKeyPairsForSecrets(ctx, unreferencedSecrets...)
 	if err != nil {
 		return anyChanges, err
 	}
@@ -287,7 +287,7 @@ func (r *APIReconciler) upsertOneIngress(
 		// I don't see an easy way to make this delete idempotent.
 		// TODO: figure out if it's worth additional complexity to avoid
 		// an orphaned policy in the old namespace.
-		r.deletePolicy(ctx, existingPolicyID)
+		_ = r.deletePolicy(ctx, existingPolicyID)
 	}
 
 	// If there was a linked policy that is no no longer needed, delete it.
@@ -360,7 +360,7 @@ func (r *APIReconciler) syncOneSecret(
 func (r *APIReconciler) SetConfig(ctx context.Context, cfg *model.Config) (changes bool, err error) {
 	// Remove keypairs corresponding to any newly-unreferenced TLS secrets.
 	unreferencedSecrets := r.secretsMap.UpdateConfig(cfg)
-	anyDeletes, err := r.deleteKeyPairs(ctx, unreferencedSecrets...)
+	anyDeletes, err := r.deleteKeyPairsForSecrets(ctx, unreferencedSecrets...)
 	if err != nil {
 		return changes, err
 	}
@@ -462,7 +462,7 @@ func (r *APIReconciler) Delete(ctx context.Context, name types.NamespacedName) (
 		Kind:           ingress.Kind,
 		NamespacedName: name,
 	})
-	anyKeyPairDeleted, err := r.deleteKeyPairs(ctx, unreferencedSecrets...)
+	anyKeyPairDeleted, err := r.deleteKeyPairsForSecrets(ctx, unreferencedSecrets...)
 	if err != nil {
 		return changed, err
 	}
@@ -480,7 +480,7 @@ func (r *APIReconciler) SetGatewayConfig(
 ) (changes bool, err error) {
 	// Sync keypairs.
 	unreferencedSecrets := r.secretsMap.UpdateGatewayConfig(gatewayConfig)
-	anyDeletes, err := r.deleteKeyPairs(ctx, unreferencedSecrets...)
+	anyDeletes, err := r.deleteKeyPairsForSecrets(ctx, unreferencedSecrets...)
 	if err != nil {
 		return changes, err
 	}
@@ -946,6 +946,17 @@ func (r *APIReconciler) upsertKeyPair(ctx context.Context, keyPair *configpb.Key
 		}
 	}
 
+	if existing != nil && keyPair.NamespaceId != nil &&
+		keyPair.GetNamespaceId() != existing.GetNamespaceId() {
+		// The key pair exists already, but in a different namespace.
+		// Delete the existing key pair so we can recreate it in the new namespace.
+		if err := r.deleteKeyPair(ctx, existing.GetId()); err != nil {
+			return false, fmt.Errorf("couldn't delete existing key pair in different namespace: %w", err)
+		}
+		existing = nil
+		keyPair.Id = nil
+	}
+
 	// If there is no existing keypair, create one.
 	if existing == nil {
 		resp, err := r.apiClient.CreateKeyPair(ctx, connect.NewRequest(&configpb.CreateKeyPairRequest{
@@ -1018,10 +1029,10 @@ func (r *APIReconciler) findKeyPairByName(
 	return resp.Msg.KeyPairs[0], nil
 }
 
-// deleteKeyPairs deletes the keypairs corresponding to the given Secret names,
-// clearing the keypair ID annotation for each. Returns true if any deletes were
-// successful, or an error if some delete operation failed.
-func (r *APIReconciler) deleteKeyPairs(
+// deleteKeyPairsForSecrets deletes the keypairs corresponding to the given
+// Secret names, clearing the keypair ID annotation for each. Returns true if
+// any deletes were successful, or an error if some delete operation failed.
+func (r *APIReconciler) deleteKeyPairsForSecrets(
 	ctx context.Context, secretNames ...types.NamespacedName,
 ) (bool, error) {
 	var anyDeletes bool
@@ -1051,10 +1062,7 @@ func (r *APIReconciler) deleteKeyPairs(
 		}
 
 		if keyPairID != "" {
-			_, err = r.apiClient.DeleteKeyPair(ctx, connect.NewRequest(&configpb.DeleteKeyPairRequest{
-				Id: keyPairID,
-			}))
-			if err != nil && connect.CodeOf(err) != connect.CodeNotFound {
+			if err := r.deleteKeyPair(ctx, keyPairID); err != nil {
 				return anyDeletes, err
 			}
 		}
@@ -1070,6 +1078,16 @@ func (r *APIReconciler) deleteKeyPairs(
 		anyDeletes = true
 	}
 	return anyDeletes, nil
+}
+
+func (r *APIReconciler) deleteKeyPair(ctx context.Context, id string) error {
+	_, err := r.apiClient.DeleteKeyPair(ctx, connect.NewRequest(&configpb.DeleteKeyPairRequest{
+		Id: id,
+	}))
+	if connect.CodeOf(err) == connect.CodeNotFound {
+		return nil
+	}
+	return err
 }
 
 func routeIDAnnotationForIndex(i int) string {

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -283,7 +283,7 @@ func (r *APIReconciler) upsertOneIngress(
 
 	// If we had to recreate the linked policy e.g. due to a change in the
 	// namespace, now we can delete the old policy.
-	if existingPolicyID != "" && existingPolicyID != updatedPolicyID {
+	if existingPolicyID != "" && updatedPolicyID != "" && existingPolicyID != updatedPolicyID {
 		// I don't see an easy way to make this delete idempotent.
 		// TODO: figure out if it's worth additional complexity to avoid
 		// an orphaned policy in the old namespace.

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -283,7 +283,7 @@ func (r *APIReconciler) upsertOneIngress(
 	// (This cannot be done until all of the linked routes are updated to no
 	// longer reference the existing policy ID.)
 	if ic.Annotations[apiPolicyIDAnnotation] != "" && updatedPolicyID == "" {
-		deleted, err := r.deletePolicy(ctx, ic.Ingress)
+		deleted, err := r.deletePolicyForObject(ctx, ic.Ingress)
 		if err != nil {
 			return changed, err
 		}
@@ -440,7 +440,7 @@ func (r *APIReconciler) Delete(ctx context.Context, name types.NamespacedName) (
 		return changed, err
 	}
 
-	policyDeleted, err := r.deletePolicy(ctx, ingress)
+	policyDeleted, err := r.deletePolicyForObject(ctx, ingress)
 	if err != nil {
 		return changed, err
 	}
@@ -605,7 +605,7 @@ func (r *APIReconciler) removeDeletedGatewayPolicies(
 			continue
 		}
 
-		deleted, err := r.deletePolicy(ctx, obj)
+		deleted, err := r.deletePolicyForObject(ctx, obj)
 		if err != nil {
 			return changes, err
 		}
@@ -657,6 +657,17 @@ func (r *APIReconciler) upsertOneRoute(ctx context.Context, route *configpb.Rout
 		} else if err == nil {
 			existing = resp.Msg.Route
 		}
+	}
+
+	if existing != nil && apiRoute.NamespaceId != nil &&
+		apiRoute.GetNamespaceId() != existing.GetNamespaceId() {
+		// The route exists already, but in a different namespace.
+		// Delete the existing route so we can recreate it in the new namespace.
+		if err := r.deleteRoute(ctx, existing.GetId()); err != nil {
+			return false, fmt.Errorf("couldn't delete existing route in different namespace: %w", err)
+		}
+		existing = nil
+		apiRoute.Id = nil
 	}
 
 	if existing == nil {
@@ -736,16 +747,23 @@ func (r *APIReconciler) deleteRoutes(
 	var anyDeletes bool
 	annotations := obj.GetAnnotations()
 	for k := range annotationKeys {
-		_, err := r.apiClient.DeleteRoute(ctx, connect.NewRequest(&configpb.DeleteRouteRequest{
-			Id: annotations[k],
-		}))
-		if err != nil && connect.CodeOf(err) != connect.CodeNotFound {
+		if err := r.deleteRoute(ctx, annotations[k]); err != nil {
 			return anyDeletes, err
 		}
 		delete(annotations, k)
 		anyDeletes = true
 	}
 	return anyDeletes, nil
+}
+
+func (r *APIReconciler) deleteRoute(ctx context.Context, id string) error {
+	_, err := r.apiClient.DeleteRoute(ctx, connect.NewRequest(&configpb.DeleteRouteRequest{
+		Id: id,
+	}))
+	if connect.CodeOf(err) == connect.CodeNotFound {
+		return nil
+	}
+	return err
 }
 
 func (r *APIReconciler) syncIngressPolicy(
@@ -796,6 +814,17 @@ func (r *APIReconciler) upsertPolicy(ctx context.Context, policy *configpb.Polic
 		} else if connect.CodeOf(err) != connect.CodeNotFound {
 			return false, err
 		}
+	}
+
+	if existing != nil && policy.NamespaceId != nil &&
+		policy.GetNamespaceId() != existing.GetNamespaceId() {
+		// The policy exists already, but in a different namespace.
+		// Delete the existing policy so we can recreate it in the new namespace.
+		if err := r.deletePolicy(ctx, existing.GetId()); err != nil {
+			return false, fmt.Errorf("couldn't delete existing policy in different namespace: %w", err)
+		}
+		existing = nil
+		policy.Id = nil
 	}
 
 	// If there is no existing policy, create one.
@@ -867,10 +896,10 @@ func (r *APIReconciler) findPolicyByName(
 	return resp.Msg.Policies[0], nil
 }
 
-// deletePolicy deletes the policy for obj and clears its policy ID annotation.
-// Returns true if any changes were made, or an error if the delete operation
-// failed.
-func (r *APIReconciler) deletePolicy(
+// deletePolicyForObject deletes the policy for obj and clears its policy ID
+// annotation. Returns true if any changes were made, or an error if the delete
+// operation failed.
+func (r *APIReconciler) deletePolicyForObject(
 	ctx context.Context, obj client.Object,
 ) (deleted bool, err error) {
 	annotations := obj.GetAnnotations()
@@ -878,14 +907,21 @@ func (r *APIReconciler) deletePolicy(
 	if policyID == "" {
 		return false, nil
 	}
-	_, err = r.apiClient.DeletePolicy(ctx, connect.NewRequest(&configpb.DeletePolicyRequest{
-		Id: policyID,
-	}))
-	if err != nil && connect.CodeOf(err) != connect.CodeNotFound {
+	if err := r.deletePolicy(ctx, policyID); err != nil {
 		return false, err
 	}
 	delete(annotations, apiPolicyIDAnnotation)
 	return true, nil
+}
+
+func (r *APIReconciler) deletePolicy(ctx context.Context, id string) (err error) {
+	_, err = r.apiClient.DeletePolicy(ctx, connect.NewRequest(&configpb.DeletePolicyRequest{
+		Id: id,
+	}))
+	if connect.CodeOf(err) == connect.CodeNotFound {
+		return nil
+	}
+	return err
 }
 
 func (r *APIReconciler) upsertKeyPair(ctx context.Context, keyPair *configpb.KeyPair) (changed bool, err error) {

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -39,7 +39,7 @@ import (
 // NewAPIReconciler initializes a reconciler that syncs using the unified API,
 // for the given API url and API token.
 func NewAPIReconciler(
-	apiURL, apiToken string, baseOptions *config.Options, dialAddressOverride string,
+	apiURL, namespaceID, apiToken string, baseOptions *config.Options, dialAddressOverride string,
 ) (Reconciler, error) {
 	opts := []sdk.ClientOption{
 		sdk.WithURL(apiURL),
@@ -64,11 +64,15 @@ func NewAPIReconciler(
 			Transport: transport,
 		}))
 	}
-	return &APIReconciler{
+	ar := &APIReconciler{
 		apiClient:   sdk.NewClient(opts...),
 		baseOptions: baseOptions,
 		secretsMap:  model.NewTLSSecretsMap(),
-	}, nil
+	}
+	if namespaceID != "" {
+		ar.namespaceID = &namespaceID
+	}
+	return ar, nil
 }
 
 var (
@@ -83,6 +87,7 @@ type APIReconciler struct {
 	k8sClient client.Client
 
 	baseOptions *config.Options
+	namespaceID *string
 	secretsMap  *model.TLSSecretsMap
 }
 
@@ -319,6 +324,7 @@ func (r *APIReconciler) syncOneSecret(
 	name := keyPairName(util.GetNamespacedName(secret))
 	keyPair := &configpb.KeyPair{
 		Name:         &name,
+		NamespaceId:  r.namespaceID,
 		Certificate:  cert,
 		Key:          secret.Data[corev1.TLSPrivateKeyKey],
 		OriginatorId: &originatorID,
@@ -561,6 +567,7 @@ func (r *APIReconciler) syncGatewayPolicies(
 		policy.Rego = nil
 		policyName := slug.Make(fmt.Sprintf("%s %s", obj.Namespace, obj.Name))
 		policy.Name = &policyName
+		policy.NamespaceId = r.namespaceID
 		if id := obj.Annotations[apiPolicyIDAnnotation]; id != "" {
 			policy.Id = &id
 		}
@@ -637,6 +644,7 @@ func (r *APIReconciler) upsertOneRoute(ctx context.Context, route *configpb.Rout
 	if err != nil {
 		return false, err
 	}
+	apiRoute.NamespaceId = r.namespaceID
 	apiRoute.OriginatorId = &originatorID
 
 	var existing *configpb.Route
@@ -652,8 +660,6 @@ func (r *APIReconciler) upsertOneRoute(ctx context.Context, route *configpb.Rout
 	}
 
 	if existing == nil {
-		apiRoute.OriginatorId = &originatorID
-
 		// If the route does not currently exist, create it.
 		resp, err := r.apiClient.CreateRoute(ctx, connect.NewRequest(&configpb.CreateRouteRequest{
 			Route: apiRoute,
@@ -676,7 +682,9 @@ func (r *APIReconciler) upsertOneRoute(ctx context.Context, route *configpb.Rout
 	}
 
 	// Clear the fields that should be ignored when looking for changes.
-	existing.NamespaceId = nil
+	if r.namespaceID == nil {
+		existing.NamespaceId = nil
+	}
 	existing.CreatedAt = nil
 	existing.ModifiedAt = nil
 	existing.AssignedPolicies = nil
@@ -759,6 +767,7 @@ func (r *APIReconciler) syncIngressPolicy(
 	if err != nil {
 		return false, "", fmt.Errorf("internal error: %w", err)
 	}
+	apiPolicy.NamespaceId = r.namespaceID
 	apiPolicy.OriginatorId = &originatorID
 	if existingPolicyID != "" {
 		apiPolicy.Id = &existingPolicyID
@@ -812,7 +821,9 @@ func (r *APIReconciler) upsertPolicy(ctx context.Context, policy *configpb.Polic
 	}
 
 	// Zero out fields that should be ignored when looking for changes.
-	existing.NamespaceId = nil
+	if r.namespaceID == nil {
+		existing.NamespaceId = nil
+	}
 	existing.CreatedAt = nil
 	existing.ModifiedAt = nil
 	existing.AssignedRoutes = nil
@@ -913,7 +924,9 @@ func (r *APIReconciler) upsertKeyPair(ctx context.Context, keyPair *configpb.Key
 	}
 
 	// Zero out fields that should be ignored when looking for changes.
-	existing.NamespaceId = nil
+	if r.namespaceID == nil {
+		existing.NamespaceId = nil
+	}
 	existing.CreatedAt = nil
 	existing.ModifiedAt = nil
 	existing.CertificateInfo = nil

--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -198,6 +198,8 @@ func (r *APIReconciler) upsertOneIngress(
 		return changed, err
 	}
 
+	existingPolicyID := ic.Annotations[apiPolicyIDAnnotation]
+
 	changedPolicy, updatedPolicyID, err := r.syncIngressPolicy(ctx, ic.Ingress, kv)
 	if err != nil {
 		return changed, err
@@ -278,6 +280,15 @@ func (r *APIReconciler) upsertOneIngress(
 		return changed, err
 	}
 	changed = changed || anyDeletes
+
+	// If we had to recreate the linked policy e.g. due to a change in the
+	// namespace, now we can delete the old policy.
+	if existingPolicyID != "" && existingPolicyID != updatedPolicyID {
+		// I don't see an easy way to make this delete idempotent.
+		// TODO: figure out if it's worth additional complexity to avoid
+		// an orphaned policy in the old namespace.
+		r.deletePolicy(ctx, existingPolicyID)
+	}
 
 	// If there was a linked policy that is no no longer needed, delete it.
 	// (This cannot be done until all of the linked routes are updated to no
@@ -819,10 +830,8 @@ func (r *APIReconciler) upsertPolicy(ctx context.Context, policy *configpb.Polic
 	if existing != nil && policy.NamespaceId != nil &&
 		policy.GetNamespaceId() != existing.GetNamespaceId() {
 		// The policy exists already, but in a different namespace.
-		// Delete the existing policy so we can recreate it in the new namespace.
-		if err := r.deletePolicy(ctx, existing.GetId()); err != nil {
-			return false, fmt.Errorf("couldn't delete existing policy in different namespace: %w", err)
-		}
+		// We'll need to delete and recreate it, but we can't delete it until
+		// any routes that reference it are also deleted.
 		existing = nil
 		policy.Id = nil
 	}

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -549,6 +549,62 @@ func TestAPIReconciler_upsertOneIngress(t *testing.T) {
 		assert.Equal(t, "recreated-route-id", ic.Annotations["api.pomerium.io/route-id-0"])
 	})
 
+	t.Run("different route namespace", func(t *testing.T) {
+		ingress := ingressTemplate.DeepCopy()
+		ingress.Annotations = map[string]string{
+			"api.pomerium.io/route-id-0": "existing-route-id",
+		}
+		ic := &model.IngressConfig{
+			AnnotationPrefix: "a", Ingress: ingress,
+			Services: map[types.NamespacedName]*corev1.Service{
+				{Name: "example-svc", Namespace: "test"}: {},
+			},
+		}
+
+		apiClient, k8sClient, r := setupReconciler(t)
+		r.namespaceID = new("namespace-bravo")
+		ctx := t.Context()
+
+		// The route already exists, but in a different namespace.
+		apiClient.EXPECT().GetRoute(ctx, RequestEq(&configpb.GetRouteRequest{
+			Id: "existing-route-id",
+		})).Return(connect.NewResponse(&configpb.GetRouteResponse{
+			Route: &configpb.Route{
+				Id:           new("existing-route-id"),
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-a-localhost-pomerium-io"),
+				NamespaceId:  new("namespace-alpha"),
+				StatName:     new("route-a-stat-name"),
+				From:         "https://a.localhost.pomerium.io",
+				To:           []string{"http://example-svc.test.svc.cluster.local:8080"},
+				Prefix:       "/",
+			},
+		}), nil)
+
+		// The existing route should be deleted and recreated.
+		apiClient.EXPECT().DeleteRoute(ctx, RequestEq(&configpb.DeleteRouteRequest{
+			Id: "existing-route-id",
+		})).Return(connect.NewResponse(&configpb.DeleteRouteResponse{}), nil)
+
+		apiClient.EXPECT().CreateRoute(ctx, RequestEq(&configpb.CreateRouteRequest{
+			Route: &configpb.Route{
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-my-ingress-a-localhost-pomerium-io"),
+				NamespaceId:  new("namespace-bravo"),
+				From:         "https://a.localhost.pomerium.io",
+				To:           []string{"http://example-svc.test.svc.cluster.local:8080"},
+				Prefix:       "/",
+			},
+		})).Return(createRouteResponseWithID("recreated-route-id"), nil)
+
+		k8sClient.EXPECT().Patch(ctx, ingress, gomock.Any()).Return(nil)
+
+		changed, err := r.upsertOneIngress(ctx, ic)
+		assert.True(t, changed)
+		assert.NoError(t, err)
+		assert.Equal(t, "recreated-route-id", ic.Annotations["api.pomerium.io/route-id-0"])
+	})
+
 	t.Run("other error on update", func(t *testing.T) {
 		ingress := ingressTemplate.DeepCopy()
 		ingress.Annotations = map[string]string{
@@ -1573,6 +1629,48 @@ func TestAPIReconciler_upsertPolicy(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("different namespace", func(t *testing.T) {
+		apiClient, _, r := setupReconciler(t)
+		ctx := t.Context()
+
+		policy := proto.CloneOf(policy)
+		policy.NamespaceId = new("namespace-bravo")
+
+		// The policy already exists, but in a different namespace.
+		apiClient.EXPECT().GetPolicy(ctx, RequestEq(&configpb.GetPolicyRequest{
+			Id: "existing-policy-id",
+		})).Return(connect.NewResponse(&configpb.GetPolicyResponse{
+			Policy: &configpb.Policy{
+				Id:          new("existing-policy-id"),
+				NamespaceId: new("namespace-alpha"),
+
+				CreatedAt:  timestamppb.Now(),
+				ModifiedAt: timestamppb.Now(),
+				AssignedRoutes: []*configpb.EntityInfo{{
+					Id:   new("some-route-id"),
+					Name: new("some-route-name"),
+				}},
+				Enforced: new(false),
+			},
+		}), nil)
+
+		// The existing policy should be deleted and recreated in the new namespace.
+		apiClient.EXPECT().DeletePolicy(ctx, RequestEq(&configpb.DeletePolicyRequest{
+			Id: "existing-policy-id",
+		})).Return(connect.NewResponse(&configpb.DeletePolicyResponse{}), nil)
+
+		apiClient.EXPECT().CreatePolicy(ctx, RequestEq(&configpb.CreatePolicyRequest{
+			Policy: &configpb.Policy{
+				NamespaceId: new("namespace-bravo"),
+			},
+		})).Return(createPolicyResponseWithID("recreated-policy-id"), nil)
+
+		changed, err := r.upsertPolicy(ctx, policy)
+		assert.True(t, changed)
+		assert.NoError(t, err)
+		assert.Equal(t, "recreated-policy-id", policy.GetId())
+	})
+
 	t.Run("already exists", func(t *testing.T) {
 		policy := &configpb.Policy{
 			OriginatorId: new("originator-id"),
@@ -1628,7 +1726,7 @@ func TestAPIReconciler_deletePolicy(t *testing.T) {
 			Id: "existing-policy-id",
 		})).Return(nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("not found")))
 
-		deleted, err := r.deletePolicy(ctx, ingress)
+		deleted, err := r.deletePolicyForObject(ctx, ingress)
 		assert.True(t, deleted)
 		assert.NoError(t, err)
 		assert.NotContains(t, ingress.Annotations, "api.pomerium.io/policy-id")
@@ -1652,7 +1750,7 @@ func TestAPIReconciler_deletePolicy(t *testing.T) {
 			Id: "existing-policy-id",
 		})).Return(nil, apiError)
 
-		deleted, err := r.deletePolicy(ctx, ingress)
+		deleted, err := r.deletePolicyForObject(ctx, ingress)
 		assert.False(t, deleted)
 		assert.Equal(t, apiError, err)
 		assert.Equal(t, "existing-policy-id", ingress.Annotations["api.pomerium.io/policy-id"])

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -74,6 +74,7 @@ func TestAPIReconcilerBasicIngressLifecycle(t *testing.T) {
 	// APIReconciler should create, update, and delete a Pomerium route and
 	// keypair entity.
 	apiClient, k8sClient, r := setupReconciler(t)
+	r.namespaceID = new("api-namespace-id")
 
 	ingress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -106,6 +107,7 @@ func TestAPIReconcilerBasicIngressLifecycle(t *testing.T) {
 	route := &configpb.Route{
 		OriginatorId: new("ingress-controller"),
 		Name:         new("test-my-ingress-a-localhost-pomerium-io"),
+		NamespaceId:  new("api-namespace-id"),
 		From:         "https://a.localhost.pomerium.io",
 		To:           []string{"http://example-svc.test.svc.cluster.local:8080"},
 		Prefix:       "/",
@@ -143,6 +145,7 @@ func TestAPIReconcilerBasicIngressLifecycle(t *testing.T) {
 		KeyPair: &configpb.KeyPair{
 			OriginatorId: new("ingress-controller"),
 			Name:         new("test-pomerium-wildcard-cert"),
+			NamespaceId:  new("api-namespace-id"),
 			Certificate:  []byte("fake-cert-data"),
 			Key:          []byte("fake-key-data"),
 		},
@@ -157,6 +160,7 @@ func TestAPIReconcilerBasicIngressLifecycle(t *testing.T) {
 			OriginatorId:      new("ingress-controller"),
 			Id:                new("new-route-id-1"),
 			Name:              new("test-my-ingress-a-localhost-pomerium-io"),
+			NamespaceId:       new("api-namespace-id"),
 			From:              "https://a.localhost.pomerium.io",
 			To:                []string{"http://example-svc.test.svc.cluster.local:8080"},
 			Prefix:            "/",
@@ -789,6 +793,7 @@ func TestAPIReconciler_upsertOneIngress_multipleRoutes(t *testing.T) {
 func TestAPIReconciler_SetGatewayConfig(t *testing.T) {
 	// Test the basic route & policy lifecycle via the SetGatewayConfig method.
 	apiClient, k8sClient, r := setupReconciler(t)
+	r.namespaceID = new("api-namespace-id")
 	ctx := t.Context()
 
 	examplePPL := `allow:
@@ -858,12 +863,14 @@ func TestAPIReconciler_SetGatewayConfig(t *testing.T) {
 		Policy: &configpb.Policy{
 			OriginatorId: new("ingress-controller"),
 			Name:         new("test-example-policy"),
+			NamespaceId:  new("api-namespace-id"),
 			SourcePpl:    &examplePPL,
 		},
 	})).Return(createPolicyResponseWithID("example-policy-id"), nil)
 	route := &configpb.Route{
 		OriginatorId:         new("ingress-controller"),
 		Name:                 new("test-route-a-a-localhost-pomerium-io"),
+		NamespaceId:          new("api-namespace-id"),
 		From:                 "https://a.localhost.pomerium.io",
 		To:                   []string{"http://example-svc.test.svc.cluster.local:8000"},
 		LoadBalancingWeights: []uint32{1},
@@ -888,6 +895,7 @@ func TestAPIReconciler_SetGatewayConfig(t *testing.T) {
 			Id:           new("example-policy-id"),
 			OriginatorId: new("ingress-controller"),
 			Name:         new("test-example-policy"),
+			NamespaceId:  new("api-namespace-id"),
 			SourcePpl:    &examplePPL,
 		},
 	}), nil)
@@ -901,6 +909,7 @@ func TestAPIReconciler_SetGatewayConfig(t *testing.T) {
 			OriginatorId:         new("ingress-controller"),
 			Id:                   new("new-route-id-1"),
 			Name:                 new("test-route-a-a-localhost-pomerium-io"),
+			NamespaceId:          new("api-namespace-id"),
 			From:                 "https://a.localhost.pomerium.io",
 			To:                   []string{"http://example-svc.test.svc.cluster.local:1234"},
 			LoadBalancingWeights: []uint32{1},
@@ -923,6 +932,7 @@ func TestAPIReconciler_SetGatewayConfig(t *testing.T) {
 			OriginatorId: new("ingress-controller"),
 			Id:           new("new-route-id-1"),
 			Name:         new("test-route-a-a-localhost-pomerium-io"),
+			NamespaceId:  new("api-namespace-id"),
 			From:         "https://a.localhost.pomerium.io",
 			Response: &configpb.RouteDirectResponse{
 				Status: 500,
@@ -1317,6 +1327,7 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 					Key:          []byte("key-data"),
 
 					// these fields should be ignored
+					NamespaceId: new("default-namespace-id"),
 					CertificateInfo: []*configpb.CertificateInfo{{
 						Version: 1234,
 						Serial:  "ABCD",
@@ -1360,6 +1371,7 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 				Key:          []byte("key-data"),
 
 				// these fields should be ignored
+				NamespaceId: new("default-namespace-id"),
 				CertificateInfo: []*configpb.CertificateInfo{{
 					Version: 1234,
 					Serial:  "ABCD",
@@ -1650,7 +1662,8 @@ func TestAPIReconciler_deletePolicy(t *testing.T) {
 func TestNewAPIReconciler_InvalidURL(t *testing.T) {
 	// NewAPIReconciler should return an error if the API URL is invalid
 	// when a dial address override is specified.
-	_, err := NewAPIReconciler("://invalid", "token", config.NewDefaultOptions(), "localhost:8443")
+	_, err := NewAPIReconciler(
+		"://invalid", "namespace", "token", config.NewDefaultOptions(), "localhost:8443")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid API URL")
 }

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -1538,7 +1538,7 @@ func TestAPIReconciler_deleteKeyPairs(t *testing.T) {
 			Id: "my-keypair-id",
 		}))
 
-		_, err := r.deleteKeyPairs(ctx, n)
+		_, err := r.deleteKeyPairsForSecrets(ctx, n)
 		assert.NoError(t, err)
 	})
 
@@ -1555,7 +1555,7 @@ func TestAPIReconciler_deleteKeyPairs(t *testing.T) {
 			Filter: filterByName(t, "test-my-secret"),
 		})).Return(connect.NewResponse(&configpb.ListKeyPairsResponse{KeyPairs: nil}), nil)
 
-		_, err := r.deleteKeyPairs(ctx, n)
+		_, err := r.deleteKeyPairsForSecrets(ctx, n)
 		assert.NoError(t, err)
 	})
 }

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -1713,11 +1713,9 @@ func TestAPIReconciler_upsertPolicy(t *testing.T) {
 			},
 		}), nil)
 
-		// The existing policy should be deleted and recreated in the new namespace.
-		apiClient.EXPECT().DeletePolicy(ctx, RequestEq(&configpb.DeletePolicyRequest{
-			Id: "existing-policy-id",
-		})).Return(connect.NewResponse(&configpb.DeletePolicyResponse{}), nil)
-
+		// The policy should be recreated in the new namespace.
+		// (The existing policy can't be deleted yet because it might still be
+		// assigned to a route.)
 		apiClient.EXPECT().CreatePolicy(ctx, RequestEq(&configpb.CreatePolicyRequest{
 			Policy: &configpb.Policy{
 				NamespaceId: new("namespace-bravo"),

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -1485,6 +1485,65 @@ func TestAPIReconciler_syncOneSecret(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("different namespace", func(t *testing.T) {
+		apiClient, k8sClient, r := setupReconciler(t)
+		r.namespaceID = new("namespace-bravo")
+		ctx := t.Context()
+
+		secret := secretTemplate.DeepCopy()
+		secret.Annotations = map[string]string{
+			apiKeyPairIDAnnotation: "existing-keypair-id",
+		}
+
+		// The policy already exists, but in a different namespace.
+		// If there is an existing keypair ID annotation present, but it cannot
+		// be retrieved, APIReconciler should create it as a new keypair.
+		apiClient.EXPECT().GetKeyPair(ctx, RequestEq(&configpb.GetKeyPairRequest{
+			Id: "existing-keypair-id",
+		})).Return(&connect.Response[configpb.GetKeyPairResponse]{
+			Msg: &configpb.GetKeyPairResponse{
+				KeyPair: &configpb.KeyPair{
+					OriginatorId: new("ingress-controller"),
+					Id:           new("existing-keypair-id"),
+					Name:         new("test-secret-1"),
+					NamespaceId:  new("namespace-alpha"),
+					Certificate:  []byte("cert-data"),
+					Key:          []byte("key-data"),
+				},
+			},
+		}, nil)
+
+		// The existing key pair should be deleted and a new key pair created in
+		// the new namespace.
+		apiClient.EXPECT().DeleteKeyPair(ctx, RequestEq(&configpb.DeleteKeyPairRequest{
+			Id: "existing-keypair-id",
+		})).Return(connect.NewResponse(&configpb.DeleteKeyPairResponse{}), nil)
+
+		apiClient.EXPECT().CreateKeyPair(ctx, RequestEq(&configpb.CreateKeyPairRequest{
+			KeyPair: &configpb.KeyPair{
+				OriginatorId: new("ingress-controller"),
+				Name:         new("test-secret-1"),
+				NamespaceId:  new("namespace-bravo"),
+				Certificate:  []byte("cert-data"),
+				Key:          []byte("key-data"),
+			},
+		})).Return(&connect.Response[configpb.CreateKeyPairResponse]{
+			Msg: &configpb.CreateKeyPairResponse{
+				KeyPair: &configpb.KeyPair{
+					Id: new("recreated-keypair-id"),
+					// rest of the data omitted (not currently read)
+				},
+			},
+		}, nil)
+
+		k8sClient.EXPECT().Patch(ctx, secret, gomock.Any()).Return(nil)
+
+		changed, err := r.syncOneSecret(ctx, secret)
+		assert.True(t, changed)
+		assert.NoError(t, err)
+		assert.Equal(t, "recreated-keypair-id", secret.Annotations[apiKeyPairIDAnnotation])
+	})
+
 	t.Run("patch error", func(t *testing.T) {
 		apiClient, k8sClient, r := setupReconciler(t)
 		ctx := t.Context()


### PR DESCRIPTION
## Summary

Add a new CLI option to specify the namespace to use when syncing via the unified API. For Pomerium Zero, this will allow us to sync to a specific cluster within an organization, rather than the default cluster. For Pomerium Enterprise, this will let us sync to a namespace or cluster other than the global namespace.

## Related issues

https://linear.app/pomerium/issue/ENG-4159/ingress-controller-api-sync-should-let-you-specify-which

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
