### PR TITLE
docs: standardize PROXY protocol capitalization

### DIFF
--- a/apis/ingress/v1/pomerium_types.go
+++ b/apis/ingress/v1/pomerium_types.go
@@ -342,7 +342,7 @@ type PomeriumSpec struct {
 	// Timeout specifies the <a href="https://www.pomerium.com/docs/reference/global-timeouts">global timeouts</a> for all routes.
 	Timeouts *Timeouts `json:"timeouts,omitempty"`
 
-	// UseProxyProtocol enables <a href="https://www.pomerium.com/docs/reference/use-proxy-protocol">Proxy Protocol</a> support.
+	// UseProxyProtocol enables <a href="https://www.pomerium.com/docs/reference/use-proxy-protocol">PROXY protocol</a> support.
 	UseProxyProtocol *bool `json:"useProxyProtocol,omitempty"`
 
 	// CodecType sets the <a href="https://www.pomerium.com/docs/reference/codec-type">Codec Type</a>.

--- a/config/crd/bases/ingress.pomerium.io_pomerium.yaml
+++ b/config/crd/bases/ingress.pomerium.io_pomerium.yaml
@@ -615,8 +615,8 @@ spec:
                     type: string
                 type: object
               useProxyProtocol:
-                description: UseProxyProtocol enables <a href="https://www.pomerium.com/docs/reference/use-proxy-protocol">Proxy
-                  Protocol</a> support.
+                description: UseProxyProtocol enables <a href="https://www.pomerium.com/docs/reference/use-proxy-protocol">PROXY
+                  protocol</a> support.
                 type: boolean
             required:
             - secrets

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -757,8 +757,8 @@ spec:
                     type: string
                 type: object
               useProxyProtocol:
-                description: UseProxyProtocol enables <a href="https://www.pomerium.com/docs/reference/use-proxy-protocol">Proxy
-                  Protocol</a> support.
+                description: UseProxyProtocol enables <a href="https://www.pomerium.com/docs/reference/use-proxy-protocol">PROXY
+                  protocol</a> support.
                 type: boolean
             required:
             - secrets

--- a/reference.md
+++ b/reference.md
@@ -355,7 +355,7 @@ PomeriumSpec defines Pomerium-specific configuration parameters.
                     <strong>boolean</strong>&#160;
                 </p>
                 <p>
-                    UseProxyProtocol enables <a href="https://www.pomerium.com/docs/reference/use-proxy-protocol">Proxy Protocol</a> support.
+                    UseProxyProtocol enables <a href="https://www.pomerium.com/docs/reference/use-proxy-protocol">PROXY protocol</a> support.
                 </p>
             </td>
         </tr>


### PR DESCRIPTION
## Summary
- Standardize the Pomerium CRD `UseProxyProtocol` docs text to `PROXY protocol`.
- Regenerate CRD, deployment, and reference output from the API comment source.

## Validation
- `make generate`
- `make build`
- `./bin/golangci-lint run --timeout=10m ./...`
- `make test` ran; most packages passed, but two Envoy-backed tests were killed locally with `signal: killed`.
- Reran the killed packages serially: `go test -tags embed_pomerium -p 1 ./pomerium ./pomerium/envoy` passed.

## AI Assistance
AI drafted the capitalization cleanup, regenerated outputs, and ran validation. I reviewed the diffs and accepted only the generated text changes.
