### PR TITLE
fix(sync): bound full-state ingress reconciliation latency

### DIFF
--- a/cmd/ingress_opts.go
+++ b/cmd/ingress_opts.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	validate "github.com/go-playground/validator/v10"
 	"github.com/spf13/pflag"
@@ -19,8 +20,10 @@ type ingressControllerOpts struct {
 	GatewayClassName        string `validate:"required"`
 	AnnotationPrefix        string `validate:"required"`
 	Namespaces              []string
-	UpdateStatusFromService string ``
-	GlobalSettings          string `validate:"required"`
+	UpdateStatusFromService string        ``
+	GlobalSettings          string        `validate:"required"`
+	ReconcileBatchWindow    time.Duration `validate:"gte=0"`
+	ReconcileBatchMaxWait   time.Duration `validate:"gte=0"`
 }
 
 const (
@@ -32,6 +35,8 @@ const (
 	sharedSecret               = "shared-secret"
 	updateStatusFromService    = "update-status-from-service"
 	globalSettings             = "pomerium-config"
+	reconcileBatchWindow       = "reconcile-batch-window"
+	reconcileBatchMaxWait      = "reconcile-batch-max-wait"
 )
 
 func (s *ingressControllerOpts) setupFlags(flags *pflag.FlagSet) {
@@ -43,10 +48,20 @@ func (s *ingressControllerOpts) setupFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&s.UpdateStatusFromService, updateStatusFromService, "", "update ingress status from given service status (pomerium-proxy)")
 	flags.StringVar(&s.GlobalSettings, globalSettings, "",
 		fmt.Sprintf("namespace/name to a resource of type %s/Settings", icsv1.GroupVersion.Group))
+	flags.DurationVar(&s.ReconcileBatchWindow, reconcileBatchWindow, 0,
+		"wait for this quiet period before applying real ingress changes as one batch (disabled by default)")
+	flags.DurationVar(&s.ReconcileBatchMaxWait, reconcileBatchMaxWait, 5*time.Second,
+		"maximum time to delay a batch while ingress changes continue arriving")
 }
 
 func (s *ingressControllerOpts) Validate() error {
-	return validate.New().Struct(s)
+	if err := validate.New().Struct(s); err != nil {
+		return err
+	}
+	if s.ReconcileBatchWindow > 0 && s.ReconcileBatchMaxWait < s.ReconcileBatchWindow {
+		return fmt.Errorf("--%s must be greater than or equal to --%s", reconcileBatchMaxWait, reconcileBatchWindow)
+	}
+	return nil
 }
 
 func (s *ingressControllerOpts) getGlobalSettings() (*types.NamespacedName, error) {
@@ -66,6 +81,12 @@ func (s *ingressControllerOpts) getIngressControllerOptions() ([]ingress.Option,
 		ingress.WithNamespaces(s.Namespaces),
 		ingress.WithAnnotationPrefix(s.AnnotationPrefix),
 		ingress.WithControllerName(s.ClassName),
+	}
+	if s.ReconcileBatchWindow > 0 {
+		opts = append(opts, ingress.WithAdaptiveReconcileBatching(
+			s.ReconcileBatchWindow,
+			s.ReconcileBatchMaxWait,
+		))
 	}
 	if name, err := s.getGlobalSettings(); err != nil {
 		return nil, err

--- a/cmd/ingress_opts_batch_test.go
+++ b/cmd/ingress_opts_batch_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIngressControllerOptsAdaptiveBatchFlags(t *testing.T) {
+	var opts ingressControllerOpts
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	opts.setupFlags(flags)
+	require.NoError(t, flags.Parse([]string{
+		"--reconcile-batch-window=1s",
+		"--reconcile-batch-max-wait=5s",
+	}))
+	opts.GlobalSettings = "default/pomerium"
+	require.NoError(t, opts.Validate())
+	assert.Equal(t, time.Second, opts.ReconcileBatchWindow)
+	assert.Equal(t, 5*time.Second, opts.ReconcileBatchMaxWait)
+}
+
+func TestIngressControllerOptsRejectsBatchMaxWaitBelowWindow(t *testing.T) {
+	var opts ingressControllerOpts
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	opts.setupFlags(flags)
+	require.NoError(t, flags.Parse([]string{
+		"--reconcile-batch-window=5s",
+		"--reconcile-batch-max-wait=1s",
+	}))
+	opts.GlobalSettings = "default/pomerium"
+	require.ErrorContains(t, opts.Validate(), "--reconcile-batch-max-wait")
+}

--- a/config/pomerium/deployment/base.yaml
+++ b/config/pomerium/deployment/base.yaml
@@ -15,5 +15,11 @@ spec:
     spec:
       containers:
         - name: pomerium
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /busybox/sleep
+                  - "30"
       serviceAccountName: pomerium-controller
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 60

--- a/controllers/ingress/batch_coordinator.go
+++ b/controllers/ingress/batch_coordinator.go
@@ -1,0 +1,253 @@
+package ingress
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	reconcileBatchSignals = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "pomerium_ingress_reconcile_batch_signals_total",
+		Help: "Number of Kubernetes change signals observed by the adaptive ingress batcher.",
+	}, []string{"source"})
+	reconcileBatchFlushes = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "pomerium_ingress_reconcile_batch_flushes_total",
+		Help: "Number of adaptive ingress batch flushes.",
+	}, []string{"result"})
+	reconcileBatchSize = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "pomerium_ingress_reconcile_batch_size",
+		Help:    "Number of change signals coalesced into an ingress batch.",
+		Buckets: prometheus.ExponentialBuckets(1, 2, 12),
+	})
+	reconcileBatchFlushDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "pomerium_ingress_reconcile_batch_flush_duration_seconds",
+		Help:    "Time spent applying an adaptive ingress batch.",
+		Buckets: prometheus.DefBuckets,
+	})
+	reconcileBatchRetries = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "pomerium_ingress_reconcile_batch_retries_total",
+		Help: "Number of ingress batch flushes attempted after a failed flush.",
+	})
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		reconcileBatchSignals,
+		reconcileBatchFlushes,
+		reconcileBatchSize,
+		reconcileBatchFlushDuration,
+		reconcileBatchRetries,
+	)
+}
+
+type batchFlushFunc func(context.Context) error
+
+type batchWaiter struct {
+	sequence uint64
+	result   chan error
+}
+
+// reconcileBatchCoordinator implements trailing-edge batching outside of
+// Reconcile. Informer events can keep extending the quiet period even while a
+// reconcile request waits for its configuration to be applied.
+type reconcileBatchCoordinator struct {
+	quietPeriod time.Duration
+	maxWait     time.Duration
+	flush       batchFlushFunc
+
+	mu              sync.Mutex
+	sequence        uint64
+	pending         bool
+	firstSignal     time.Time
+	lastSignal      time.Time
+	pendingSignals  int
+	waiters         []batchWaiter
+	lastFlushFailed bool
+	wake            chan struct{}
+}
+
+func newReconcileBatchCoordinator(
+	quietPeriod time.Duration,
+	maxWait time.Duration,
+	flush batchFlushFunc,
+) *reconcileBatchCoordinator {
+	if maxWait < quietPeriod {
+		maxWait = quietPeriod
+	}
+	return &reconcileBatchCoordinator{
+		quietPeriod: quietPeriod,
+		maxWait:     maxWait,
+		flush:       flush,
+		wake:        make(chan struct{}, 1),
+	}
+}
+
+// NeedLeaderElection keeps the batch writer on the same elected replica as
+// the ingress controller.
+func (*reconcileBatchCoordinator) NeedLeaderElection() bool { return true }
+
+// Signal records an informer event without blocking its handler.
+func (c *reconcileBatchCoordinator) Signal(source string) {
+	c.mu.Lock()
+	c.signalLocked(time.Now())
+	c.mu.Unlock()
+	reconcileBatchSignals.WithLabelValues(source).Inc()
+	c.notify()
+}
+
+// Submit records a real change detected by Reconcile and waits for the batch
+// containing it to finish. A failed flush is returned to controller-runtime so
+// its normal rate-limited retry behavior remains intact.
+func (c *reconcileBatchCoordinator) Submit(ctx context.Context) error {
+	waiter := batchWaiter{result: make(chan error, 1)}
+	c.mu.Lock()
+	c.signalLocked(time.Now())
+	waiter.sequence = c.sequence
+	c.waiters = append(c.waiters, waiter)
+	c.mu.Unlock()
+	reconcileBatchSignals.WithLabelValues("reconcile").Inc()
+	c.notify()
+
+	select {
+	case err := <-waiter.result:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *reconcileBatchCoordinator) signalLocked(now time.Time) {
+	c.sequence++
+	if !c.pending {
+		c.pending = true
+		c.firstSignal = now
+		c.pendingSignals = 0
+	}
+	c.lastSignal = now
+	c.pendingSignals++
+}
+
+func (c *reconcileBatchCoordinator) notify() {
+	select {
+	case c.wake <- struct{}{}:
+	default:
+	}
+}
+
+// Start processes one full-state write at a time. Signals received during a
+// write form the next batch instead of starting a concurrent Set call.
+func (c *reconcileBatchCoordinator) Start(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName("adaptive-ingress-batcher")
+	logger.Info("starting", "quiet-period", c.quietPeriod, "max-wait", c.maxWait)
+	defer c.finishWaiters(ctx.Err())
+
+	for {
+		deadline, ok := c.deadline()
+		if !ok {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-c.wake:
+				continue
+			}
+		}
+		if !deadline.After(time.Now()) {
+			c.flushPending(ctx)
+			continue
+		}
+
+		timer := time.NewTimer(time.Until(deadline))
+		select {
+		case <-ctx.Done():
+			stopTimer(timer)
+			return nil
+		case <-c.wake:
+			stopTimer(timer)
+			continue
+		case <-timer.C:
+			c.flushPending(ctx)
+		}
+	}
+}
+
+func (c *reconcileBatchCoordinator) deadline() (time.Time, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.pending {
+		return time.Time{}, false
+	}
+	quietDeadline := c.lastSignal.Add(c.quietPeriod)
+	maxDeadline := c.firstSignal.Add(c.maxWait)
+	if maxDeadline.Before(quietDeadline) {
+		return maxDeadline, true
+	}
+	return quietDeadline, true
+}
+
+func (c *reconcileBatchCoordinator) flushPending(ctx context.Context) {
+	c.mu.Lock()
+	if !c.pending {
+		c.mu.Unlock()
+		return
+	}
+	sequence := c.sequence
+	size := c.pendingSignals
+	retry := c.lastFlushFailed
+	c.pending = false
+	c.pendingSignals = 0
+	c.mu.Unlock()
+
+	if retry {
+		reconcileBatchRetries.Inc()
+	}
+	started := time.Now()
+	err := c.flush(ctx)
+	reconcileBatchFlushDuration.Observe(time.Since(started).Seconds())
+	reconcileBatchSize.Observe(float64(size))
+	result := "success"
+	if err != nil {
+		result = "error"
+	}
+	reconcileBatchFlushes.WithLabelValues(result).Inc()
+
+	c.mu.Lock()
+	c.lastFlushFailed = err != nil
+	remaining := c.waiters[:0]
+	for _, waiter := range c.waiters {
+		if waiter.sequence <= sequence {
+			waiter.result <- err
+			close(waiter.result)
+		} else {
+			remaining = append(remaining, waiter)
+		}
+	}
+	c.waiters = remaining
+	c.mu.Unlock()
+}
+
+func (c *reconcileBatchCoordinator) finishWaiters(err error) {
+	if err == nil {
+		err = context.Canceled
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, waiter := range c.waiters {
+		waiter.result <- err
+		close(waiter.result)
+	}
+	c.waiters = nil
+}
+
+func stopTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}

