### PR TITLE
sync: make sure to apply namespace ID to settings

### DIFF
--- a/pomerium/sync_api.go
+++ b/pomerium/sync_api.go
@@ -393,7 +393,13 @@ func (r *APIReconciler) SetConfig(ctx context.Context, cfg *model.Config) (chang
 		return false, err
 	}
 
-	resp, err := r.apiClient.GetSettings(ctx, connect.NewRequest(&configpb.GetSettingsRequest{}))
+	req := &configpb.GetSettingsRequest{}
+	if r.namespaceID != nil {
+		req.For = &configpb.GetSettingsRequest_NamespaceId{
+			NamespaceId: *r.namespaceID,
+		}
+	}
+	resp, err := r.apiClient.GetSettings(ctx, connect.NewRequest(req))
 	if err != nil {
 		return false, err
 	}
@@ -401,6 +407,7 @@ func (r *APIReconciler) SetConfig(ctx context.Context, cfg *model.Config) (chang
 
 	// Preserve any settings that cannot be set via the Pomerium CRD.
 	settings.Id = existing.Id
+	settings.NamespaceId = existing.NamespaceId
 	settings.AutoApplyChangesets = existing.AutoApplyChangesets
 	settings.AutocertDir = existing.AutocertDir
 	settings.RuntimeFlags = existing.RuntimeFlags

--- a/pomerium/sync_api_test.go
+++ b/pomerium/sync_api_test.go
@@ -1146,20 +1146,26 @@ func TestAPIReconciler_SetConfig(t *testing.T) {
 
 	t.Run("settings changed", func(t *testing.T) {
 		apiClient, _, r := setupReconciler(t)
+		r.namespaceID = new("api-namespace-id")
 		ctx := t.Context()
 
 		// APIReconciler should first call GetSettings() to determine if it needs to sync any changes...
-		apiClient.EXPECT().GetSettings(ctx, RequestEq(&configpb.GetSettingsRequest{})).
-			Return(&connect.Response[configpb.GetSettingsResponse]{
-				Msg: &configpb.GetSettingsResponse{
-					Settings: &configpb.Settings{
-						Id: new("settings-id-123"),
-					},
+		apiClient.EXPECT().GetSettings(ctx, RequestEq(&configpb.GetSettingsRequest{
+			For: &configpb.GetSettingsRequest_NamespaceId{
+				NamespaceId: "api-namespace-id",
+			},
+		})).Return(&connect.Response[configpb.GetSettingsResponse]{
+			Msg: &configpb.GetSettingsResponse{
+				Settings: &configpb.Settings{
+					Id:          new("settings-id-123"),
+					NamespaceId: new("api-namespace-id"),
 				},
-			}, nil)
+			},
+		}, nil)
 
 		expectedSettings := proto.CloneOf(defaultSettings)
 		expectedSettings.Id = new("settings-id-123")
+		expectedSettings.NamespaceId = new("api-namespace-id")
 		expectedSettings.AuthenticateServiceUrl = new("https://authenticate.localhost.pomerium.io")
 		expectedSettings.AutocertDir = nil
 		expectedSettings.IdpClientId = new("CLIENT_ID")


### PR DESCRIPTION
## Summary

Update the GetSettings() request to use the new `namespace_id` field, to make sure that we operate on the settings for the cluster corresponding to the provided namespace.

## Related issues

https://linear.app/pomerium/issue/ENG-4272/ingress-controller-settings-sync-to-zero-fails-with-cannot-get

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
