### PR TITLE
docker: use distroless base-nossl image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base-debian12:debug-nonroot@sha256:ddd86b705dac25b3cc5f9d580018c6397c6b02ae5c2fa58ae95409c71e73cc3b
+FROM gcr.io/distroless/base-nossl-debian12:debug-nonroot@sha256:32d0efd5a21d0274ba4d04c5bc233fec686a4d5fe28aca3447926d5304f1b102
 COPY bin/manager /manager
 USER 65532:65532
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,6 +1,6 @@
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base-debian12:debug-nonroot@sha256:ddd86b705dac25b3cc5f9d580018c6397c6b02ae5c2fa58ae95409c71e73cc3b
+FROM gcr.io/distroless/base-nossl-debian12:debug-nonroot@sha256:32d0efd5a21d0274ba4d04c5bc233fec686a4d5fe28aca3447926d5304f1b102
 ARG TARGETARCH
 COPY bin/manager-linux-$TARGETARCH /manager
 USER 65532:65532


### PR DESCRIPTION
## Summary

Backport of #1484.

Switch the runtime base image from `gcr.io/distroless/base-debian12:debug-nonroot` to `gcr.io/distroless/base-nossl-debian12:debug-nonroot` in `Dockerfile` and `Dockerfile.ci`.

glibc is the only thing we need from the base image. The embedded envoy binary is a dynamically linked PIE, and every library it needs comes from `libc6`: `libc.so.6`, `libm.so.6`, `libpthread.so.0`, `libdl.so.2`, `libresolv.so.2`, `librt.so.1` and the loader. Neither the `manager` binary nor envoy links `libssl.so.3` or `libcrypto.so.3` — envoy statically links BoringSSL — so the OpenSSL shared libraries were never loaded.

`base-nossl-debian12` is `base-debian12` minus the `libssl3` package and nothing else: same `libc6`, `base-files`, `netbase`, `tzdata` and `media-types`, and nothing added. Net effect is dropping the OpenSSL CVE surface from the published images.

The base image digest is refreshed to current, since there is no digest-stable mapping between the `base` and `base-nossl` variants.

## Related issues

- #1484
- pomerium/pomerium#6612

## User Explanation

Published ingress controller images no longer include the OpenSSL shared libraries, which were never loaded at runtime. No behavior change.

## AI disclosure

Claude Code — made the Dockerfile edits, checked the dynamic-linking requirements of the manager and envoy binaries, diffed the two base images, and ran a container smoke test (on `main`, see #1484).