--- a/controllers/ingress/batch_coordinator.go
+++ b/controllers/ingress/batch_coordinator.go
@@ -144,7 +144,9 @@ func (c *reconcileBatchCoordinator) notify() {
 func (c *reconcileBatchCoordinator) Start(ctx context.Context) error {
 	logger := log.FromContext(ctx).WithName("adaptive-ingress-batcher")
 	logger.Info("starting", "quiet-period", c.quietPeriod, "max-wait", c.maxWait)
-	defer c.finishWaiters(ctx.Err())
+	defer func() {
+		c.finishWaiters(ctx.Err())
+	}()
 
 	for {
 		deadline, ok := c.deadline()

--- a/controllers/ingress/batch_coordinator_test.go
+++ b/controllers/ingress/batch_coordinator_test.go
@@ -119,3 +119,17 @@ func TestReconcileBatchCoordinatorReturnsFailureAndRetries(t *testing.T) {
 	require.NoError(t, c.Submit(context.Background()))
 	assert.Equal(t, int32(2), calls.Load())
 }
+
+func TestReconcileBatchCoordinatorPreservesShutdownError(t *testing.T) {
+	c := newReconcileBatchCoordinator(time.Hour, time.Hour, func(context.Context) error {
+		return nil
+	})
+	result := make(chan error, 1)
+	c.waiters = append(c.waiters, batchWaiter{result: result})
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	require.NoError(t, c.Start(ctx))
+
+	assert.ErrorIs(t, <-result, context.DeadlineExceeded)
+}

--- a/controllers/ingress/batch_coordinator_test.go
+++ b/controllers/ingress/batch_coordinator_test.go
@@ -1,0 +1,121 @@
+package ingress
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func startBatchCoordinator(t *testing.T, c *reconcileBatchCoordinator) context.CancelFunc {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, <-done)
+	})
+	return cancel
+}
+
+func TestReconcileBatchCoordinatorCoalescesBurstAfterQuietPeriod(t *testing.T) {
+	var calls atomic.Int32
+	flushed := make(chan time.Time, 2)
+	c := newReconcileBatchCoordinator(30*time.Millisecond, 200*time.Millisecond, func(context.Context) error {
+		calls.Add(1)
+		flushed <- time.Now()
+		return nil
+	})
+	startBatchCoordinator(t, c)
+
+	c.Signal("test")
+	time.Sleep(15 * time.Millisecond)
+	c.Signal("test")
+	lastSignal := time.Now()
+	time.Sleep(15 * time.Millisecond)
+	c.Signal("test")
+	lastSignal = time.Now()
+
+	select {
+	case at := <-flushed:
+		assert.GreaterOrEqual(t, at.Sub(lastSignal), 25*time.Millisecond)
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("batch did not flush")
+	}
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestReconcileBatchCoordinatorBoundsContinuousEvents(t *testing.T) {
+	flushed := make(chan time.Time, 2)
+	c := newReconcileBatchCoordinator(40*time.Millisecond, 90*time.Millisecond, func(context.Context) error {
+		flushed <- time.Now()
+		return nil
+	})
+	startBatchCoordinator(t, c)
+
+	started := time.Now()
+	for i := 0; i < 8; i++ {
+		c.Signal("test")
+		time.Sleep(15 * time.Millisecond)
+	}
+
+	select {
+	case at := <-flushed:
+		assert.Less(t, at.Sub(started), 150*time.Millisecond)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("continuous events postponed the batch beyond maxWait")
+	}
+}
+
+func TestReconcileBatchCoordinatorSerializesFlushes(t *testing.T) {
+	var active atomic.Int32
+	var maxActive atomic.Int32
+	started := make(chan struct{}, 2)
+	release := make(chan struct{}, 2)
+	c := newReconcileBatchCoordinator(time.Millisecond, 10*time.Millisecond, func(context.Context) error {
+		current := active.Add(1)
+		for {
+			maximum := maxActive.Load()
+			if current <= maximum || maxActive.CompareAndSwap(maximum, current) {
+				break
+			}
+		}
+		started <- struct{}{}
+		<-release
+		active.Add(-1)
+		return nil
+	})
+	startBatchCoordinator(t, c)
+
+	c.Signal("test")
+	require.Eventually(t, func() bool { return len(started) == 1 }, time.Second, time.Millisecond)
+	c.Signal("test")
+	time.Sleep(20 * time.Millisecond)
+	assert.Equal(t, 1, len(started), "a second flush must not overlap the first")
+	release <- struct{}{}
+	require.Eventually(t, func() bool { return len(started) == 2 }, time.Second, time.Millisecond)
+	release <- struct{}{}
+	assert.Equal(t, int32(1), maxActive.Load())
+}
+
+func TestReconcileBatchCoordinatorReturnsFailureAndRetries(t *testing.T) {
+	temporary := errors.New("temporary failure")
+	var calls atomic.Int32
+	c := newReconcileBatchCoordinator(time.Millisecond, 10*time.Millisecond, func(context.Context) error {
+		if calls.Add(1) == 1 {
+			return temporary
+		}
+		return nil
+	})
+	startBatchCoordinator(t, c)
+
+	err := c.Submit(context.Background())
+	require.ErrorIs(t, err, temporary)
+	require.NoError(t, c.Submit(context.Background()))
+	assert.Equal(t, int32(2), calls.Load())
+}

--- a/controllers/ingress/batch_events.go
+++ b/controllers/ingress/batch_events.go
@@ -1,0 +1,51 @@
+package ingress
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func (r *ingressController) batchSignalPredicate(source string) predicate.Predicate {
+	if r.batchCoordinator == nil {
+		return predicate.Funcs{}
+	}
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			r.batchCoordinator.Signal(source)
+			return true
+		},
+		UpdateFunc: func(event.UpdateEvent) bool {
+			r.batchCoordinator.Signal(source)
+			return true
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			r.batchCoordinator.Signal(source)
+			return true
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			r.batchCoordinator.Signal(source)
+			return true
+		},
+	}
+}
+
+func (r *ingressController) batchSignalMap(
+	source string,
+	mapper handler.MapFunc,
+) handler.MapFunc {
+	if r.batchCoordinator == nil {
+		return mapper
+	}
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		requests := mapper(ctx, obj)
+		if len(requests) > 0 {
+			r.batchCoordinator.Signal(source)
+		}
+		return requests
+	}
+}

--- a/controllers/ingress/batch_reconcile.go
+++ b/controllers/ingress/batch_reconcile.go
@@ -1,0 +1,82 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/pomerium/ingress-controller/model"
+)
+
+func (r *ingressController) flushReconcileBatch(ctx context.Context) error {
+	if err := r.initComplete.yield(ctx); err != nil {
+		return fmt.Errorf("initial reconciliation: %w", err)
+	}
+	_, err := r.reconcileAll(ctx)
+	return err
+}
+
+func (r *ingressController) reconcileBatched(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ingress := new(networkingv1.Ingress)
+	if err := r.Client.Get(ctx, req.NamespacedName, ingress); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{Requeue: true}, fmt.Errorf("get ingress: %w", err)
+		}
+		return r.reconcileBatchedDelete(ctx, req.NamespacedName, reasonIngressDeleted)
+	} else if ingress.DeletionTimestamp != nil {
+		return r.reconcileBatchedDelete(ctx, req.NamespacedName, reasonIngressDeleted)
+	}
+
+	managing, err := r.isManaging(ctx, ingress)
+	if err != nil {
+		return ctrl.Result{Requeue: true}, fmt.Errorf("get ingressClass info: %w", err)
+	}
+	if !managing.managed {
+		return r.reconcileBatchedDelete(ctx, req.NamespacedName, managing.reasonIfNot)
+	}
+
+	ic, err := r.fetchIngress(ctx, ingress)
+	if err != nil {
+		r.IngressNotReconciled(ctx, ingress, err)
+		return ctrl.Result{Requeue: true}, fmt.Errorf("fetch ingress related resources: %w", err)
+	}
+
+	needsUpdate, err := r.ingressChangeDetector.NeedsIngressUpdate(ic)
+	if err != nil {
+		return ctrl.Result{Requeue: true}, fmt.Errorf("detect ingress change: %w", err)
+	}
+	if needsUpdate {
+		if err := r.batchCoordinator.Submit(ctx); err != nil {
+			r.IngressNotReconciled(ctx, ingress, err)
+			return ctrl.Result{Requeue: true}, fmt.Errorf("apply ingress batch: %w", err)
+		}
+	}
+
+	statusChanged, err := r.updateIngressStatus(ctx, ingress)
+	if err != nil {
+		return ctrl.Result{Requeue: true}, fmt.Errorf("update ingress status: %w", err)
+	}
+	if needsUpdate || statusChanged {
+		r.IngressReconciled(ctx, ingress)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ingressController) reconcileBatchedDelete(
+	ctx context.Context,
+	name types.NamespacedName,
+	reason string,
+) (ctrl.Result, error) {
+	if r.ingressChangeDetector.TracksIngress(name) {
+		if err := r.batchCoordinator.Submit(ctx); err != nil {
+			return ctrl.Result{Requeue: true}, fmt.Errorf("apply ingress deletion batch: %w", err)
+		}
+		r.IngressDeleted(ctx, name, reason)
+	}
+	r.DeleteCascade(model.Key{Kind: r.ingressKind, NamespacedName: name})
+	return ctrl.Result{}, nil
+}

--- a/controllers/ingress/batch_reconcile.go
+++ b/controllers/ingress/batch_reconcile.go
@@ -16,7 +16,7 @@ func (r *ingressController) flushReconcileBatch(ctx context.Context) error {
 	if err := r.initComplete.yield(ctx); err != nil {
 		return fmt.Errorf("initial reconciliation: %w", err)
 	}
-	_, err := r.reconcileAll(ctx)
+	_, _, err := r.reconcileAll(ctx)
 	return err
 }
 
