### PR TITLE
kustomize config for syncing to Pomerium Zero

### DIFF
--- a/config/zero/kustomization.yaml
+++ b/config/zero/kustomization.yaml
@@ -1,0 +1,30 @@
+namespace: pomerium
+commonLabels:
+  app.kubernetes.io/name: pomerium
+resources:
+  - ../default
+  - pomerium.yaml
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: POMERIUM_ZERO_API_USER
+          valueFrom:
+            secretKeyRef:
+              name: pomerium-zero-api-user
+              key: token
+      - op: replace
+        path: /spec/template/spec/containers/0/args/0
+        value: controller
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: '--sync-api-url=https://console.pomerium.app'
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: '--sync-api-token=$(POMERIUM_ZERO_API_USER)'
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: pomerium

--- a/config/zero/pomerium.yaml
+++ b/config/zero/pomerium.yaml
@@ -1,0 +1,6 @@
+apiVersion: ingress.pomerium.io/v1
+kind: Pomerium
+metadata:
+  name: global
+spec:
+  secrets: pomerium/bootstrap


### PR DESCRIPTION
## Summary

Add a config/zero kustomization to configure ingress-controller to sync to Pomerium Zero via the unified API. This requires the separate creation of a 'pomerium-zero-api-user' secret with an API User token.

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
