### PR TITLE
ci: repair the workflow linter's own trigger, bump action-validator to 0.9.0

### DIFF
--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -4,11 +4,13 @@ permissions:
   pull-requests: write
 on:
   push:
+    branches:
+      - main
     paths:
-      - ".github/workflows/"
+      - ".github/workflows/**"
   pull_request:
     paths:
-      - ".github/workflows/"
+      - ".github/workflows/**"
 
 jobs:
   check:
@@ -22,7 +24,7 @@ jobs:
         uses: asdf-vm/actions/install@v4
         with:
           tool_versions: |
-            action-validator 0.5.1
+            action-validator 0.9.0
 
       - name: Lint Actions
         run: |


### PR DESCRIPTION
## What broke

`Lint Workflows` failed on the **v0.33.1** release tag ([run 30962357065](https://github.com/pomerium/ingress-controller/actions/runs/30962357065/job/92169014524), exit 123):

```
Fatal error validating .github/workflows/sync-crds-to-install.yaml
NoFilesMatchingGlob: Glob "config/crd/bases/**" in /on/push/paths does not match any files
```

The glob is fine. `action-validator` 0.5.1 validated `paths:` globs with the Rust `glob` crate, where a trailing `/**` only matches *subdirectories* — and `config/crd/bases/` is flat (two `.yaml` files, no subdirs), so the match count was 0. Reproduced against a full checkout where those files demonstrably exist, so this is a linter false positive, not a workflow bug.

v0.33.0 and v0.33.1 are the only failing `Lint Workflows` runs ever; the glob arrived with #1444, and older tags predate it.

## The fix

**Bump `action-validator` 0.5.1 → 0.9.0.** Upstream ([PR #113](https://github.com/mpalmer/action-validator/pull/113), released in [v0.9.0](https://github.com/mpalmer/action-validator/releases/tag/v0.9.0) on 2026-04-09) replaced the `glob` crate with a matcher implementing GitHub's filter-pattern rules over `git ls-files`, closing [issue #27](https://github.com/mpalmer/action-validator/issues/27) — which contains this exact error from another reporter. So `sync-crds-to-install.yaml` needs **no change at all**; its glob was always right. `pomerium/desktop-client` already pins 0.9.0.

**Fix this workflow's own trigger.** `".github/workflows/"` matches nothing in GitHub's filter syntax — a trailing slash never matches a file path. So neither the `push` nor the `pull_request` trigger has fired since the file was added in June 2025 (#1172). All 27 of its runs are tag pushes, where [GitHub ignores `paths` filters](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax): *"Path filters are not evaluated for pushes of tags."* Zero `pull_request` runs in 14 months, despite ~8 dependabot PRs editing these very files. That is why the bad glob sailed through review, and why the linter only ever spoke up on a release tag, after the fact.

**Scope `push:` to `main`.** Every other workflow here scopes its push trigger; this one didn't. Unscoped, it ran on tag pushes (the release-tag noise above) and would now also double-run with `pull_request` on branch pushes.

The two changes are self-reinforcing: **0.9.0 flags `".github/workflows/"` as unmatched, while 0.5.1 passed it.** The pinned linter blessed the exact pattern that kept it from ever running — so this bump catches the defect that disabled it, and stops flagging the non-defect that failed the release.

## Verification

Ran the real `action-validator_linux_amd64` release binaries against actual checkouts (`docker --platform linux/amd64`, `git` present), using the job's exact `find … | xargs -I {} action-validator --verbose {}` command:

| tree | 0.5.1 | 0.9.0 |
|---|---|---|
| `origin/main` (today) | **exit 123** — `config/crd/bases/**` | **exit 123** — `.github/workflows/` |
| this branch | — | **exit 0**, all 10 workflows clean |

Also confirmed against dependabot PR #1493 (bumps SHAs across all workflow files): clean. And that `**` vs `**/*` is equivalent for GitHub — `docs/**/*.md` matches `docs/README.md` per GitHub's own cheat sheet — so no trigger behavior changes for the CRD sync.

The asdf plugin for `action-validator` is the upstream repo itself; its `bin/list-all` reads the releases API and `bin/install` fetches the per-tag `action-validator_linux_amd64` asset, which exists for v0.9.0.

Note: 0.9.0 shells out to `git ls-files`, so it needs a git binary and a real repo. Both hold on `ubuntu-latest` with `actions/checkout`.

## Expect a behavior change

This job will start running on PRs for the first time — including this one, which touches `.github/workflows/`. It isn't a required status check on `main` (required contexts are `pre-commit`, `build`, `test`, `lint`) or on any release branch, so failures are advisory. Worth *not* adding it to required contexts while it stays path-filtered: `enforce_admins` is on, and a path-filtered required check hangs every PR that doesn't touch workflows.

## Follow-ups, deliberately not in this PR

- **`0-33-0` needs a backport**, or the next `v0.33.x` tag fails the same way — that branch still has the 0.5.1 pin. With `push:` scoped to `main`, tag pushes stop triggering the job at all, which is what actually silences the release-tag red X.
- `permissions: pull-requests: write` here is unused; nothing in the job uses a token past checkout.
- `actions/checkout@v7.0.0` and `asdf-vm/actions/install@v4` are mutable refs, against this repo's SHA-pinning convention elsewhere. Now exercised on every workflow PR.
- `pomerium/mac-builds` has the same trailing-slash pattern and the same 0.5.1 pin.