### PR TITLE
ingress: add h2c_upstream annotation

### DIFF
--- a/model/ingress_config.go
+++ b/model/ingress_config.go
@@ -28,6 +28,8 @@ const (
 	TLSServerName = "tls_server_name"
 	// SecureUpstream indicate that service communication should happen over HTTPS
 	SecureUpstream = "secure_upstream"
+	// H2CUpstream indicates that service communication should happen over plaintext HTTP/2 (h2c)
+	H2CUpstream = "h2c_upstream"
 	// PathRegex indicates that paths of ImplementationSpecific type should be treated as regular expression
 	PathRegex = "path_regex"
 	// UseServiceProxy will use standard k8s service proxy as upstream, opposed to individual endpoints
@@ -189,6 +191,11 @@ func (ic *IngressConfig) IsAnnotationSet(name string) bool {
 // IsSecureUpstream returns true if upstream endpoints should be HTTPS
 func (ic *IngressConfig) IsSecureUpstream() bool {
 	return ic.IsAnnotationSet(SecureUpstream)
+}
+
+// IsH2CUpstream returns true if upstream endpoints should use plaintext HTTP/2 (h2c)
+func (ic *IngressConfig) IsH2CUpstream() bool {
+	return ic.IsAnnotationSet(H2CUpstream)
 }
 
 // IsSSHUpstream returns true if this route is for natively-proxied SSH https://www.pomerium.com/docs/capabilities/native-ssh-access

--- a/pomerium/ingress_annotations.go
+++ b/pomerium/ingress_annotations.go
@@ -95,6 +95,7 @@ var (
 	handledElsewhere = boolMap([]string{
 		model.PathRegex,
 		model.SecureUpstream,
+		model.H2CUpstream,
 		model.SSHUpstream,
 		model.TCPUpstream,
 		model.UDPUpstream,

--- a/pomerium/ingress_to_route.go
+++ b/pomerium/ingress_to_route.go
@@ -43,6 +43,12 @@ func IngressToRoutes(ctx context.Context, ic *model.IngressConfig) ([]config.Pol
 func ingressToRoutes(ctx context.Context, ic *model.IngressConfig) (routeList, error) {
 	tmpl := &pb.Route{}
 
+	// upstream scheme annotations apply to HTTP-01 solver ingresses too (they bypass applyAnnotations),
+	// so they are validated here where both branches converge
+	if err := validateUpstreamAnnotations(ic); err != nil {
+		return nil, fmt.Errorf("annotations: %w", err)
+	}
+
 	if model.IsHTTP01Solver(ic.Ingress) {
 		log.FromContext(ctx).Info("Ingress is HTTP-01 challenge solver, enabling public unauthenticated access")
 		tmpl.AllowPublicUnauthenticatedAccess = true
@@ -314,17 +320,38 @@ func getPathServiceHosts(r *pb.Route, p networkingv1.HTTPIngressPath, ic *model.
 	return hosts, nil
 }
 
+// upstreamSchemes maps upstream scheme annotations to the `to` URL scheme.
+// The list is ordered: the first annotation set wins, preserving historical precedence.
+var upstreamSchemes = []struct{ annotation, scheme string }{
+	{model.SSHUpstream, "ssh"},
+	{model.TCPUpstream, "tcp"},
+	{model.UDPUpstream, "udp"},
+	{model.SecureUpstream, "https"},
+	{model.H2CUpstream, "h2c"},
+}
+
 func getUpstreamScheme(ic *model.IngressConfig) string {
-	if ic.IsSSHUpstream() {
-		return "ssh"
-	} else if ic.IsTCPUpstream() {
-		return "tcp"
-	} else if ic.IsUDPUpstream() {
-		return "udp"
-	} else if ic.IsSecureUpstream() {
-		return "https"
+	for _, s := range upstreamSchemes {
+		if ic.IsAnnotationSet(s.annotation) {
+			return s.scheme
+		}
 	}
 	return "http"
+}
+
+// validateUpstreamAnnotations rejects h2c_upstream combined with any other upstream scheme annotation.
+// Older scheme annotations are intentionally still resolved by precedence for backwards compatibility.
+func validateUpstreamAnnotations(ic *model.IngressConfig) error {
+	if !ic.IsH2CUpstream() {
+		return nil
+	}
+	for _, s := range upstreamSchemes {
+		if s.annotation != model.H2CUpstream && ic.IsAnnotationSet(s.annotation) {
+			return fmt.Errorf("%s/%s and %s/%s are mutually exclusive",
+				ic.AnnotationPrefix, model.H2CUpstream, ic.AnnotationPrefix, s.annotation)
+		}
+	}
+	return nil
 }
 
 func setServiceURLs(r *pb.Route, p networkingv1.HTTPIngressPath, ic *model.IngressConfig) error {

--- a/pomerium/routes_test.go
+++ b/pomerium/routes_test.go
@@ -1356,6 +1356,27 @@ func TestEndpointsHTTPS(t *testing.T) {
 			},
 			"",
 		},
+		{
+			"H2C multiple IPs",
+			map[string]string{
+				fmt.Sprintf("p/%s", model.H2CUpstream): "true",
+			},
+			networkingv1.ServiceBackendPort{Name: "grpc"},
+			[]corev1.ServicePort{{
+				Name:       "grpc",
+				Port:       9090,
+				TargetPort: intstr.IntOrString{IntVal: 9090},
+			}},
+			[]corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{IP: "1.2.3.4"}, {IP: "1.2.3.5"}},
+				Ports:     []corev1.EndpointPort{{Name: "grpc", Port: 9090}},
+			}},
+			[]string{
+				"h2c://1.2.3.4:9090",
+				"h2c://1.2.3.5:9090",
+			},
+			"",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			pathTypePrefix := networkingv1.PathTypePrefix
@@ -1427,6 +1448,31 @@ func TestEndpointsHTTPS(t *testing.T) {
 			require.NotNil(t, route, "route not found in %v", routes)
 			require.ElementsMatch(t, tc.expectTO, route.To)
 			require.Equal(t, tc.expectTLSServerName, route.TlsServerName)
+		})
+	}
+}
+
+func TestH2CUpstreamConflicts(t *testing.T) {
+	for _, s := range upstreamSchemes {
+		if s.annotation == model.H2CUpstream {
+			continue
+		}
+		t.Run(s.annotation, func(t *testing.T) {
+			ic := &model.IngressConfig{
+				AnnotationPrefix: "p",
+				Ingress: &networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress",
+						Namespace: "default",
+						Annotations: map[string]string{
+							fmt.Sprintf("p/%s", model.H2CUpstream): "true",
+							fmt.Sprintf("p/%s", s.annotation):      "true",
+						},
+					},
+				},
+			}
+			_, err := ingressToRoutes(t.Context(), ic)
+			assert.ErrorContains(t, err, fmt.Sprintf("p/%s and p/%s are mutually exclusive", model.H2CUpstream, s.annotation))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Pomerium core supports plaintext HTTP/2 upstreams via the `h2c://` scheme in route `to` URLs, but Ingress resources had no way to request it: the controller builds `to` URLs from Service/Endpoints and picks the scheme itself.

- Add an `ingress.pomerium.io/h2c_upstream: "true"` annotation, modeled on `secure_upstream`, that emits `h2c://` upstream URLs.
- Reject `h2c_upstream` when combined with `secure_upstream` (or `ssh_upstream` / `tcp_upstream` / `udp_upstream`), since the schemes are mutually exclusive per route and core would otherwise silently degrade mixed lists to HTTP/1.1.
- Consolidate the scheme-annotation list into a single ordered table shared by scheme selection and validation. Existing precedence among the older annotations is unchanged.

## Example

```yaml
metadata:
  annotations:
    ingress.pomerium.io/h2c_upstream: "true"
```

Combining it with `secure_upstream` fails with:

```
annotations: ingress.pomerium.io/h2c_upstream and ingress.pomerium.io/secure_upstream are mutually exclusive
```

## Test plan

- [x] `make test` (envtest + `pomerium/ctrl`) passes
- [x] `golangci-lint run ./...` clean
- [x] New table cases in `TestEndpointsHTTPS` for `h2c://` endpoint URLs
- [x] New `TestH2CUpstreamConflicts` covering all four conflicting annotation pairs

Documentation PR: https://github.com/pomerium/documentation/pull/2361
