### PR TITLE
cmd: add zero-managed mode to all-in-one command

### DIFF
--- a/apis/ingress/v1/pomerium_types.go
+++ b/apis/ingress/v1/pomerium_types.go
@@ -321,7 +321,7 @@ type PomeriumSpec struct {
 	// raw strings, while <code>data.signing_key</code> is base64-encoded.
 	// </p>
 	//
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Format="namespace/name"

--- a/cmd/all_in_one.go
+++ b/cmd/all_in_one.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/health"
 	"github.com/pomerium/pomerium/pkg/netutil"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
+	zero_cmd "github.com/pomerium/pomerium/pkg/zero/cmd"
 )
 
 type allCmdOptions struct {
@@ -59,6 +60,7 @@ type allCmdOptions struct {
 	grpcAddr           string   `validate:"required,hostname_port"`
 	services           []string `validate:"dive,oneof=all authenticate authorize databroker proxy"`
 	syncAPIIngress     string
+	zeroToken          string
 
 	CertificateControllerOptions certificateControllerOptions
 	DataBrokerOptions            dataBrokerOptions
@@ -70,10 +72,13 @@ type allCmdParam struct {
 	gatewayConfig           *gateway.ControllerConfig
 	updateStatusFromService string
 	dumpConfigDiff          bool
+	leaderElectionID        string
+	leaderElectionNamespace string
 	syncAPIURL              string
 	syncAPINamespaceID      string
 	syncAPIToken            string
 	syncAPIBootstrap        bool
+	zeroToken               string
 
 	// bootstrapMetricsAddr for bootstrap configuration controller metrics
 	bootstrapMetricsAddr string
@@ -148,6 +153,7 @@ func (s *allCmd) setupFlags() error {
 	flags.StringVar(&s.grpcAddr, "grpc-addr", ":5443", "the address the gRPC server would bind to")
 	flags.StringSliceVar(&s.services, "services", []string{"all"}, "the pomerium services to run")
 	flags.StringVar(&s.syncAPIIngress, syncAPIIngress, "", "unified API sync ingress")
+	flags.StringVar(&s.zeroToken, "pomerium-zero-token", "", "Pomerium Zero cluster token")
 
 	for _, flag := range hidden {
 		if err := s.PersistentFlags().MarkHidden(flag); err != nil {
@@ -208,10 +214,13 @@ func (s *allCmdOptions) getParam(ctx context.Context) (*allCmdParam, error) {
 		updateStatusFromService:         s.UpdateStatusFromService,
 		dumpConfigDiff:                  s.debugDumpConfigDiff,
 		configControllerShutdownTimeout: s.configControllerShutdownTimeout,
+		leaderElectionID:                s.LeaderElectionID,
+		leaderElectionNamespace:         s.LeaderElectionNamespace,
 		syncAPIURL:                      s.SyncAPIURL,
 		syncAPINamespaceID:              s.SyncAPINamespaceID,
 		syncAPIToken:                    s.SyncAPIToken,
 		syncAPIBootstrap:                s.syncAPIIngress != "",
+		zeroToken:                       s.zeroToken,
 		certificateControllerName:       s.CertificateControllerOptions.Name,
 	}
 	if err := p.makeBootstrapConfig(ctx, *s); err != nil {
@@ -222,6 +231,30 @@ func (s *allCmdOptions) getParam(ctx context.Context) (*allCmdParam, error) {
 }
 
 func (s *allCmdParam) run(ctx context.Context) error {
+	if s.zeroToken != "" {
+		// Run Pomerium Core in Zero-managed mode.
+		return s.runZeroManagedPomerium(ctx)
+	}
+
+	// Run Pomerium Core using the bootstrap config source.
+	return s.runBootstrappedPomerium(ctx)
+}
+
+func (s *allCmdParam) runZeroManagedPomerium(ctx context.Context) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return runHealthz(ctx, s.cfg.Options.HealthCheckAddr)
+	})
+	eg.Go(func() error {
+		return zero_cmd.Run(ctx, s.zeroToken)
+	})
+	eg.Go(func() error {
+		return s.runConfigControllers(ctx, config.New(config.NewDefaultOptions()))
+	})
+	return eg.Wait()
+}
+
+func (s *allCmdParam) runBootstrappedPomerium(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -420,25 +453,8 @@ func (s *allCmdParam) buildController(ctx context.Context, cfg *config.Config) (
 	}
 
 	client := databroker.NewDataBrokerServiceClient(conn)
-	var reconciler pomerium.Reconciler
-	if s.syncAPIURL != "" {
-		var dialAddressOverride string
-		if s.syncAPIBootstrap {
-			_, port, err := net.SplitHostPort(s.cfg.Options.Addr)
-			if err != nil {
-				return nil, fmt.Errorf("couldn't get server address port: %w", err)
-			}
-			dialAddressOverride = net.JoinHostPort("localhost", port)
-		}
-		reconciler, err = pomerium.NewAPIReconciler(s.syncAPIURL, s.syncAPINamespaceID, s.syncAPIToken, s.cfg.Options, dialAddressOverride)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		reconciler = pomerium.NewDataBrokerReconciler(client, s.dumpConfigDiff)
-	}
+
 	c := &controllers.Controller{
-		Reconciler:              reconciler,
 		DataBrokerServiceClient: client,
 		MgrOpts: runtime_ctrl.Options{
 			Scheme: scheme,
@@ -454,6 +470,31 @@ func (s *allCmdParam) buildController(ctx context.Context, cfg *config.Config) (
 		GlobalSettings:            &s.settings,
 		GatewayControllerConfig:   s.gatewayConfig,
 		CertificateControllerName: s.certificateControllerName,
+	}
+
+	if s.syncAPIURL != "" {
+		var dialAddressOverride string
+		if s.syncAPIBootstrap {
+			_, port, err := net.SplitHostPort(s.cfg.Options.Addr)
+			if err != nil {
+				return nil, fmt.Errorf("couldn't get server address port: %w", err)
+			}
+			dialAddressOverride = net.JoinHostPort("localhost", port)
+		}
+		c.Reconciler, err = pomerium.NewAPIReconciler(s.syncAPIURL, s.syncAPINamespaceID, s.syncAPIToken, s.cfg.Options, dialAddressOverride)
+		if err != nil {
+			return nil, err
+		}
+
+		if s.zeroToken != "" {
+			// If running Core in Zero-managed mode, we may not be able to rely
+			// on taking a databroker lease.
+			c.MgrOpts.LeaderElection = true
+			c.MgrOpts.LeaderElectionID = s.leaderElectionID
+			c.MgrOpts.LeaderElectionNamespace = s.leaderElectionNamespace
+		}
+	} else {
+		c.Reconciler = pomerium.NewDataBrokerReconciler(client, s.dumpConfigDiff)
 	}
 
 	return c, nil

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -34,9 +34,6 @@ type controllerCmd struct {
 	tlsInsecureSkipVerify      bool
 	tlsOverrideCertificateName string
 
-	leaderElectionID        string
-	leaderElectionNamespace string
-
 	sharedSecret string
 
 	debug bool
@@ -66,8 +63,6 @@ const (
 	databrokerTLSCA            = "databroker-tls-ca"
 	tlsInsecureSkipVerify      = "databroker-tls-insecure-skip-verify"
 	tlsOverrideCertificateName = "databroker-tls-override-certificate-name"
-	leaderElectionID           = "leader-election-id"
-	leaderElectionNamespace    = "leader-election-namespace"
 )
 
 func (s *controllerCmd) setupFlags() error {
@@ -82,8 +77,6 @@ func (s *controllerCmd) setupFlags() error {
 		"disable remote hosts TLS certificate chain and hostname check for the databroker connection")
 	flags.StringVar(&s.tlsOverrideCertificateName, tlsOverrideCertificateName, "",
 		"override the certificate name used for the databroker connection")
-	flags.StringVar(&s.leaderElectionID, leaderElectionID, "pomerium-ingress-controller", "leader election lease name")
-	flags.StringVar(&s.leaderElectionNamespace, leaderElectionNamespace, "", "leader election lease namespace")
 
 	flags.StringVar(&s.sharedSecret, sharedSecret, "",
 		"base64-encoded shared secret for signing JWTs")
@@ -174,8 +167,8 @@ func (s *controllerCmd) buildController(ctx context.Context) (*controllers.Contr
 			return nil, err
 		}
 		c.MgrOpts.LeaderElection = true
-		c.MgrOpts.LeaderElectionID = s.leaderElectionID
-		c.MgrOpts.LeaderElectionNamespace = s.leaderElectionNamespace
+		c.MgrOpts.LeaderElectionID = s.LeaderElectionID
+		c.MgrOpts.LeaderElectionNamespace = s.LeaderElectionNamespace
 		return c, nil
 	} else if f := s.Flags(); f.Changed(leaderElectionID) || f.Changed(leaderElectionNamespace) {
 		return nil, fmt.Errorf("kubernetes leader election can be used only with sync API")

--- a/cmd/ingress_opts.go
+++ b/cmd/ingress_opts.go
@@ -21,6 +21,8 @@ type ingressControllerOpts struct {
 	Namespaces              []string
 	UpdateStatusFromService string ``
 	GlobalSettings          string `validate:"required"`
+	LeaderElectionID        string
+	LeaderElectionNamespace string
 	SyncAPIURL              string
 	SyncAPINamespaceID      string
 	SyncAPIToken            string
@@ -39,6 +41,8 @@ const (
 	syncAPIURL                 = "sync-api-url"
 	syncAPINamespaceID         = "sync-api-namespace-id"
 	syncAPIToken               = "sync-api-token" //nolint:gosec
+	leaderElectionID           = "leader-election-id"
+	leaderElectionNamespace    = "leader-election-namespace"
 )
 
 func (s *ingressControllerOpts) setupFlags(flags *pflag.FlagSet) {
@@ -53,6 +57,8 @@ func (s *ingressControllerOpts) setupFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&s.SyncAPIURL, syncAPIURL, "", "unified API sync URL")
 	flags.StringVar(&s.SyncAPINamespaceID, syncAPINamespaceID, "", "unified API sync namespace ID")
 	flags.StringVar(&s.SyncAPIToken, syncAPIToken, "", "unified API sync token")
+	flags.StringVar(&s.LeaderElectionID, leaderElectionID, "pomerium-ingress-controller", "leader election lease name")
+	flags.StringVar(&s.LeaderElectionNamespace, leaderElectionNamespace, "", "leader election lease namespace")
 }
 
 func (s *ingressControllerOpts) Validate() error {

--- a/config/crd/bases/ingress.pomerium.io_pomerium.yaml
+++ b/config/crd/bases/ingress.pomerium.io_pomerium.yaml
@@ -624,8 +624,6 @@ spec:
                 description: UseProxyProtocol enables <a href="https://www.pomerium.com/docs/reference/use-proxy-protocol">PROXY
                   protocol</a> support.
                 type: boolean
-            required:
-            - secrets
             type: object
             x-kubernetes-validations:
             - fieldPath: .authenticate

--- a/controllers/settings/fetch.go
+++ b/controllers/settings/fetch.go
@@ -105,7 +105,7 @@ func fetchConfigSecrets(ctx context.Context, client client.Client, cfg *model.Co
 	s := cfg.Spec
 	return applyAll(
 		// bootstrap secrets
-		apply("bootstrap secret", required(&s.Secrets), &cfg.Secrets),
+		apply("bootstrap secret", optional(&s.Secrets), &cfg.Secrets),
 		// ca secrets
 		func() error {
 			for _, caSecret := range s.CASecrets {

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -766,8 +766,6 @@ spec:
                 description: UseProxyProtocol enables <a href="https://www.pomerium.com/docs/reference/use-proxy-protocol">PROXY
                   protocol</a> support.
                 type: boolean
-            required:
-            - secrets
             type: object
             x-kubernetes-validations:
             - fieldPath: .authenticate

--- a/go.mod
+++ b/go.mod
@@ -191,6 +191,7 @@ require (
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.2 // indirect
@@ -303,6 +304,8 @@ require (
 	go.opentelemetry.io/contrib/propagators/jaeger v1.44.0 // indirect
 	go.opentelemetry.io/contrib/propagators/ot v1.44.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
+	go.opentelemetry.io/otel/bridge/opencensus v1.44.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -572,6 +572,8 @@ github.com/gosimple/unidecode v1.0.1 h1:hZzFTMMqSswvf0LBJZCZgThIZrpDHFXux9KeGmn6
 github.com/gosimple/unidecode v1.0.1/go.mod h1:CP0Cr1Y1kogOtx0bJblKzsVWrqYaqfNOnHzpgWw4Awc=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 h1:B+8ClL/kCQkRiU82d9xajRPKYMrB7E0MbtzWVi1K4ns=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3/go.mod h1:NbCUVmiS4foBGBHOYlCT25+YmGpJ32dZPi75pGEUpj4=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -1025,6 +1027,10 @@ go.opentelemetry.io/contrib/propagators/ot v1.44.0 h1:JLTPenzmPtLp5ODPntAA5JhxVu
 go.opentelemetry.io/contrib/propagators/ot v1.44.0/go.mod h1:8zr0bHgwkoQXucBK39/H4QphmLf1lSen1Z7FPDZD5Uc=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
+go.opentelemetry.io/otel/bridge/opencensus v1.44.0 h1:yTmzt6ADCszaKbyrHGC2fK+khPcZSy6PGZ0h/QIfVj0=
+go.opentelemetry.io/otel/bridge/opencensus v1.44.0/go.mod h1:S7ZRuvEu5x0FX0t+6PRz0g7J06q0mLJ0PAYMJ1B6BWY=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 h1:SUplec5dp06reu1zaXmOXdvqH398taqrDXqUl99jxSc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0/go.mod h1:ho2g4N+ane+swq5I/VBkKWnRDY4kUINH3FuqyZqX/Ug=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 h1:4YsVu3B8+3qtWYYrsUYgn0OG78pN0rnNPRGX4SbokQI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0/go.mod h1:+wnlSn0mD1ADVMe3v9Z/WIaiz6q6gL2J/ejaAmdmv80=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 h1:qazEJlUOQzhCpzQpFETGby7EdqjI1wsd0W+6Gg1SCTU=

--- a/main.go
+++ b/main.go
@@ -8,6 +8,8 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
+	_ "github.com/pomerium/pomerium/pkg/zero/bootstrapwriters/k8s"
+
 	"github.com/pomerium/ingress-controller/cmd"
 	_ "github.com/pomerium/ingress-controller/internal"
 )

--- a/pomerium/ctrl/bootstrap.go
+++ b/pomerium/ctrl/bootstrap.go
@@ -187,7 +187,7 @@ func applyStoragePostgres(dst *config.Options, src *model.Config) error {
 
 func applySecrets(_ context.Context, dst *config.Options, src *model.Config) error {
 	if src.Secrets == nil {
-		return fmt.Errorf("secrets missing, this is a bug")
+		return fmt.Errorf("bootstrap secrets missing")
 	}
 
 	name := types.NamespacedName{Name: src.Secrets.Name, Namespace: src.Secrets.Namespace}


### PR DESCRIPTION
## Summary

Add a new flag `--pomerium-zero-token` to the all-in-one command. When this flag is provided, ingress-controller will launch Core in the Zero-managed mode using the given token.

In this mode, we can't directly configure a health check listener in Core, so run a separate no-op /readyz check handler in addition to the main Zero-managed mode entry point.

Also, in this mode the bootstrap secrets are not required, so change the `Secrets` field of the Pomerium CRD from required to optional. This does come at a cost for the regular (non-Zero) mode: if you try to save the CRD without the bootstrap secrets, before you would get a validation error from the kube-apiserver and now you would get a runtime error from ingress-controller.

## Related issues

https://linear.app/pomerium/issue/ENG-4170/ingress-controller-as-the-default-install-path-for-zerokubernetes-post

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