@@ -38,6 +38,7 @@ func (r *ingressController) reconcileBatched(ctx context.Context, req ctrl.Reque
 	if !managing.managed {
 		return r.reconcileBatchedDelete(ctx, req.NamespacedName, managing.reasonIfNot)
 	}
+	r.managedIngresses.Store(req.NamespacedName, struct{}{})
 
 	ic, err := r.fetchIngress(ctx, ingress)
 	if err != nil {
@@ -71,12 +72,17 @@ func (r *ingressController) reconcileBatchedDelete(
 	name types.NamespacedName,
 	reason string,
 ) (ctrl.Result, error) {
-	if r.ingressChangeDetector.TracksIngress(name) {
+	tracked := r.ingressChangeDetector.TracksIngress(name)
+	_, knownManaged := r.managedIngresses.Load(name)
+	if tracked {
 		if err := r.batchCoordinator.Submit(ctx); err != nil {
 			return ctrl.Result{Requeue: true}, fmt.Errorf("apply ingress deletion batch: %w", err)
 		}
+	}
+	if tracked || knownManaged {
 		r.IngressDeleted(ctx, name, reason)
 	}
+	r.managedIngresses.Delete(name)
 	r.DeleteCascade(model.Key{Kind: r.ingressKind, NamespacedName: name})
 	return ctrl.Result{}, nil
 }

--- a/controllers/ingress/batch_reconcile_test.go
+++ b/controllers/ingress/batch_reconcile_test.go
@@ -202,7 +202,7 @@ func TestReconcileBatchedAppliesFullStateOnce(t *testing.T) {
 		"an unchanged ingress should not emit duplicate status updates")
 }
 
-func TestReconcileBatchedSkipsUnrelatedIngressWithMissingDependency(t *testing.T) {
+func TestReconcileBatchedPreservesFullStateWithMissingDependency(t *testing.T) {
 	reconciler := &batchTestReconciler{tracked: map[types.NamespacedName]int64{
 		{Namespace: "default", Name: "app-a"}: 1,
 		{Namespace: "default", Name: "app-b"}: 1,
@@ -219,20 +219,23 @@ func TestReconcileBatchedSkipsUnrelatedIngressWithMissingDependency(t *testing.T
 	result, err := r.reconcileBatched(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
 		Namespace: "default", Name: "app-a",
 	}})
+	require.ErrorContains(t, err, "missing")
+	assert.True(t, result.Requeue)
+	assert.Zero(t, reconciler.setCalls, "a partial full-state configuration must not be applied")
+	assert.True(t, reconciler.TracksIngress(types.NamespacedName{Namespace: "default", Name: "app-a"}))
+	assert.True(t, reconciler.TracksIngress(types.NamespacedName{Namespace: "default", Name: "app-b"}))
+
+	require.NoError(t, r.Client.Delete(context.Background(), broken))
+	result, err = r.reconcileBatched(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: "default", Name: "app-a",
+	}})
 	require.NoError(t, err)
 	assert.False(t, result.Requeue)
-	assert.Equal(t, 1, reconciler.setCalls)
+	assert.Equal(t, 1, reconciler.setCalls, "the retry should apply the complete state after recovery")
 	assert.Equal(t, []types.NamespacedName{
 		{Namespace: "default", Name: "app-a"},
 		{Namespace: "default", Name: "app-b"},
 	}, reconciler.lastSet)
-
-	result, err = r.reconcileBatched(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
-		Namespace: "default", Name: "broken",
-	}})
-	require.ErrorContains(t, err, "missing")
-	assert.True(t, result.Requeue)
-	assert.Equal(t, 1, reconciler.setCalls, "the invalid ingress must not trigger another full Set")
 }
 
 func TestReconcileBatchedDeletesStatusForInvalidManagedIngress(t *testing.T) {

--- a/controllers/ingress/batch_reconcile_test.go
+++ b/controllers/ingress/batch_reconcile_test.go
@@ -1,0 +1,258 @@
+package ingress
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/pomerium/ingress-controller/controllers/reporter"
+	"github.com/pomerium/ingress-controller/model"
+)
+
+type batchTestReconciler struct {
+	sync.Mutex
+	tracked  map[types.NamespacedName]int64
+	setCalls int
+	setErr   error
+	lastSet  []types.NamespacedName
+	reported map[types.NamespacedName]int
+}
+
+func (*batchTestReconciler) Upsert(context.Context, *model.IngressConfig) (bool, error) {
+	return false, errors.New("unexpected Upsert")
+}
+
+func (*batchTestReconciler) Delete(context.Context, types.NamespacedName) (bool, error) {
+	return false, errors.New("unexpected Delete")
+}
+
+func (r *batchTestReconciler) Set(_ context.Context, ics []*model.IngressConfig) (bool, error) {
+	r.Lock()
+	defer r.Unlock()
+	r.setCalls++
+	if r.setErr != nil {
+		return false, r.setErr
+	}
+	r.tracked = make(map[types.NamespacedName]int64, len(ics))
+	r.lastSet = r.lastSet[:0]
+	for _, ic := range ics {
+		name := ic.GetIngressNamespacedName()
+		r.tracked[name] = ic.Ingress.Generation
+		r.lastSet = append(r.lastSet, name)
+	}
+	sort.Slice(r.lastSet, func(i, j int) bool { return r.lastSet[i].String() < r.lastSet[j].String() })
+	return true, nil
+}
+
+func (r *batchTestReconciler) NeedsIngressUpdate(ic *model.IngressConfig) (bool, error) {
+	r.Lock()
+	defer r.Unlock()
+	generation, ok := r.tracked[ic.GetIngressNamespacedName()]
+	return !ok || generation != ic.Ingress.Generation, nil
+}
+
+func (r *batchTestReconciler) TracksIngress(name types.NamespacedName) bool {
+	r.Lock()
+	defer r.Unlock()
+	_, ok := r.tracked[name]
+	return ok
+}
+
+func (r *batchTestReconciler) IngressReconciled(_ context.Context, ingress *networkingv1.Ingress) error {
+	r.Lock()
+	defer r.Unlock()
+	if r.reported == nil {
+		r.reported = make(map[types.NamespacedName]int)
+	}
+	r.reported[types.NamespacedName{Namespace: ingress.Namespace, Name: ingress.Name}]++
+	return nil
+}
+
+func (*batchTestReconciler) IngressNotReconciled(context.Context, *networkingv1.Ingress, error) error {
+	return nil
+}
+
+func (*batchTestReconciler) IngressDeleted(context.Context, types.NamespacedName, string) error {
+	return nil
+}
+
+func newBatchTestController(
+	t *testing.T,
+	reconciler *batchTestReconciler,
+) (*ingressController, *networkingv1.Ingress) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, networkingv1.AddToScheme(scheme))
+
+	className := "pomerium"
+	pathType := networkingv1.PathTypePrefix
+	newIngress := func(name string) *networkingv1.Ingress {
+		return &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Generation: 2},
+			Spec: networkingv1.IngressSpec{
+				IngressClassName: &className,
+				Rules: []networkingv1.IngressRule{{
+					Host: name + ".example.com",
+					IngressRuleValue: networkingv1.IngressRuleValue{HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{
+							Path:     "/",
+							PathType: &pathType,
+							Backend: networkingv1.IngressBackend{Service: &networkingv1.IngressServiceBackend{
+								Name: "echo",
+								Port: networkingv1.ServiceBackendPort{Name: "http"},
+							}},
+						}},
+					}},
+				}},
+			},
+		}
+	}
+
+	a := newIngress("app-a")
+	b := newIngress("app-b")
+	objects := []runtime.Object{
+		&networkingv1.IngressClass{
+			ObjectMeta: metav1.ObjectMeta{Name: className},
+			Spec:       networkingv1.IngressClassSpec{Controller: DefaultClassControllerName},
+		},
+		a,
+		b,
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "echo", Namespace: "default"},
+			Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{
+				Name: "http", Port: 80, TargetPort: intstr.FromInt32(8080),
+			}}},
+		},
+		&corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "echo", Namespace: "default"}},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+	r := &ingressController{
+		controllerName:             DefaultClassControllerName,
+		annotationPrefix:           DefaultAnnotationPrefix,
+		Scheme:                     scheme,
+		Client:                     c,
+		IngressReconciler:          reconciler,
+		Registry:                   model.NewRegistry(),
+		MultiIngressStatusReporter: reporter.MultiIngressStatusReporter{reconciler},
+		ingressChangeDetector:      reconciler,
+		ingressKind:                "Ingress",
+		serviceKind:                "Service",
+		endpointsKind:              "Endpoints",
+		secretKind:                 "Secret",
+		ingressClassKind:           "IngressClass",
+	}
+	r.batchCoordinator = newReconcileBatchCoordinator(time.Millisecond, 10*time.Millisecond, func(ctx context.Context) error {
+		_, err := r.reconcileAll(ctx)
+		return err
+	})
+	startBatchCoordinator(t, r.batchCoordinator)
+	return r, b
+}
+
+func TestReconcileBatchedAppliesFullStateOnce(t *testing.T) {
+	reconciler := &batchTestReconciler{tracked: map[types.NamespacedName]int64{
+		{Namespace: "default", Name: "app-a"}: 1,
+		{Namespace: "default", Name: "app-b"}: 1,
+	}}
+	r, _ := newBatchTestController(t, reconciler)
+	ctx := context.Background()
+
+	result, err := r.reconcileBatched(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: "default", Name: "app-a",
+	}})
+	require.NoError(t, err)
+	assert.False(t, result.Requeue)
+	assert.Equal(t, 1, reconciler.setCalls)
+	assert.Equal(t, []types.NamespacedName{
+		{Namespace: "default", Name: "app-a"},
+		{Namespace: "default", Name: "app-b"},
+	}, reconciler.lastSet)
+	assert.Equal(t, 1, reconciler.reported[types.NamespacedName{Namespace: "default", Name: "app-a"}])
+
+	result, err = r.reconcileBatched(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: "default", Name: "app-b",
+	}})
+	require.NoError(t, err)
+	assert.False(t, result.Requeue)
+	assert.Equal(t, 1, reconciler.setCalls, "the first full-state Set already included app-b")
+	assert.Zero(t, reconciler.reported[types.NamespacedName{Namespace: "default", Name: "app-b"}],
+		"an unchanged ingress should not emit duplicate status updates")
+}
+
+func TestReconcileBatchedSkipsUnrelatedIngressWithMissingDependency(t *testing.T) {
+	reconciler := &batchTestReconciler{tracked: map[types.NamespacedName]int64{
+		{Namespace: "default", Name: "app-a"}: 1,
+		{Namespace: "default", Name: "app-b"}: 1,
+	}}
+	r, ingressB := newBatchTestController(t, reconciler)
+	broken := ingressB.DeepCopy()
+	broken.Name = "broken"
+	broken.ResourceVersion = ""
+	broken.UID = ""
+	broken.Spec.Rules[0].Host = "broken.example.com"
+	broken.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name = "missing"
+	require.NoError(t, r.Client.Create(context.Background(), broken))
+
+	result, err := r.reconcileBatched(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: "default", Name: "app-a",
+	}})
+	require.NoError(t, err)
+	assert.False(t, result.Requeue)
+	assert.Equal(t, 1, reconciler.setCalls)
+	assert.Equal(t, []types.NamespacedName{
+		{Namespace: "default", Name: "app-a"},
+		{Namespace: "default", Name: "app-b"},
+	}, reconciler.lastSet)
+
+	result, err = r.reconcileBatched(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: "default", Name: "broken",
+	}})
+	require.ErrorContains(t, err, "missing")
+	assert.True(t, result.Requeue)
+	assert.Equal(t, 1, reconciler.setCalls, "the invalid ingress must not trigger another full Set")
+}
+
+func TestReconcileBatchedDeleteRetriesFailedSet(t *testing.T) {
+	reconciler := &batchTestReconciler{tracked: map[types.NamespacedName]int64{
+		{Namespace: "default", Name: "app-a"}: 2,
+		{Namespace: "default", Name: "app-b"}: 2,
+	}}
+	r, ingressB := newBatchTestController(t, reconciler)
+	ctx := context.Background()
+	require.NoError(t, r.Client.Delete(ctx, ingressB))
+
+	reconciler.setErr = errors.New("temporary failure")
+	result, err := r.reconcileBatched(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: "default", Name: "app-b",
+	}})
+	require.ErrorContains(t, err, "temporary failure")
+	assert.True(t, result.Requeue)
+	assert.Equal(t, 1, reconciler.setCalls)
+	assert.True(t, reconciler.TracksIngress(types.NamespacedName{Namespace: "default", Name: "app-b"}))
+
+	reconciler.setErr = nil
+	result, err = r.reconcileBatched(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: "default", Name: "app-b",
+	}})
+	require.NoError(t, err)
+	assert.False(t, result.Requeue)
+	assert.Equal(t, 2, reconciler.setCalls)
+	assert.False(t, reconciler.TracksIngress(types.NamespacedName{Namespace: "default", Name: "app-b"}))
+	assert.Equal(t, []types.NamespacedName{{Namespace: "default", Name: "app-a"}}, reconciler.lastSet)
+}

