### PR TITLE
docs: update PR script to use oxfmt

### DIFF
--- a/scripts/open-docs-pull-request.sh
+++ b/scripts/open-docs-pull-request.sh
@@ -19,7 +19,7 @@ echo "Copying contents to git repo"
 cp -R "$source_path" "$clone_dir/$destination_path"
 cd "$clone_dir"
 npm ci
-npx --no-install prettier --write "$destination_path/$source_path"
+npx --no-install oxfmt --write "$destination_path/$source_path"
 git checkout -b "$destination_head_branch"
 
 if [ -z "$(git status -z)" ]; then


### PR DESCRIPTION
## Summary

The documentation repo has switched from prettier to oxfmt (in https://github.com/pomerium/documentation/pull/2338). Update the open-docs-pull-request.sh script accordingly.

## Related issues

Example failing 'Docs' workflow: https://github.com/pomerium/ingress-controller/actions/runs/30672218536.

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
