### PR TITLE
feat: add path/header normalization settings to the Pomerium CRD

### DIFF
--- a/apis/ingress/v1/pomerium_types.go
+++ b/apis/ingress/v1/pomerium_types.go
@@ -351,6 +351,36 @@ type PomeriumSpec struct {
 	// +kubebuilder:validation:Enum=auto;http1;http2;http3
 	CodecType *string `json:"codecType,omitempty"`
 
+	// NormalizePath sets whether paths are normalized according to RFC 3986
+	// before any processing of requests by HTTP filters or routing.
+	// These settings apply to the whole listener and cannot be set per Ingress.
+	//
+	// +kubebuilder:validation:Optional
+	NormalizePath *bool `json:"normalizePath,omitempty"`
+
+	// MergeSlashes sets whether adjacent slashes in the path are merged into one
+	// before any processing of requests by HTTP filters or routing.
+	// These settings apply to the whole listener and cannot be set per Ingress.
+	//
+	// +kubebuilder:validation:Optional
+	MergeSlashes *bool `json:"mergeSlashes,omitempty"`
+
+	// PathWithEscapedSlashesAction sets the action to take when a request URL path
+	// contains escaped slash sequences (%2F, %2f, %5C and %5c).
+	// These settings apply to the whole listener and cannot be set per Ingress.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=keep_unchanged;reject_request;unescape_and_redirect;unescape_and_forward
+	PathWithEscapedSlashesAction *string `json:"pathWithEscapedSlashesAction,omitempty"`
+
+	// HeadersWithUnderscoresAction sets the action to take when a client request
+	// with a header name containing underscore characters is received.
+	// These settings apply to the whole listener and cannot be set per Ingress.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=allow;reject_request;drop_header
+	HeadersWithUnderscoresAction *string `json:"headersWithUnderscoresAction,omitempty"`
+
 	// BearerTokenFormat sets the <a href="https://www.pomerium.com/docs/reference/bearer-token-format">Bearer Token Format</a>.
 	//
 	// +kubebuilder:validation:Optional

--- a/apis/ingress/v1/zz_generated.deepcopy.go
+++ b/apis/ingress/v1/zz_generated.deepcopy.go
@@ -552,6 +552,26 @@ func (in *PomeriumSpec) DeepCopyInto(out *PomeriumSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.NormalizePath != nil {
+		in, out := &in.NormalizePath, &out.NormalizePath
+		*out = new(bool)
+		**out = **in
+	}
+	if in.MergeSlashes != nil {
+		in, out := &in.MergeSlashes, &out.MergeSlashes
+		*out = new(bool)
+		**out = **in
+	}
+	if in.PathWithEscapedSlashesAction != nil {
+		in, out := &in.PathWithEscapedSlashesAction, &out.PathWithEscapedSlashesAction
+		*out = new(string)
+		**out = **in
+	}
+	if in.HeadersWithUnderscoresAction != nil {
+		in, out := &in.HeadersWithUnderscoresAction, &out.HeadersWithUnderscoresAction
+		*out = new(string)
+		**out = **in
+	}
 	if in.BearerTokenFormat != nil {
 		in, out := &in.BearerTokenFormat, &out.BearerTokenFormat
 		*out = new(string)

--- a/config/crd/bases/ingress.pomerium.io_pomerium.yaml
+++ b/config/crd/bases/ingress.pomerium.io_pomerium.yaml
@@ -310,6 +310,16 @@ spec:
                 items:
                   type: string
                 type: array
+              headersWithUnderscoresAction:
+                description: |-
+                  HeadersWithUnderscoresAction sets the action to take when a client request
+                  with a header name containing underscore characters is received.
+                  These settings apply to the whole listener and cannot be set per Ingress.
+                enum:
+                - allow
+                - reject_request
+                - drop_header
+                type: string
               identityProvider:
                 description: |-
                   IdentityProvider configure single-sign-on authentication and user identity details
@@ -433,6 +443,18 @@ spec:
                 items:
                   type: string
                 type: array
+              mergeSlashes:
+                description: |-
+                  MergeSlashes sets whether adjacent slashes in the path are merged into one
+                  before any processing of requests by HTTP filters or routing.
+                  These settings apply to the whole listener and cannot be set per Ingress.
+                type: boolean
+              normalizePath:
+                description: |-
+                  NormalizePath sets whether paths are normalized according to RFC 3986
+                  before any processing of requests by HTTP filters or routing.
+                  These settings apply to the whole listener and cannot be set per Ingress.
+                type: boolean
               otel:
                 description: OTEL sets the <a href="https://www.pomerium.com/docs/reference/tracing">OpenTelemetry
                   Tracing</a>.
@@ -494,6 +516,17 @@ spec:
                 description: PassIdentityHeaders sets the <a href="https://www.pomerium.com/docs/reference/pass-identity-headers">pass
                   identity headers</a> option.
                 type: boolean
+              pathWithEscapedSlashesAction:
+                description: |-
+                  PathWithEscapedSlashesAction sets the action to take when a request URL path
+                  contains escaped slash sequences (%2F, %2f, %5C and %5c).
+                  These settings apply to the whole listener and cannot be set per Ingress.
+                enum:
+                - keep_unchanged
+                - reject_request
+                - unescape_and_redirect
+                - unescape_and_forward
+                type: string
               programmaticRedirectDomains:
                 description: |-
                   ProgrammaticRedirectDomains specifies a list of domains that can be used for

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -452,6 +452,16 @@ spec:
                 items:
                   type: string
                 type: array
+              headersWithUnderscoresAction:
+                description: |-
+                  HeadersWithUnderscoresAction sets the action to take when a client request
+                  with a header name containing underscore characters is received.
+                  These settings apply to the whole listener and cannot be set per Ingress.
+                enum:
+                - allow
+                - reject_request
+                - drop_header
+                type: string
               identityProvider:
                 description: |-
                   IdentityProvider configure single-sign-on authentication and user identity details
@@ -575,6 +585,18 @@ spec:
                 items:
                   type: string
                 type: array
+              mergeSlashes:
+                description: |-
+                  MergeSlashes sets whether adjacent slashes in the path are merged into one
+                  before any processing of requests by HTTP filters or routing.
+                  These settings apply to the whole listener and cannot be set per Ingress.
+                type: boolean
+              normalizePath:
+                description: |-
+                  NormalizePath sets whether paths are normalized according to RFC 3986
+                  before any processing of requests by HTTP filters or routing.
+                  These settings apply to the whole listener and cannot be set per Ingress.
+                type: boolean
               otel:
                 description: OTEL sets the <a href="https://www.pomerium.com/docs/reference/tracing">OpenTelemetry
                   Tracing</a>.
@@ -636,6 +658,17 @@ spec:
                 description: PassIdentityHeaders sets the <a href="https://www.pomerium.com/docs/reference/pass-identity-headers">pass
                   identity headers</a> option.
                 type: boolean
+              pathWithEscapedSlashesAction:
+                description: |-
+                  PathWithEscapedSlashesAction sets the action to take when a request URL path
+                  contains escaped slash sequences (%2F, %2f, %5C and %5c).
+                  These settings apply to the whole listener and cannot be set per Ingress.
+                enum:
+                - keep_unchanged
+                - reject_request
+                - unescape_and_redirect
+                - unescape_and_forward
+                type: string
               programmaticRedirectDomains:
                 description: |-
                   ProgrammaticRedirectDomains specifies a list of domains that can be used for

--- a/pomerium/config.go
+++ b/pomerium/config.go
@@ -185,6 +185,38 @@ func applySetOtherOptions(_ context.Context, p *pb.Config, c *model.Config) erro
 			return fmt.Errorf("unknown codecType %s", *c.Spec.CodecType)
 		}
 	}
+	p.Settings.NormalizePath = c.Spec.NormalizePath
+	p.Settings.MergeSlashes = c.Spec.MergeSlashes
+	if c.Spec.PathWithEscapedSlashesAction != nil {
+		switch *c.Spec.PathWithEscapedSlashesAction {
+		case "keep_unchanged":
+			p.Settings.PathWithEscapedSlashesAction = pb.PathWithEscapedSlashesAction_PATH_WITH_ESCAPED_SLASHES_ACTION_KEEP_UNCHANGED.Enum()
+		case "reject_request":
+			p.Settings.PathWithEscapedSlashesAction = pb.PathWithEscapedSlashesAction_PATH_WITH_ESCAPED_SLASHES_ACTION_REJECT_REQUEST.Enum()
+		case "unescape_and_redirect":
+			p.Settings.PathWithEscapedSlashesAction = pb.PathWithEscapedSlashesAction_PATH_WITH_ESCAPED_SLASHES_ACTION_UNESCAPE_AND_REDIRECT.Enum()
+		case "unescape_and_forward":
+			p.Settings.PathWithEscapedSlashesAction = pb.PathWithEscapedSlashesAction_PATH_WITH_ESCAPED_SLASHES_ACTION_UNESCAPE_AND_FORWARD.Enum()
+		default:
+			return fmt.Errorf("unknown pathWithEscapedSlashesAction %s", *c.Spec.PathWithEscapedSlashesAction)
+		}
+	} else {
+		p.Settings.PathWithEscapedSlashesAction = nil
+	}
+	if c.Spec.HeadersWithUnderscoresAction != nil {
+		switch *c.Spec.HeadersWithUnderscoresAction {
+		case "allow":
+			p.Settings.HeadersWithUnderscoresAction = pb.HeadersWithUnderscoresAction_HEADERS_WITH_UNDERSCORES_ACTION_ALLOW.Enum()
+		case "reject_request":
+			p.Settings.HeadersWithUnderscoresAction = pb.HeadersWithUnderscoresAction_HEADERS_WITH_UNDERSCORES_ACTION_REJECT_REQUEST.Enum()
+		case "drop_header":
+			p.Settings.HeadersWithUnderscoresAction = pb.HeadersWithUnderscoresAction_HEADERS_WITH_UNDERSCORES_ACTION_DROP_HEADER.Enum()
+		default:
+			return fmt.Errorf("unknown headersWithUnderscoresAction %s", *c.Spec.HeadersWithUnderscoresAction)
+		}
+	} else {
+		p.Settings.HeadersWithUnderscoresAction = nil
+	}
 	if c.Spec.AccessLogFields != nil {
 		p.Settings.AccessLogFields = &pb.Settings_StringList{
 			Values: *c.Spec.AccessLogFields,

--- a/pomerium/config_test.go
+++ b/pomerium/config_test.go
@@ -37,6 +37,42 @@ func TestApplyConfig(t *testing.T) {
 		assert.Equal(t, []string{"a", "b", "c"}, dst.Settings.GetAllowUpgrades().GetValues(),
 			"should set allow upgrades")
 	})
+
+	t.Run("Normalization", func(t *testing.T) {
+		t.Parallel()
+		var dst pb.Config
+
+		assert.NoError(t, pomerium.ApplyConfig(t.Context(), &dst, &model.Config{}))
+		assert.Nil(t, dst.Settings.NormalizePath, "should default to nil")
+		assert.Nil(t, dst.Settings.MergeSlashes, "should default to nil")
+		assert.Nil(t, dst.Settings.PathWithEscapedSlashesAction, "should default to nil")
+		assert.Nil(t, dst.Settings.HeadersWithUnderscoresAction, "should default to nil")
+
+		assert.NoError(t, pomerium.ApplyConfig(t.Context(), &dst, &model.Config{
+			Pomerium: v1.Pomerium{
+				Spec: v1.PomeriumSpec{
+					NormalizePath:                proto.Bool(false),
+					MergeSlashes:                 proto.Bool(false),
+					PathWithEscapedSlashesAction: proto.String("keep_unchanged"),
+					HeadersWithUnderscoresAction: proto.String("allow"),
+				},
+			},
+		}))
+		assert.False(t, dst.Settings.GetNormalizePath())
+		assert.False(t, dst.Settings.GetMergeSlashes())
+		assert.Equal(t, pb.PathWithEscapedSlashesAction_PATH_WITH_ESCAPED_SLASHES_ACTION_KEEP_UNCHANGED,
+			dst.Settings.GetPathWithEscapedSlashesAction())
+		assert.Equal(t, pb.HeadersWithUnderscoresAction_HEADERS_WITH_UNDERSCORES_ACTION_ALLOW,
+			dst.Settings.GetHeadersWithUnderscoresAction())
+
+		assert.Error(t, pomerium.ApplyConfig(t.Context(), &dst, &model.Config{
+			Pomerium: v1.Pomerium{
+				Spec: v1.PomeriumSpec{
+					PathWithEscapedSlashesAction: proto.String("nonsense"),
+				},
+			},
+		}), "should reject an unknown action")
+	})
 }
 
 func TestApplyConfig_DownstreamMTLS(t *testing.T) {

--- a/reference.md
+++ b/reference.md
@@ -199,6 +199,17 @@ PomeriumSpec defines Pomerium-specific configuration parameters.
         <tr>
             <td>
                 <p>
+                <code>headersWithUnderscoresAction</code>&#160;&#160;
+                    <strong>string</strong>&#160;
+                </p>
+                <p>
+                    HeadersWithUnderscoresAction sets the action to take when a client request with a header name containing underscore characters is received. These settings apply to the whole listener and cannot be set per Ingress.
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <p>
                 <code>identityProvider</code>&#160;&#160;
                     <strong>object</strong>&#160;
                     (<a href="#identityprovider">identityProvider</a>)
@@ -255,6 +266,28 @@ PomeriumSpec defines Pomerium-specific configuration parameters.
         <tr>
             <td>
                 <p>
+                <code>mergeSlashes</code>&#160;&#160;
+                    <strong>boolean</strong>&#160;
+                </p>
+                <p>
+                    MergeSlashes sets whether adjacent slashes in the path are merged into one before any processing of requests by HTTP filters or routing. These settings apply to the whole listener and cannot be set per Ingress.
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <p>
+                <code>normalizePath</code>&#160;&#160;
+                    <strong>boolean</strong>&#160;
+                </p>
+                <p>
+                    NormalizePath sets whether paths are normalized according to RFC 3986 before any processing of requests by HTTP filters or routing. These settings apply to the whole listener and cannot be set per Ingress.
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <p>
                 <code>otel</code>&#160;&#160;
                     <strong>object</strong>&#160;
                     (<a href="#otel">otel</a>)
@@ -272,6 +305,17 @@ PomeriumSpec defines Pomerium-specific configuration parameters.
                 </p>
                 <p>
                     PassIdentityHeaders sets the <a href="https://www.pomerium.com/docs/reference/pass-identity-headers">pass identity headers</a> option.
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <p>
+                <code>pathWithEscapedSlashesAction</code>&#160;&#160;
+                    <strong>string</strong>&#160;
+                </p>
+                <p>
+                    PathWithEscapedSlashesAction sets the action to take when a request URL path contains escaped slash sequences (%2F, %2f, %5C and %5c). These settings apply to the whole listener and cannot be set per Ingress.
                 </p>
             </td>
         </tr>


### PR DESCRIPTION
Core added normalize_path, merge_slashes, path_with_escaped_slashes_action and headers_with_underscores_action in pomerium#6398 (Settings fields 184-187), and v0.33.0 turned three of them on by default. None of the four are reachable from Kubernetes: they aren't in PomeriumSpec, and no Ingress annotation can set them because annotations map to Route fields while these are listener/HCM-level.

The visible symptom is that any request with %2F in the path returns 400 path_normalization_failed on v0.33.0, which breaks ArgoCD, since it encodes repo and cluster URLs into a single path segment. Rejection happens in the HCM before ext_authz, so it reproduces unauthenticated:

    curl -sk --path-as-is -o /dev/null -w '%{http_code}\n' https://<host>/foo%2Fbar
    # v0.32.9 -> 302     v0.33.0 -> 400

Add the four fields to PomeriumSpec and map them in applySetOtherOptions, following the existing codecType/bearerTokenFormat pattern. Behavior is unchanged when unset: each maps to nil and core keeps applying its own defaults.

These are listener-level settings, so the CRD field is global for the deployment. There is no per-Ingress form of this, and the field docs say so.

## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