--- a/controllers/ingress/batch_reconcile_test.go
+++ b/controllers/ingress/batch_reconcile_test.go
@@ -30,6 +30,7 @@ type batchTestReconciler struct {
 	setErr   error
 	lastSet  []types.NamespacedName
 	reported map[types.NamespacedName]int
+	deleted  map[types.NamespacedName]int
 }
 
 func (*batchTestReconciler) Upsert(context.Context, *model.IngressConfig) (bool, error) {
@@ -86,7 +87,13 @@ func (*batchTestReconciler) IngressNotReconciled(context.Context, *networkingv1.
 	return nil
 }
 
-func (*batchTestReconciler) IngressDeleted(context.Context, types.NamespacedName, string) error {
+func (r *batchTestReconciler) IngressDeleted(_ context.Context, name types.NamespacedName, _ string) error {
+	r.Lock()
+	defer r.Unlock()
+	if r.deleted == nil {
+		r.deleted = make(map[types.NamespacedName]int)
+	}
+	r.deleted[name]++
 	return nil
 }
 
@@ -158,7 +165,7 @@ func newBatchTestController(
 		ingressClassKind:           "IngressClass",
 	}
 	r.batchCoordinator = newReconcileBatchCoordinator(time.Millisecond, 10*time.Millisecond, func(ctx context.Context) error {
-		_, err := r.reconcileAll(ctx)
+		_, _, err := r.reconcileAll(ctx)
 		return err
 	})
 	startBatchCoordinator(t, r.batchCoordinator)
@@ -226,6 +233,32 @@ func TestReconcileBatchedSkipsUnrelatedIngressWithMissingDependency(t *testing.T
 	require.ErrorContains(t, err, "missing")
 	assert.True(t, result.Requeue)
 	assert.Equal(t, 1, reconciler.setCalls, "the invalid ingress must not trigger another full Set")
+}
+
+func TestReconcileBatchedDeletesStatusForInvalidManagedIngress(t *testing.T) {
+	reconciler := &batchTestReconciler{tracked: make(map[types.NamespacedName]int64)}
+	r, ingress := newBatchTestController(t, reconciler)
+	broken := ingress.DeepCopy()
+	broken.Name = "broken"
+	broken.ResourceVersion = ""
+	broken.UID = ""
+	broken.Spec.Rules[0].Host = "broken.example.com"
+	broken.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name = "missing"
+	ctx := context.Background()
+	require.NoError(t, r.Client.Create(ctx, broken))
+
+	name := types.NamespacedName{Namespace: broken.Namespace, Name: broken.Name}
+	result, err := r.reconcileBatched(ctx, ctrl.Request{NamespacedName: name})
+	require.ErrorContains(t, err, "missing")
+	assert.True(t, result.Requeue)
+	assert.False(t, reconciler.TracksIngress(name))
+
+	require.NoError(t, r.Client.Delete(ctx, broken))
+	result, err = r.reconcileBatched(ctx, ctrl.Request{NamespacedName: name})
+	require.NoError(t, err)
+	assert.False(t, result.Requeue)
+	assert.Equal(t, 1, reconciler.deleted[name])
+	assert.Equal(t, 0, reconciler.setCalls, "an invalid ingress was never part of the applied config")
 }
 
 func TestReconcileBatchedDeleteRetriesFailedSet(t *testing.T) {

--- a/controllers/ingress/builder.go
+++ b/controllers/ingress/builder.go
@@ -40,6 +40,21 @@ func NewIngressController(
 	for _, opt := range opts {
 		opt(ic)
 	}
+	if ic.reconcileBatchWindow > 0 {
+		detector, ok := pcr.(pomerium.IngressChangeDetector)
+		if !ok {
+			return fmt.Errorf("adaptive reconcile batching requires an ingress change detector")
+		}
+		ic.ingressChangeDetector = detector
+		ic.batchCoordinator = newReconcileBatchCoordinator(
+			ic.reconcileBatchWindow,
+			ic.reconcileBatchMaxWait,
+			ic.flushReconcileBatch,
+		)
+		if err := mgr.Add(ic.batchCoordinator); err != nil {
+			return fmt.Errorf("add adaptive reconcile batch coordinator: %w", err)
+		}
+	}
 
 	if err := ic.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller: %w", err)

--- a/controllers/ingress/controller.go
+++ b/controllers/ingress/controller.go
@@ -55,6 +55,14 @@ type ingressController struct {
 	// globalSettings defines which global settings object to watch
 	globalSettings *types.NamespacedName
 
+	// reconcileBatchWindow is the quiet period used to coalesce real changes.
+	// A zero value disables batching.
+	reconcileBatchWindow time.Duration
+	// reconcileBatchMaxWait bounds the delay under continuous event load.
+	reconcileBatchMaxWait time.Duration
+	batchCoordinator      *reconcileBatchCoordinator
+	ingressChangeDetector pomerium.IngressChangeDetector
+
 	// object Kinds are frequently used, do not change and are cached
 	endpointsKind    string
 	ingressKind      string
@@ -119,6 +127,15 @@ func WithWatchSettings(name types.NamespacedName) Option {
 	}
 }
 
+// WithAdaptiveReconcileBatching coalesces real configuration changes after a
+// quiet period, while maxWait bounds latency when events arrive continuously.
+func WithAdaptiveReconcileBatching(quietPeriod, maxWait time.Duration) Option {
+	return func(ic *ingressController) {
+		ic.reconcileBatchWindow = quietPeriod
+		ic.reconcileBatchMaxWait = maxWait
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager
 func (r *ingressController) SetupWithManager(mgr ctrl.Manager) error {
 	r.Client = mgr.GetClient()
@@ -134,17 +151,26 @@ func (r *ingressController) SetupWithManager(mgr ctrl.Manager) error {
 
 	err := ctrl.NewControllerManagedBy(mgr).
 		Named(controllerName).
-		For(&networkingv1.Ingress{}).
+		For(
+			&networkingv1.Ingress{},
+			builder.WithPredicates(r.batchSignalPredicate("ingress")),
+		).
 		Watches(
 			&networkingv1.IngressClass{},
-			handler.EnqueueRequestsFromMapFunc(r.watchIngressClass()),
+			handler.EnqueueRequestsFromMapFunc(r.batchSignalMap("ingress-class", r.watchIngressClass())),
 			builder.WithPredicates(generic.NewPredicateFuncs(func(ic *networkingv1.IngressClass) bool {
 				return ic.Spec.Controller == r.controllerName
 			})),
 		).
-		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.getDependantIngressFn(r.secretKind))).
-		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(r.getDependantIngressFn(r.serviceKind))).
-		Watches(&corev1.Endpoints{}, handler.EnqueueRequestsFromMapFunc(r.getDependantIngressFn(r.endpointsKind))).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(
+			r.batchSignalMap("secret", r.getDependantIngressFn(r.secretKind)),
+		)).
+		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(
+			r.batchSignalMap("service", r.getDependantIngressFn(r.serviceKind)),
+		)).
+		Watches(&corev1.Endpoints{}, handler.EnqueueRequestsFromMapFunc(
+			r.batchSignalMap("endpoints", r.getDependantIngressFn(r.endpointsKind)),
+		)).
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
 		Complete(r)
 	if err != nil {

--- a/controllers/ingress/controller.go
+++ b/controllers/ingress/controller.go
@@ -1,6 +1,7 @@
 package ingress
 
 import (
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -62,6 +63,7 @@ type ingressController struct {
 	reconcileBatchMaxWait time.Duration
 	batchCoordinator      *reconcileBatchCoordinator
 	ingressChangeDetector pomerium.IngressChangeDetector
+	managedIngresses      sync.Map
 
 	// object Kinds are frequently used, do not change and are cached
 	endpointsKind    string

--- a/controllers/ingress/reconcile.go
+++ b/controllers/ingress/reconcile.go
@@ -75,14 +75,13 @@ func (r *ingressController) reconcileAll(ctx context.Context) ([]*model.IngressC
 		active[name.String()] = struct{}{}
 		ic, err := r.fetchIngress(ctx, ingress)
 		if err != nil {
-			// An invalid Ingress must not prevent unrelated valid changes from
-			// being applied in the same full-state batch.
 			r.IngressNotReconciled(ctx, ingress, err)
-			logger.Error(err, "skip ingress with unavailable dependencies", "ingress", types.NamespacedName{
-				Namespace: ingress.Namespace,
-				Name:      ingress.Name,
-			})
-			continue
+			// Do not persist a partial full-state configuration. A dependency may
+			// be temporarily unavailable while informer caches converge; omitting
+			// its Ingress here would remove a previously valid route. Returning the
+			// error preserves the last applied configuration and lets
+			// controller-runtime retry the batch.
+			return ics, active, fmt.Errorf("fetch ingress %s dependencies: %w", name, err)
 		}
 		logger.V(1).Info("fetch", "ingress", ingress.Name, "secrets", len(ic.Secrets), "services", len(ic.Services))
 		ics = append(ics, ic)

--- a/controllers/ingress/reconcile.go
+++ b/controllers/ingress/reconcile.go
@@ -6,6 +6,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -27,9 +28,28 @@ func (r *ingressController) reconcileInitial(ctx context.Context) (err error) {
 		}
 	}()
 
+	ics, err := r.reconcileAll(ctx)
+	for i := range ics {
+		ingress := ics[i].Ingress
+		if err != nil {
+			r.IngressNotReconciled(ctx, ingress, err)
+		} else if _, statusErr := r.updateIngressStatus(ctx, ingress); statusErr != nil {
+			r.IngressNotReconciled(ctx, ingress, fmt.Errorf("update /status: %w", statusErr))
+		} else {
+			r.IngressReconciled(ctx, ingress)
+		}
+	}
+	return err
+}
+
+// reconcileAll reads the current managed Ingress state and persists it with a
+// single full-state Set call. It deliberately does not update statuses; queued
+// reconcile requests do that after the batch has been applied.
+func (r *ingressController) reconcileAll(ctx context.Context) ([]*model.IngressConfig, error) {
+	logger := log.FromContext(ctx)
 	ingressList := new(networkingv1.IngressList)
 	if err := r.Client.List(ctx, ingressList); err != nil {
-		return fmt.Errorf("list ingresses: %w", err)
+		return nil, fmt.Errorf("list ingresses: %w", err)
 	}
 
 	var ics []*model.IngressConfig
@@ -37,7 +57,7 @@ func (r *ingressController) reconcileInitial(ctx context.Context) (err error) {
 		ingress := &ingressList.Items[i]
 		res, err := r.isManaging(ctx, ingress)
 		if err != nil {
-			return fmt.Errorf("get ingressClass info: %w", err)
+			return nil, fmt.Errorf("get ingressClass info: %w", err)
 		}
 		if !res.managed {
 			logger.V(1).Info("skipping ingress", "ingress", ingress.Name, "reason", res.reasonIfNot)
@@ -45,26 +65,24 @@ func (r *ingressController) reconcileInitial(ctx context.Context) (err error) {
 		}
 		ic, err := r.fetchIngress(ctx, ingress)
 		if err != nil {
-			return fmt.Errorf("fetch ingress %s/%s: %w", ingress.Namespace, ingress.Name, err)
+			// An invalid Ingress must not prevent unrelated valid changes from
+			// being applied in the same full-state batch.
+			r.IngressNotReconciled(ctx, ingress, err)
+			logger.Error(err, "skip ingress with unavailable dependencies", "ingress", types.NamespacedName{
+				Namespace: ingress.Namespace,
+				Name:      ingress.Name,
+			})
+			continue
 		}
 		logger.V(1).Info("fetch", "ingress", ingress.Name, "secrets", len(ic.Secrets), "services", len(ic.Services))
 		ics = append(ics, ic)
 	}
 
-	_, err = r.IngressReconciler.Set(ctx, ics)
-	for i := range ics {
-		ingress := ics[i].Ingress
-		if err != nil {
-			r.IngressNotReconciled(ctx, ingress, err)
-		} else if err := r.updateIngressStatus(ctx, ingress); err != nil {
-			r.IngressNotReconciled(ctx, ingress, fmt.Errorf("update /status: %w", err))
-		} else {
-			r.IngressReconciled(ctx, ingress)
-		}
-	}
-
-	return err
+	_, err := r.IngressReconciler.Set(ctx, ics)
+	return ics, err
 }
+
+const reasonIngressDeleted = "Ingress resource was deleted"
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -72,13 +90,18 @@ func (r *ingressController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err := r.initComplete.yield(ctx); err != nil {
 		return ctrl.Result{Requeue: true}, fmt.Errorf("initial reconciliation: %w", err)
 	}
+	if r.batchCoordinator != nil {
+		return r.reconcileBatched(ctx, req)
+	}
 
 	ingress := new(networkingv1.Ingress)
 	if err := r.Client.Get(ctx, req.NamespacedName, ingress); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{Requeue: true}, fmt.Errorf("get ingress: %w", err)
 		}
-		return r.deleteIngress(ctx, req.NamespacedName, "Ingress resource was deleted")
+		return r.deleteIngress(ctx, req.NamespacedName, reasonIngressDeleted)
+	} else if ingress.DeletionTimestamp != nil {
+		return r.deleteIngress(ctx, req.NamespacedName, reasonIngressDeleted)
 	}
 
 	managing, err := r.isManaging(ctx, ingress)
@@ -124,28 +147,35 @@ func (r *ingressController) upsertIngress(ctx context.Context, ic *model.Ingress
 
 	r.IngressReconciled(ctx, ic.Ingress)
 
-	if err = r.updateIngressStatus(ctx, ic.Ingress); err != nil {
+	if _, err = r.updateIngressStatus(ctx, ic.Ingress); err != nil {
 		return ctrl.Result{Requeue: true}, fmt.Errorf("update ingress status: %w", err)
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func (r *ingressController) updateIngressStatus(ctx context.Context, ingress *networkingv1.Ingress) error {
+func (r *ingressController) updateIngressStatus(ctx context.Context, ingress *networkingv1.Ingress) (bool, error) {
 	if r.updateStatusFromService == nil {
-		return nil
+		return false, nil
 	}
 
 	svc := new(corev1.Service)
 	if err := r.Client.Get(ctx, *r.updateStatusFromService, svc); err != nil {
-		return fmt.Errorf("get pomerium-proxy service %s: %w", r.updateStatusFromService.String(), err)
+		return false, fmt.Errorf("get pomerium-proxy service %s: %w", r.updateStatusFromService.String(), err)
 	}
 
-	ingress.Status.LoadBalancer = networkingv1.IngressLoadBalancerStatus{
+	desired := networkingv1.IngressLoadBalancerStatus{
 		Ingress: svcStatusToIngress(svc),
 	}
+	if apiequality.Semantic.DeepEqual(ingress.Status.LoadBalancer, desired) {
+		return false, nil
+	}
+	ingress.Status.LoadBalancer = desired
 
-	return r.Client.Status().Update(ctx, ingress)
+	if err := r.Client.Status().Update(ctx, ingress); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func svcStatusToIngress(svc *corev1.Service) []networkingv1.IngressLoadBalancerIngress {

--- a/controllers/ingress/reconcile.go
+++ b/controllers/ingress/reconcile.go
@@ -28,7 +28,13 @@ func (r *ingressController) reconcileInitial(ctx context.Context) (err error) {
 		}
 	}()
 
-	ics, err := r.reconcileAll(ctx)
+	ics, active, err := r.reconcileAll(ctx)
+	if err == nil {
+		// Prune before reporting each active Ingress. On large clusters those
+		// status updates can consume most of the initial reconciliation timeout,
+		// leaving no usable context for stale-entry cleanup.
+		r.PruneIngressStatuses(ctx, active)
+	}
 	for i := range ics {
 		ingress := ics[i].Ingress
 		if err != nil {
@@ -45,24 +51,28 @@ func (r *ingressController) reconcileInitial(ctx context.Context) (err error) {
 // reconcileAll reads the current managed Ingress state and persists it with a
 // single full-state Set call. It deliberately does not update statuses; queued
 // reconcile requests do that after the batch has been applied.
-func (r *ingressController) reconcileAll(ctx context.Context) ([]*model.IngressConfig, error) {
+func (r *ingressController) reconcileAll(ctx context.Context) ([]*model.IngressConfig, map[string]struct{}, error) {
 	logger := log.FromContext(ctx)
 	ingressList := new(networkingv1.IngressList)
 	if err := r.Client.List(ctx, ingressList); err != nil {
-		return nil, fmt.Errorf("list ingresses: %w", err)
+		return nil, nil, fmt.Errorf("list ingresses: %w", err)
 	}
 
 	var ics []*model.IngressConfig
+	active := make(map[string]struct{})
 	for i := range ingressList.Items {
 		ingress := &ingressList.Items[i]
 		res, err := r.isManaging(ctx, ingress)
 		if err != nil {
-			return nil, fmt.Errorf("get ingressClass info: %w", err)
+			return nil, nil, fmt.Errorf("get ingressClass info: %w", err)
 		}
 		if !res.managed {
 			logger.V(1).Info("skipping ingress", "ingress", ingress.Name, "reason", res.reasonIfNot)
 			continue
 		}
+		name := types.NamespacedName{Namespace: ingress.Namespace, Name: ingress.Name}
+		r.managedIngresses.Store(name, struct{}{})
+		active[name.String()] = struct{}{}
 		ic, err := r.fetchIngress(ctx, ingress)
 		if err != nil {
 			// An invalid Ingress must not prevent unrelated valid changes from
@@ -79,7 +89,7 @@ func (r *ingressController) reconcileAll(ctx context.Context) ([]*model.IngressC
 	}
 
 	_, err := r.IngressReconciler.Set(ctx, ics)
-	return ics, err
+	return ics, active, err
 }
 
 const reasonIngressDeleted = "Ingress resource was deleted"
@@ -112,6 +122,7 @@ func (r *ingressController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if !managing.managed {
 		return r.deleteIngress(ctx, req.NamespacedName, managing.reasonIfNot)
 	}
+	r.managedIngresses.Store(req.NamespacedName, struct{}{})
 
 	ic, err := r.fetchIngress(ctx, ingress)
 	if err != nil {
@@ -127,13 +138,15 @@ func (r *ingressController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 }
 
 func (r *ingressController) deleteIngress(ctx context.Context, name types.NamespacedName, reason string) (ctrl.Result, error) {
+	_, knownManaged := r.managedIngresses.Load(name)
 	changed, err := r.IngressReconciler.Delete(ctx, name)
 	if err != nil {
 		return ctrl.Result{Requeue: true}, fmt.Errorf("deleting ingress: %w", err)
 	}
-	if changed {
+	if changed || knownManaged {
 		r.IngressDeleted(ctx, name, reason)
 	}
+	r.managedIngresses.Delete(name)
 	r.DeleteCascade(model.Key{Kind: r.ingressKind, NamespacedName: name})
 	return ctrl.Result{}, nil
 }

--- a/controllers/reporter/ingress.go
+++ b/controllers/reporter/ingress.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -31,9 +33,20 @@ type IngressStatusReporter interface {
 	IngressDeleted(ctx context.Context, name types.NamespacedName, reason string) error
 }
 
+// IngressStatusPruner removes status entries for Ingresses that no longer
+// exist. It is optional because event and log reporters have nothing to prune.
+type IngressStatusPruner interface {
+	PruneIngressStatuses(ctx context.Context, active map[string]struct{}) error
+}
+
 // IngressSettingsReporter reflects ingress updates in a Pomerium Settings CRD /status section
 type IngressSettingsReporter struct {
 	SettingsReporter
+}
+
+type jsonPatchOperation struct {
+	Op   string `json:"op"`
+	Path string `json:"path"`
 }
 
 // IngressReconciled an ingress was successfully reconciled with Pomerium
@@ -77,15 +90,9 @@ func (r *IngressSettingsReporter) IngressNotReconciled(ctx context.Context, ingr
 
 // IngressDeleted an ingress resource was deleted and Pomerium no longer serves it
 func (r *IngressSettingsReporter) IngressDeleted(ctx context.Context, name types.NamespacedName, _ string) error {
-	patch, err := json.Marshal([]struct {
-		Op   string `json:"op"`
-		Path string `json:"path"`
-	}{{
-		Op: "remove",
-		// https://datatracker.ietf.org/doc/html/rfc6901#section-3
-		// "/"(forward slash) is encoded as "~1"
-		// ¯\_(ツ)_/¯
-		Path: fmt.Sprintf("/status/ingress/%s~1%s", name.Namespace, name.Name),
+	patch, err := json.Marshal([]jsonPatchOperation{{
+		Op:   "remove",
+		Path: ingressStatusJSONPath(name.String()),
 	}})
 	if err != nil {
 		return err
@@ -103,6 +110,53 @@ func (r *IngressSettingsReporter) IngressDeleted(ctx context.Context, name types
 		return fmt.Errorf("failed to patch /status for ingress %v: %w", name, err)
 	}
 	return nil
+}
+
+// PruneIngressStatuses removes entries left behind when an Ingress was
+// deleted while the controller was not running. Active invalid Ingresses are
+// supplied by the controller and deliberately retained.
+func (r *IngressSettingsReporter) PruneIngressStatuses(ctx context.Context, active map[string]struct{}) error {
+	var current icsv1.Pomerium
+	if err := r.Get(ctx, r.NamespacedName, &current); err != nil {
+		return fmt.Errorf("read Pomerium status before pruning: %w", err)
+	}
+
+	stale := make([]string, 0)
+	for key := range current.Status.Routes {
+		if _, ok := active[key]; !ok {
+			stale = append(stale, key)
+		}
+	}
+	if len(stale) == 0 {
+		return nil
+	}
+	sort.Strings(stale)
+
+	operations := make([]jsonPatchOperation, 0, len(stale))
+	for _, key := range stale {
+		operations = append(operations, jsonPatchOperation{
+			Op:   "remove",
+			Path: ingressStatusJSONPath(key),
+		})
+	}
+	patch, err := json.Marshal(operations)
+	if err != nil {
+		return fmt.Errorf("encode stale ingress status patch: %w", err)
+	}
+
+	if err := r.Status().Patch(ctx, &icsv1.Pomerium{
+		ObjectMeta: metav1.ObjectMeta{Name: r.Name},
+	}, client.RawPatch(types.JSONPatchType, patch)); err != nil {
+		return fmt.Errorf("prune %d stale ingress status entries: %w", len(stale), err)
+	}
+	return nil
+}
+
+func ingressStatusJSONPath(key string) string {
+	// JSON Pointer escapes "~" before "/" according to RFC 6901 section 3.
+	escaped := strings.ReplaceAll(key, "~", "~0")
+	escaped = strings.ReplaceAll(escaped, "/", "~1")
+	return "/status/ingress/" + escaped
 }
 
 // IngressEventReporter reflects updates as events posted to the ingress

--- a/controllers/reporter/ingress_prune_test.go
+++ b/controllers/reporter/ingress_prune_test.go
@@ -1,0 +1,79 @@
+package reporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	icsv1 "github.com/pomerium/ingress-controller/apis/ingress/v1"
+)
+
+func TestIngressSettingsReporterPrunesOnlyStaleStatuses(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, icsv1.AddToScheme(scheme))
+	pomerium := &icsv1.Pomerium{
+		ObjectMeta: metav1.ObjectMeta{Name: "global"},
+		Status: icsv1.PomeriumStatus{Routes: map[string]icsv1.ResourceStatus{
+			"apps/valid":       {Reconciled: true},
+			"apps/invalid":     {Reconciled: false},
+			"deleted/old":      {Reconciled: true},
+			"deleted~team/old": {Reconciled: true},
+		}},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&icsv1.Pomerium{}).
+		WithObjects(pomerium).
+		Build()
+	reporter := &IngressSettingsReporter{SettingsReporter: SettingsReporter{
+		NamespacedName: types.NamespacedName{Name: "global"},
+		Client:         cl,
+	}}
+
+	err := reporter.PruneIngressStatuses(context.Background(), map[string]struct{}{
+		"apps/valid":   {},
+		"apps/invalid": {},
+	})
+	require.NoError(t, err)
+
+	var updated icsv1.Pomerium
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKey{Name: "global"}, &updated))
+	require.Equal(t, map[string]icsv1.ResourceStatus{
+		"apps/valid":   {Reconciled: true},
+		"apps/invalid": {Reconciled: false},
+	}, updated.Status.Routes)
+}
+
+func TestIngressSettingsReporterPruneIsNoopWithoutStaleStatuses(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, icsv1.AddToScheme(scheme))
+	pomerium := &icsv1.Pomerium{
+		ObjectMeta: metav1.ObjectMeta{Name: "global"},
+		Status: icsv1.PomeriumStatus{Routes: map[string]icsv1.ResourceStatus{
+			"apps/valid": {Reconciled: true},
+		}},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&icsv1.Pomerium{}).
+		WithObjects(pomerium).
+		Build()
+	reporter := &IngressSettingsReporter{SettingsReporter: SettingsReporter{
+		NamespacedName: types.NamespacedName{Name: "global"},
+		Client:         cl,
+	}}
+
+	require.NoError(t, reporter.PruneIngressStatuses(context.Background(), map[string]struct{}{
+		"apps/valid": {},
+	}))
+}

--- a/controllers/reporter/reporter.go
+++ b/controllers/reporter/reporter.go
@@ -58,6 +58,20 @@ func (r MultiIngressStatusReporter) IngressDeleted(ctx context.Context, name typ
 	logErrorIfAny(ctx, errs.ErrorOrNil(), "ingress", name, "original reason", reason)
 }
 
+// PruneIngressStatuses asks reporters with persistent route status to remove
+// entries that are not present in the active managed Ingress set.
+func (r MultiIngressStatusReporter) PruneIngressStatuses(ctx context.Context, active map[string]struct{}) {
+	var errs *multierror.Error
+	for _, u := range r {
+		if pruner, ok := u.(IngressStatusPruner); ok {
+			if err := pruner.PruneIngressStatuses(ctx, active); err != nil {
+				errs = multierror.Append(errs, err)
+			}
+		}
+	}
+	logErrorIfAny(ctx, errs.ErrorOrNil())
+}
+
 // SettingsUpdated marks that configuration was reconciled
 func (r MultiPomeriumStatusReporter) SettingsUpdated(ctx context.Context, obj *icsv1.Pomerium) {
 	var errs *multierror.Error

--- a/controllers/settings/controller.go
+++ b/controllers/settings/controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -133,7 +134,12 @@ func (c *settingsController) Reconcile(ctx context.Context, req ctrl.Request) (c
 	cfg, err := FetchConfig(ctx, c.Client, c.key.NamespacedName)
 	logger.Info("fetch", "deps", c.Registry.Deps(c.key), "error", err)
 	if err != nil {
-		c.SettingsRejected(ctx, &cfg.Pomerium, err)
+		if cfg == nil && apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		if cfg != nil {
+			c.SettingsRejected(ctx, &cfg.Pomerium, err)
+		}
 		return ctrl.Result{Requeue: true}, fmt.Errorf("get settings: %w", err)
 	}
 	// bootstrap config must at least construct a valid config once to be considered running

--- a/controllers/settings/controller.go
+++ b/controllers/settings/controller.go
@@ -95,7 +95,13 @@ func NewSettingsController(
 	secretKind := generic.GVKForType[*corev1.Secret](mgr.GetScheme()).Kind
 	err := ctrl.NewControllerManagedBy(mgr).
 		Named(controllerName).
-		For(new(icsv1.Pomerium)).
+		For(
+			new(icsv1.Pomerium),
+			// Ingress reconciliation updates Pomerium.status.routes. The
+			// settings config depends only on spec, so status-only updates must
+			// not trigger another full Envoy validation.
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(deps.GetDependantMapFunc(stc.Registry, secretKind)),

--- a/controllers/settings/controller_predicate_test.go
+++ b/controllers/settings/controller_predicate_test.go
@@ -1,0 +1,33 @@
+package settings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	icsv1 "github.com/pomerium/ingress-controller/apis/ingress/v1"
+)
+
+func TestSettingsGenerationPredicateIgnoresStatusOnlyUpdates(t *testing.T) {
+	p := predicate.GenerationChangedPredicate{}
+	before := &icsv1.Pomerium{ObjectMeta: metav1.ObjectMeta{Name: "global", Generation: 7}}
+	after := before.DeepCopy()
+	after.ResourceVersion = "2"
+	after.Status.Routes = map[string]icsv1.ResourceStatus{
+		"default/app": {ObservedGeneration: 3, Reconciled: true},
+	}
+
+	assert.False(t, p.Update(event.UpdateEvent{ObjectOld: before, ObjectNew: after}))
+}
+
+func TestSettingsGenerationPredicateAcceptsSpecUpdates(t *testing.T) {
+	p := predicate.GenerationChangedPredicate{}
+	before := &icsv1.Pomerium{ObjectMeta: metav1.ObjectMeta{Name: "global", Generation: 7}}
+	after := before.DeepCopy()
+	after.Generation = 8
+
+	assert.True(t, p.Update(event.UpdateEvent{ObjectOld: before, ObjectNew: after}))
+}

--- a/controllers/settings/controller_reconcile_test.go
+++ b/controllers/settings/controller_reconcile_test.go
@@ -1,0 +1,106 @@
+package settings
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	icsv1 "github.com/pomerium/ingress-controller/apis/ingress/v1"
+	controllers_mock "github.com/pomerium/ingress-controller/controllers/mock"
+	"github.com/pomerium/ingress-controller/model"
+)
+
+func TestReconcileIgnoresDeletedPomerium(t *testing.T) {
+	ctx := context.Background()
+	name := types.NamespacedName{Name: "canary"}
+	mc := controllers_mock.NewMockClient(gomock.NewController(t))
+	mc.EXPECT().
+		Get(ctx, name, gomock.AssignableToTypeOf(new(icsv1.Pomerium))).
+		Return(apierrors.NewNotFound(schema.GroupResource{
+			Group:    icsv1.GroupVersion.Group,
+			Resource: "pomerium",
+		}, name.Name))
+
+	c := settingsController{
+		key: model.Key{
+			Kind:           "Pomerium",
+			NamespacedName: name,
+		},
+		Client:   mc,
+		Registry: model.NewRegistry(),
+	}
+
+	result, err := c.Reconcile(ctx, ctrl.Request{NamespacedName: name})
+
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+}
+
+func TestReconcileDoesNotReportReadErrorWithoutPomerium(t *testing.T) {
+	ctx := context.Background()
+	name := types.NamespacedName{Name: "canary"}
+	mc := controllers_mock.NewMockClient(gomock.NewController(t))
+	mc.EXPECT().
+		Get(ctx, name, gomock.AssignableToTypeOf(new(icsv1.Pomerium))).
+		Return(apierrors.NewForbidden(schema.GroupResource{
+			Group:    icsv1.GroupVersion.Group,
+			Resource: "pomerium",
+		}, name.Name, assert.AnError))
+
+	c := settingsController{
+		key: model.Key{
+			Kind:           "Pomerium",
+			NamespacedName: name,
+		},
+		Client:   mc,
+		Registry: model.NewRegistry(),
+	}
+
+	result, err := c.Reconcile(ctx, ctrl.Request{NamespacedName: name})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "get settings")
+	assert.True(t, result.Requeue)
+}
+
+func TestReconcileRetriesMissingDependency(t *testing.T) {
+	ctx := context.Background()
+	name := types.NamespacedName{Name: "canary"}
+	secretName := types.NamespacedName{Namespace: "pomerium", Name: "bootstrap-secrets"}
+	mc := controllers_mock.NewMockClient(gomock.NewController(t))
+	mc.EXPECT().
+		Get(ctx, name, gomock.AssignableToTypeOf(new(icsv1.Pomerium))).
+		Do(func(_ context.Context, _ types.NamespacedName, dst *icsv1.Pomerium, _ ...client.GetOption) {
+			dst.Spec.Secrets = "pomerium/bootstrap-secrets"
+		}).
+		Return(nil)
+	mc.EXPECT().
+		Get(ctx, secretName, gomock.AssignableToTypeOf(new(corev1.Secret))).
+		Return(apierrors.NewNotFound(schema.GroupResource{
+			Resource: "secrets",
+		}, secretName.Name))
+
+	c := settingsController{
+		key: model.Key{
+			Kind:           "Pomerium",
+			NamespacedName: name,
+		},
+		Client:   mc,
+		Registry: model.NewRegistry(),
+	}
+
+	result, err := c.Reconcile(ctx, ctrl.Request{NamespacedName: name})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "bootstrap-secrets")
+	assert.True(t, result.Requeue)
+}

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1006,6 +1006,12 @@ spec:
               fieldPath: status.podIP
         image: pomerium/ingress-controller:v0.32.9
         imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /busybox/sleep
+              - "30"
         livenessProbe:
           failureThreshold: 10
           httpGet:
@@ -1064,7 +1070,7 @@ spec:
       securityContext:
         runAsNonRoot: true
       serviceAccountName: pomerium-controller
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 60
       volumes:
       - emptyDir: {}
         name: tmp

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/open-policy-agent/opa v1.12.1
 	github.com/pomerium/pomerium v0.32.9
+	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.34.0
 	github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cobra v1.10.2
@@ -224,7 +225,6 @@ require (
 	github.com/pomerium/protoutil v0.0.0-20260116153545-19d2ae5b7518 // indirect
 	github.com/pomerium/webauthn v0.0.0-20260116153041-d32e028c3f7e // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect

--- a/pomerium/ingress_config_cache.go
+++ b/pomerium/ingress_config_cache.go
@@ -1,0 +1,182 @@
+package pomerium
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"sort"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/pomerium/ingress-controller/model"
+)
+
+type ingressConfigFingerprint [sha256.Size]byte
+
+// ingressConfigCache tracks the exact Kubernetes inputs last applied for each
+// Ingress. Status and other server-managed metadata are deliberately excluded.
+type ingressConfigCache struct {
+	mu          sync.RWMutex
+	initialized bool
+	applied     map[types.NamespacedName]ingressConfigFingerprint
+}
+
+func (c *ingressConfigCache) hit(name types.NamespacedName, fingerprint ingressConfigFingerprint) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	applied, ok := c.applied[name]
+	return ok && applied == fingerprint
+}
+
+func (c *ingressConfigCache) contains(name types.NamespacedName) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	_, ok := c.applied[name]
+	return ok
+}
+
+func (c *ingressConfigCache) matches(fingerprints map[types.NamespacedName]ingressConfigFingerprint) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if !c.initialized || len(c.applied) != len(fingerprints) {
+		return false
+	}
+	for name, fingerprint := range fingerprints {
+		if c.applied[name] != fingerprint {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *ingressConfigCache) store(name types.NamespacedName, fingerprint ingressConfigFingerprint) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.applied == nil {
+		c.applied = make(map[types.NamespacedName]ingressConfigFingerprint)
+	}
+	c.initialized = true
+	c.applied[name] = fingerprint
+}
+
+func (c *ingressConfigCache) replace(fingerprints map[types.NamespacedName]ingressConfigFingerprint) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.initialized = true
+	c.applied = fingerprints
+}
+
+func (c *ingressConfigCache) delete(name types.NamespacedName) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.applied, name)
+}
+
+type ingressConfigFingerprintInput struct {
+	AnnotationPrefix string                 `json:"annotationPrefix"`
+	Ingress          ingressFingerprint     `json:"ingress"`
+	Endpoints        []endpointsFingerprint `json:"endpoints"`
+	Secrets          []secretFingerprint    `json:"secrets"`
+	Services         []serviceFingerprint   `json:"services"`
+}
+
+type ingressFingerprint struct {
+	UID         types.UID                `json:"uid"`
+	Generation  int64                    `json:"generation"`
+	Labels      map[string]string        `json:"labels"`
+	Annotations map[string]string        `json:"annotations"`
+	Spec        networkingv1.IngressSpec `json:"spec"`
+}
+
+type objectFingerprint struct {
+	Namespace       string    `json:"namespace"`
+	Name            string    `json:"name"`
+	UID             types.UID `json:"uid"`
+	ResourceVersion string    `json:"resourceVersion"`
+}
+
+type endpointsFingerprint struct {
+	Object  objectFingerprint       `json:"object"`
+	Subsets []corev1.EndpointSubset `json:"subsets"`
+}
+
+type secretFingerprint struct {
+	Object objectFingerprint `json:"object"`
+	Type   corev1.SecretType `json:"type"`
+	Data   map[string][]byte `json:"data"`
+}
+
+type serviceFingerprint struct {
+	Object objectFingerprint  `json:"object"`
+	Spec   corev1.ServiceSpec `json:"spec"`
+}
+
+func fingerprintIngressConfigs(ics []*model.IngressConfig) (map[types.NamespacedName]ingressConfigFingerprint, error) {
+	fingerprints := make(map[types.NamespacedName]ingressConfigFingerprint, len(ics))
+	for _, ic := range ics {
+		fingerprint, err := fingerprintIngressConfig(ic)
+		if err != nil {
+			return nil, err
+		}
+		fingerprints[ic.GetIngressNamespacedName()] = fingerprint
+	}
+	return fingerprints, nil
+}
+
+func fingerprintIngressConfig(ic *model.IngressConfig) (ingressConfigFingerprint, error) {
+	input := ingressConfigFingerprintInput{
+		AnnotationPrefix: ic.AnnotationPrefix,
+		Ingress: ingressFingerprint{
+			UID:         ic.Ingress.UID,
+			Generation:  ic.Ingress.Generation,
+			Labels:      ic.Ingress.Labels,
+			Annotations: ic.Ingress.Annotations,
+			Spec:        ic.Ingress.Spec,
+		},
+		Endpoints: make([]endpointsFingerprint, 0, len(ic.Endpoints)),
+		Secrets:   make([]secretFingerprint, 0, len(ic.Secrets)),
+		Services:  make([]serviceFingerprint, 0, len(ic.Services)),
+	}
+
+	for _, endpoint := range ic.Endpoints {
+		input.Endpoints = append(input.Endpoints, endpointsFingerprint{
+			Object: objectMetaFingerprint(endpoint.ObjectMeta), Subsets: endpoint.Subsets,
+		})
+	}
+	for _, secret := range ic.Secrets {
+		input.Secrets = append(input.Secrets, secretFingerprint{
+			Object: objectMetaFingerprint(secret.ObjectMeta), Type: secret.Type, Data: secret.Data,
+		})
+	}
+	for _, service := range ic.Services {
+		input.Services = append(input.Services, serviceFingerprint{
+			Object: objectMetaFingerprint(service.ObjectMeta), Spec: service.Spec,
+		})
+	}
+
+	sort.Slice(input.Endpoints, func(i, j int) bool { return objectLess(input.Endpoints[i].Object, input.Endpoints[j].Object) })
+	sort.Slice(input.Secrets, func(i, j int) bool { return objectLess(input.Secrets[i].Object, input.Secrets[j].Object) })
+	sort.Slice(input.Services, func(i, j int) bool { return objectLess(input.Services[i].Object, input.Services[j].Object) })
+
+	b, err := json.Marshal(input)
+	if err != nil {
+		return ingressConfigFingerprint{}, err
+	}
+	return sha256.Sum256(b), nil
+}
+
+func objectMetaFingerprint(meta metav1.ObjectMeta) objectFingerprint {
+	return objectFingerprint{
+		Namespace: meta.Namespace, Name: meta.Name, UID: meta.UID, ResourceVersion: meta.ResourceVersion,
+	}
+}
+
+func objectLess(a, b objectFingerprint) bool {
+	if a.Namespace != b.Namespace {
+		return a.Namespace < b.Namespace
+	}
+	return a.Name < b.Name
+}

--- a/pomerium/ingress_config_cache_test.go
+++ b/pomerium/ingress_config_cache_test.go
@@ -1,0 +1,126 @@
+package pomerium
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/pomerium/ingress-controller/model"
+)
+
+func cacheTestIngressConfig() *model.IngressConfig {
+	serviceName := types.NamespacedName{Namespace: "default", Name: "service"}
+	secretName := types.NamespacedName{Namespace: "default", Name: "tls"}
+	return &model.IngressConfig{
+		AnnotationPrefix: "ingress.pomerium.io",
+		Ingress: &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default", Name: "app", UID: "ingress-uid", Generation: 7,
+				ResourceVersion: "100", Labels: map[string]string{"app": "test"},
+				Annotations: map[string]string{"ingress.pomerium.io/pass_identity_headers": "true"},
+			},
+			Spec: networkingv1.IngressSpec{Rules: []networkingv1.IngressRule{{Host: "app.example.test"}}},
+			Status: networkingv1.IngressStatus{LoadBalancer: networkingv1.IngressLoadBalancerStatus{
+				Ingress: []networkingv1.IngressLoadBalancerIngress{{IP: "192.0.2.1"}},
+			}},
+		},
+		Services: map[types.NamespacedName]*corev1.Service{serviceName: {
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "service", UID: "service-uid", ResourceVersion: "200"},
+			Spec:       corev1.ServiceSpec{ClusterIP: "10.96.0.10"},
+		}},
+		Endpoints: map[types.NamespacedName]*corev1.Endpoints{serviceName: {
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "service", UID: "endpoints-uid", ResourceVersion: "300"},
+			Subsets:    []corev1.EndpointSubset{{Addresses: []corev1.EndpointAddress{{IP: "10.0.0.1"}}}},
+		}},
+		Secrets: map[types.NamespacedName]*corev1.Secret{secretName: {
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "tls", UID: "secret-uid", ResourceVersion: "400"},
+			Type:       corev1.SecretTypeTLS, Data: map[string][]byte{corev1.TLSCertKey: []byte("certificate")},
+		}},
+	}
+}
+
+func TestIngressConfigCacheIgnoresStatusOnlyUpdates(t *testing.T) {
+	before := cacheTestIngressConfig()
+	after := cacheTestIngressConfig()
+	after.Ingress.ResourceVersion = "101"
+	after.Ingress.ManagedFields = []metav1.ManagedFieldsEntry{{Manager: "controller"}}
+	after.Ingress.Status.LoadBalancer.Ingress[0].IP = "192.0.2.2"
+
+	beforeFingerprint, err := fingerprintIngressConfig(before)
+	require.NoError(t, err)
+	afterFingerprint, err := fingerprintIngressConfig(after)
+	require.NoError(t, err)
+	assert.Equal(t, beforeFingerprint, afterFingerprint)
+}
+
+func TestIngressConfigCacheDetectsConfigInputs(t *testing.T) {
+	base, err := fingerprintIngressConfig(cacheTestIngressConfig())
+	require.NoError(t, err)
+	tests := map[string]func(*model.IngressConfig){
+		"annotation": func(ic *model.IngressConfig) {
+			ic.Ingress.Annotations["ingress.pomerium.io/pass_identity_headers"] = "false"
+		},
+		"label": func(ic *model.IngressConfig) { ic.Ingress.Labels["app"] = "changed" },
+		"spec":  func(ic *model.IngressConfig) { ic.Ingress.Spec.Rules[0].Host = "changed.example.test" },
+		"service": func(ic *model.IngressConfig) {
+			ic.Services[types.NamespacedName{Namespace: "default", Name: "service"}].Spec.ClusterIP = "10.96.0.11"
+		},
+		"endpoints": func(ic *model.IngressConfig) {
+			ic.Endpoints[types.NamespacedName{Namespace: "default", Name: "service"}].Subsets[0].Addresses[0].IP = "10.0.0.2"
+		},
+		"secret": func(ic *model.IngressConfig) {
+			ic.Secrets[types.NamespacedName{Namespace: "default", Name: "tls"}].Data[corev1.TLSCertKey] = []byte("changed")
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			ic := cacheTestIngressConfig()
+			mutate(ic)
+			got, err := fingerprintIngressConfig(ic)
+			require.NoError(t, err)
+			assert.NotEqual(t, base, got)
+		})
+	}
+}
+
+func TestIngressConfigCacheShortCircuitsDuplicates(t *testing.T) {
+	ic := cacheTestIngressConfig()
+	fingerprint, err := fingerprintIngressConfig(ic)
+	require.NoError(t, err)
+	r := &DataBrokerReconciler{}
+	r.ingressConfigCache.store(ic.GetIngressNamespacedName(), fingerprint)
+
+	changed, err := r.Upsert(context.Background(), cacheTestIngressConfig())
+	require.NoError(t, err)
+	assert.False(t, changed)
+
+	r.ingressConfigCache.replace(map[types.NamespacedName]ingressConfigFingerprint{ic.GetIngressNamespacedName(): fingerprint})
+	changed, err = r.Set(context.Background(), []*model.IngressConfig{cacheTestIngressConfig()})
+	require.NoError(t, err)
+	assert.False(t, changed)
+}
+
+func TestIngressConfigCacheDoesNotSkipInitialEmptySet(t *testing.T) {
+	var cache ingressConfigCache
+	assert.False(t, cache.matches(map[types.NamespacedName]ingressConfigFingerprint{}))
+	cache.replace(map[types.NamespacedName]ingressConfigFingerprint{})
+	assert.True(t, cache.matches(map[types.NamespacedName]ingressConfigFingerprint{}))
+}
+
+func TestIngressConfigCacheTracksAndDeletes(t *testing.T) {
+	ic := cacheTestIngressConfig()
+	fingerprint, err := fingerprintIngressConfig(ic)
+	require.NoError(t, err)
+	var cache ingressConfigCache
+	name := ic.GetIngressNamespacedName()
+	cache.store(name, fingerprint)
+	assert.True(t, cache.contains(name))
+	cache.delete(name)
+	assert.False(t, cache.contains(name))
+}

--- a/pomerium/reconcile.go
+++ b/pomerium/reconcile.go
@@ -19,6 +19,13 @@ type IngressReconciler interface {
 	Delete(ctx context.Context, namespacedName types.NamespacedName) (changes bool, err error)
 }
 
+// IngressChangeDetector reports whether the current Kubernetes inputs have
+// already been persisted. It is used by optional controller-side batching.
+type IngressChangeDetector interface {
+	NeedsIngressUpdate(ic *model.IngressConfig) (bool, error)
+	TracksIngress(namespacedName types.NamespacedName) bool
+}
+
 // GatewayReconciler updates Pomerium configuration based on Gateway-defined resources.
 type GatewayReconciler interface {
 	// GatewaySetConfig updates the entire Gateway-defined route configuration.

--- a/pomerium/sync.go
+++ b/pomerium/sync.go
@@ -3,9 +3,9 @@ package pomerium
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -101,7 +101,6 @@ func (r *DataBrokerReconciler) Upsert(ctx context.Context, ic *model.IngressConf
 
 // Set merges existing config with the one generated for ingress
 func (r *DataBrokerReconciler) Set(ctx context.Context, ics []*model.IngressConfig) (bool, error) {
-	logger := log.FromContext(ctx)
 	fingerprints, err := fingerprintIngressConfigs(ics)
 	if err != nil {
 		return false, fmt.Errorf("fingerprint ingress configs: %w", err)
@@ -114,26 +113,55 @@ func (r *DataBrokerReconciler) Set(ctx context.Context, ics []*model.IngressConf
 	if err != nil {
 		return false, fmt.Errorf("get config: %w", err)
 	}
-	next := new(pb.Config)
-
-	for _, ic := range ics {
-		cfg := proto.Clone(next).(*pb.Config)
-		if err := multierror.Append(
-			upsertRoutes(ctx, cfg, ic),
-			validate(ctx, cfg, string(ic.Ingress.UID)),
-		).ErrorOrNil(); err != nil {
-			logger.Error(err, "skip ingress", "ingress", fmt.Sprintf("%s/%s", ic.Namespace, ic.Name))
-			continue
-		}
-		addCerts(cfg, ic.Secrets)
-		next = cfg
-	}
+	next := buildIngressConfig(ctx, ics, nil)
 
 	changed, err := r.saveConfig(ctx, prev, next, r.ConfigID)
+	var validationErr *configValidationError
+	if errors.As(err, &validationErr) {
+		// Keep the fast path to one full validation. If it fails, fall back to
+		// validating each Ingress in isolation so one invalid object still does
+		// not block unrelated valid changes.
+		next = buildIngressConfig(ctx, ics, validate)
+		changed, err = r.saveConfig(ctx, prev, next, r.ConfigID)
+	}
 	if err == nil {
 		r.ingressConfigCache.replace(fingerprints)
 	}
 	return changed, err
+}
+
+type configValidator func(context.Context, *pb.Config, string) error
+
+// buildIngressConfig builds each Ingress in isolation before merging it into
+// the full configuration. The optional validator is used by the slow fallback
+// after full validation fails. Cloning and validating the accumulated config
+// for every Ingress makes reconciliation quadratic and can leave removed
+// endpoints active while a large batch is being rebuilt.
+func buildIngressConfig(
+	ctx context.Context,
+	ics []*model.IngressConfig,
+	validator configValidator,
+) *pb.Config {
+	logger := log.FromContext(ctx)
+	next := new(pb.Config)
+
+	for _, ic := range ics {
+		cfg := new(pb.Config)
+		if err := upsertRoutes(ctx, cfg, ic); err != nil {
+			logger.Error(err, "skip ingress", "ingress", fmt.Sprintf("%s/%s", ic.Namespace, ic.Name))
+			continue
+		}
+		if validator != nil {
+			if err := validator(ctx, cfg, string(ic.Ingress.UID)); err != nil {
+				logger.Error(err, "skip ingress", "ingress", fmt.Sprintf("%s/%s", ic.Namespace, ic.Name))
+				continue
+			}
+		}
+		next.Routes = append(next.Routes, cfg.Routes...)
+		addCerts(next, ic.Secrets)
+	}
+
+	return next
 }
 
 // SetConfig updates just the shared config settings
@@ -239,7 +267,7 @@ func (r *DataBrokerReconciler) saveConfig(ctx context.Context, prev, next *pb.Co
 	ensureDeterministicConfigOrder(next)
 
 	if err := validate(ctx, next, id); err != nil {
-		return false, fmt.Errorf("config validation: %w", err)
+		return false, &configValidationError{err: err}
 	}
 
 	logger := log.FromContext(ctx)
@@ -265,6 +293,18 @@ func (r *DataBrokerReconciler) saveConfig(ctx context.Context, prev, next *pb.Co
 	logger.Info("new pomerium config applied")
 
 	return true, nil
+}
+
+type configValidationError struct {
+	err error
+}
+
+func (e *configValidationError) Error() string {
+	return fmt.Sprintf("config validation: %v", e.err)
+}
+
+func (e *configValidationError) Unwrap() error {
+	return e.err
 }
 
 func debugDumpConfigDiff(prev, next *pb.Config) []byte {

--- a/pomerium/sync.go
+++ b/pomerium/sync.go
@@ -36,6 +36,7 @@ const (
 
 var (
 	_ = IngressReconciler((*DataBrokerReconciler)(nil))
+	_ = IngressChangeDetector((*DataBrokerReconciler)(nil))
 	_ = GatewayReconciler((*DataBrokerReconciler)(nil))
 	_ = ConfigReconciler((*DataBrokerReconciler)(nil))
 )
@@ -50,10 +51,36 @@ type DataBrokerReconciler struct {
 	DebugDumpConfigDiff bool
 	// RemoveUnreferencedCerts would strip any certs not matched by any of the Routes SNI
 	RemoveUnreferencedCerts bool
+	// ingressConfigCache avoids rebuilding the monolithic Pomerium config for
+	// duplicate Kubernetes events. The zero value is ready for use.
+	ingressConfigCache ingressConfigCache
+}
+
+// NeedsIngressUpdate reports whether the current Kubernetes inputs differ
+// from the last configuration successfully persisted by this reconciler.
+func (r *DataBrokerReconciler) NeedsIngressUpdate(ic *model.IngressConfig) (bool, error) {
+	fingerprint, err := fingerprintIngressConfig(ic)
+	if err != nil {
+		return false, fmt.Errorf("fingerprint ingress config: %w", err)
+	}
+	return !r.ingressConfigCache.hit(ic.GetIngressNamespacedName(), fingerprint), nil
+}
+
+// TracksIngress reports whether this reconciler last persisted an Ingress.
+func (r *DataBrokerReconciler) TracksIngress(namespacedName types.NamespacedName) bool {
+	return r.ingressConfigCache.contains(namespacedName)
 }
 
 // Upsert should update or create the pomerium routes corresponding to this ingress
 func (r *DataBrokerReconciler) Upsert(ctx context.Context, ic *model.IngressConfig) (bool, error) {
+	fingerprint, err := fingerprintIngressConfig(ic)
+	if err != nil {
+		return false, fmt.Errorf("fingerprint ingress config: %w", err)
+	}
+	if r.ingressConfigCache.hit(ic.GetIngressNamespacedName(), fingerprint) {
+		return false, nil
+	}
+
 	prev, err := r.getConfig(ctx)
 	if err != nil {
 		return false, fmt.Errorf("get config: %w", err)
@@ -65,12 +92,23 @@ func (r *DataBrokerReconciler) Upsert(ctx context.Context, ic *model.IngressConf
 	}
 	addCerts(next, ic.Secrets)
 
-	return r.saveConfig(ctx, prev, next, fmt.Sprintf("%s-%s", r.ConfigID, ic.Ingress.UID))
+	changed, err := r.saveConfig(ctx, prev, next, fmt.Sprintf("%s-%s", r.ConfigID, ic.Ingress.UID))
+	if err == nil {
+		r.ingressConfigCache.store(ic.GetIngressNamespacedName(), fingerprint)
+	}
+	return changed, err
 }
 
 // Set merges existing config with the one generated for ingress
 func (r *DataBrokerReconciler) Set(ctx context.Context, ics []*model.IngressConfig) (bool, error) {
 	logger := log.FromContext(ctx)
+	fingerprints, err := fingerprintIngressConfigs(ics)
+	if err != nil {
+		return false, fmt.Errorf("fingerprint ingress configs: %w", err)
+	}
+	if r.ingressConfigCache.matches(fingerprints) {
+		return false, nil
+	}
 
 	prev, err := r.getConfig(ctx)
 	if err != nil {
@@ -91,7 +129,11 @@ func (r *DataBrokerReconciler) Set(ctx context.Context, ics []*model.IngressConf
 		next = cfg
 	}
 
-	return r.saveConfig(ctx, prev, next, r.ConfigID)
+	changed, err := r.saveConfig(ctx, prev, next, r.ConfigID)
+	if err == nil {
+		r.ingressConfigCache.replace(fingerprints)
+	}
+	return changed, err
 }
 
 // SetConfig updates just the shared config settings
@@ -123,6 +165,7 @@ func (r *DataBrokerReconciler) Delete(ctx context.Context, namespacedName types.
 	if err != nil {
 		return false, fmt.Errorf("updating pomerium config: %w", err)
 	}
+	r.ingressConfigCache.delete(namespacedName)
 	return changed, nil
 }
 

--- a/pomerium/sync_test.go
+++ b/pomerium/sync_test.go
@@ -1,0 +1,119 @@
+package pomerium
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	pb "github.com/pomerium/pomerium/pkg/grpc/config"
+
+	"github.com/pomerium/ingress-controller/model"
+)
+
+func TestBuildIngressConfigValidatesIngressesInIsolation(t *testing.T) {
+	ics := []*model.IngressConfig{
+		buildConfigTestIngress("app-a", "uid-a"),
+		buildConfigTestIngress("broken", "skip"),
+		buildConfigTestIngress("app-b", "uid-b"),
+	}
+
+	var validatedRouteCounts []int
+	validator := func(_ context.Context, cfg *pb.Config, id string) error {
+		validatedRouteCounts = append(validatedRouteCounts, len(cfg.Routes))
+		if id == "skip" {
+			return errors.New("invalid ingress")
+		}
+		return nil
+	}
+
+	cfg := buildIngressConfig(context.Background(), ics, validator)
+
+	assert.Equal(t, []int{1, 1, 1}, validatedRouteCounts,
+		"validation input must not grow with the accumulated full-state config")
+	require.Len(t, cfg.Routes, 2)
+	assert.Contains(t, cfg.Routes[0].Name, "app-a")
+	assert.Contains(t, cfg.Routes[1].Name, "app-b")
+}
+
+func TestBuildIngressConfigMatchesAccumulatedBuild(t *testing.T) {
+	ics := []*model.IngressConfig{
+		buildConfigTestIngress("app-a", "uid-a"),
+		buildConfigTestIngress("app-b", "uid-b"),
+		buildConfigTestIngress("app-c", "uid-c"),
+	}
+	tlsName := types.NamespacedName{Namespace: "default", Name: "tls"}
+	ics[0].Secrets = map[types.NamespacedName]*corev1.Secret{tlsName: {
+		ObjectMeta: metav1.ObjectMeta{Namespace: tlsName.Namespace, Name: tlsName.Name},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       []byte("certificate"),
+			corev1.TLSPrivateKeyKey: []byte("private-key"),
+		},
+	}}
+
+	legacy := new(pb.Config)
+	for _, ic := range ics {
+		cfg := proto.Clone(legacy).(*pb.Config)
+		require.NoError(t, upsertRoutes(context.Background(), cfg, ic))
+		addCerts(cfg, ic.Secrets)
+		legacy = cfg
+	}
+	next := buildIngressConfig(context.Background(), ics, func(context.Context, *pb.Config, string) error {
+		return nil
+	})
+	ensureDeterministicConfigOrder(legacy)
+	ensureDeterministicConfigOrder(next)
+
+	assert.True(t, proto.Equal(legacy, next))
+}
+
+func buildConfigTestIngress(name string, uid types.UID) *model.IngressConfig {
+	const annotationPrefix = "ingress.pomerium.io"
+	serviceName := types.NamespacedName{Namespace: "default", Name: "echo"}
+	pathType := networkingv1.PathTypePrefix
+	return &model.IngressConfig{
+		AnnotationPrefix: annotationPrefix,
+		Ingress: &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      name,
+				UID:       uid,
+				Annotations: map[string]string{
+					fmt.Sprintf("%s/%s", annotationPrefix, model.UseServiceProxy): "true",
+				},
+			},
+			Spec: networkingv1.IngressSpec{Rules: []networkingv1.IngressRule{{
+				Host: name + ".example.test",
+				IngressRuleValue: networkingv1.IngressRuleValue{HTTP: &networkingv1.HTTPIngressRuleValue{
+					Paths: []networkingv1.HTTPIngressPath{{
+						Path:     "/",
+						PathType: &pathType,
+						Backend: networkingv1.IngressBackend{Service: &networkingv1.IngressServiceBackend{
+							Name: "echo",
+							Port: networkingv1.ServiceBackendPort{Name: "http"},
+						}},
+					}},
+				}},
+			}}},
+		},
+		Services: map[types.NamespacedName]*corev1.Service{serviceName: {
+			ObjectMeta: metav1.ObjectMeta{Namespace: serviceName.Namespace, Name: serviceName.Name},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "10.96.0.10",
+				Ports: []corev1.ServicePort{{
+					Name: "http", Port: 80, TargetPort: intstr.FromInt32(8080),
+				}},
+			},
+		}},
+	}
+}


### PR DESCRIPTION
## Summary

This draft is a `v0.32.9`-based candidate for a controlled dev canary. It is related to pomerium/ingress-controller#1477, but does not include that PR's commit history.

The current implementation repeatedly copies and validates the growing configuration for every Ingress, causing reconciliation time to grow quadratically.

This change:

- builds each Ingress route fragment once;
- combines all fragments into one complete configuration;
- validates and writes the configuration once;
- isolates only invalid Ingresses if final validation fails;
- batches related events and skips duplicate or status-only changes;
- removes stale managed statuses; and
- safely drains pods during rollouts.

Pomerium still receives one complete, validated configuration.

## Local validation

- ~446 Ingresses: full-state application reduced from ~65 seconds to ~2 seconds.
- Cold start: initial sync completed in ~10 seconds.
- Unit tests, envtest, race tests and `go vet` passed.
- 60-minute test with three replicas:
  - 7,011 HTTP 200 responses
  - 0 HTTP 503 responses
  - 0 timeouts
  - 0 TLS/transport errors
- The test included a rollout and backend scaling from 2 → 3 → 2 endpoints.
- Pomerium Core remains at `v0.32.9`.

## Proposed dev canary

Repeat cold starts, a three-replica rollout and backend removal in non-production GKE while monitoring:

- restart-to-ready and initial-sync duration;
- reconciliation queue and batch duration;
- HTTP 503 responses, timeouts and TLS errors;
- retries and pod restarts; and
- API server load.

Keep the current dev image available for immediate rollback.

## Related issues

Related to pomerium/ingress-controller#1477.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] updated docs
- [ ] ready for review