### PR TITLE
docs: update template and PR script

### DIFF
--- a/docs/templates/header.tmpl
+++ b/docs/templates/header.tmpl
@@ -1,4 +1,4 @@
-{{- define "header"}}
+{{- define "header" -}}
 ---
 title: Kubernetes Deployment Reference
 sidebar_label: Reference

--- a/reference.md
+++ b/reference.md
@@ -1,4 +1,3 @@
-
 ---
 title: Kubernetes Deployment Reference
 sidebar_label: Reference

--- a/scripts/open-docs-pull-request.sh
+++ b/scripts/open-docs-pull-request.sh
@@ -18,8 +18,8 @@ git clone --depth 1 \
 echo "Copying contents to git repo"
 cp -R "$source_path" "$clone_dir/$destination_path"
 cd "$clone_dir"
-yarn
-yarn prettier --write "$destination_path/$source_path"
+npm ci
+npx --no-install prettier --write "$destination_path/$source_path"
 git checkout -b "$destination_head_branch"
 
 if [ -z "$(git status -z)" ]; then


### PR DESCRIPTION
## Summary

When the documentation repo updated prettier from v3.8.4 to v3.9.6 in commit pomerium/documentation@5f088a47, prettier started to mangle the front matter in reference.md. This is apparently caused by the blank line before the front matter. If we remove this blank line, prettier no longer tries to put all of the front matter on a single line.

Separately, the documentation repo switched from yarn to npm in commit pomerium/documentation@528d9c40. Update the open-docs-pull-request.sh script accordingly. This way, it should use the version of prettier defined in the package-lock.json file, and it will avoid generating a whole new yarn.lock file.

## Related issues

Fixes https://linear.app/pomerium/issue/ENG-4295/docs-prettier-is-mangling-the-k8s-referencemd-front-matter

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
