### PR TITLE
ci: update Go toolchain to 1.26.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 golangci-lint 2.12.2
-golang 1.26.4
+golang 1.26.5
 nodejs 24.15.0
 kustomize 5.8.1


### PR DESCRIPTION
## What

This updates the 0-33-0 Ingress Controller release branch to build with Go 1.26.5.

## Why

Ingress Controller main is already patched. The active release branch still selected Go 1.26.4 and needs the same security update for release artifacts.

## Testing

A full local compile requires generated Envoy assets that are absent from a fresh macOS worktree. CI provisions those assets; this PR changes only the exact toolchain pin.

## Related issue

- [ENG-4243](https://linear.app/pomerium/issue/ENG-4243)

## AI assistance

Codex made the toolchain-only edit and verified the release-branch scope. Bobby directed the scope.